### PR TITLE
Added a default method to write a single value

### DIFF
--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/api/services/AttributeServices.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/api/services/AttributeServices.java
@@ -161,6 +161,18 @@ public interface AttributeServices {
                 .thenApply(response -> newArrayList(response.getResults()));
         }
     }
+    
+    /**
+     * This service is used to write to the value attribute of one node.
+     *
+     * @param nodeId the {@link NodeId} identifying the node to write to.
+     * @param value  the {@link DataValue} to write.
+     * @return a {@link CompletableFuture} containing the result for the write.
+     */
+    default CompletableFuture<StatusCode> writeValue(NodeId nodeId, DataValue value) {
+        return write(Collections.singletonList(new WriteValue(nodeId, uint(13), null, value)))
+            .thenApply(response -> response.getResults()[0]);
+    }
 
     /**
      * This Service is used to read historical values or Events of one or more Nodes.


### PR DESCRIPTION
This change adds a new default method the interface which can be used
to write a single value. It is a convenience method for "writeValues"
which requires a list as argument and returns a list as result.

---

This would be the pendant to `readValue`.