### PR TITLE
#11: Server: Unable to write to node of type "Variant"

### DIFF
--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/util/AttributeWriter.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/util/AttributeWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 Kevin Herron
+ * Copyright (c) 2016 Kevin Herron and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -455,9 +455,7 @@ public class AttributeWriter {
                 /*
                  * Writing a ByteString to a UByte[] is explicitly allowed by the spec.
                  */
-                boolean byteStringToByteArray = (o instanceof ByteString && expected == UByte.class);
-
-                if (byteStringToByteArray) {
+                if (o instanceof ByteString && expected == UByte.class) {
                     ByteString byteString = (ByteString) o;
 
                     return new DataValue(
@@ -465,6 +463,9 @@ public class AttributeWriter {
                         value.getStatusCode(),
                         value.getSourceTime(),
                         value.getServerTime());
+                } else if (expected == Variant.class) {
+                    // allow to write anything to a Variant
+                	return value;
                 } else {
                     throw new UaException(StatusCodes.Bad_TypeMismatch);
                 }

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/util/AttributeWriterTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/util/AttributeWriterTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2016 Jens Reimann
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ * 	http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * 	http://www.eclipse.org/org/documents/edl-v10.html.
+ */
+
+package org.eclipse.milo.opcua.sdk.server.util;
+
+import java.util.function.Consumer;
+
+import org.eclipse.milo.opcua.sdk.core.AccessLevel;
+import org.eclipse.milo.opcua.sdk.core.ValueRanks;
+import org.eclipse.milo.opcua.stack.core.AttributeId;
+import org.eclipse.milo.opcua.stack.core.Identifiers;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
+import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class AttributeWriterTest {
+
+	@Test
+	public void testVariantToVariant() throws UaException {
+		testWriteConversion(new Variant("String"), null, null);
+	}
+
+	@Test
+	public void testStringToString() throws UaException {
+		testWriteConversion(new Variant("String"), Identifiers.String, null);
+	}
+
+	@Test
+	public void testStringToDouble() throws UaException {
+		expectFailure(StatusCodes.Bad_TypeMismatch, () -> testWriteConversion(new Variant("String"), Identifiers.Double, null));
+	}
+
+	@Test
+	public void testByteStringToUByteArray() throws UaException {
+		testWriteConversion(new Variant(ByteString.of("foo".getBytes())), Identifiers.Byte, node -> {
+			node.setValueRank(ValueRanks.OneDimension);
+		});
+	}
+
+	public interface UaOperation {
+		public void run() throws UaException;
+	}
+
+	public static void expectFailure(long code, UaOperation operation) {
+		try {
+			operation.run();
+			Assert.fail("Operation is expected to fail with code: " + code);
+		} catch (UaException e) {
+			Assert.assertEquals(e.getStatusCode().getValue(), code, "Status code does not match");
+		}
+	}
+
+	private void testWriteConversion(Variant value,
+			NodeId dataType,
+			Consumer<org.eclipse.milo.opcua.sdk.server.model.UaVariableNode> nodeCustomizer ) throws UaException {
+		
+		testWriteConversion(new DataValue(value), dataType, nodeCustomizer);
+		
+	}
+
+	private void testWriteConversion(DataValue value,
+			NodeId dataType,
+			Consumer<org.eclipse.milo.opcua.sdk.server.model.UaVariableNode> nodeCustomizer) throws UaException {
+		
+		final org.eclipse.milo.opcua.sdk.server.model.UaVariableNode varNode = createMockNode("test", node -> {
+			node.setAccessLevel(Unsigned.ubyte(AccessLevel.getMask(AccessLevel.READ_WRITE)));
+			if ( nodeCustomizer != null ) {
+				nodeCustomizer.accept(node);
+			}
+		});
+
+		if (dataType != null) {
+			varNode.setDataType(dataType);
+		}
+
+		AttributeWriter.writeAttribute(null, varNode, AttributeId.Value, value, null);
+	}
+
+	private org.eclipse.milo.opcua.sdk.server.model.UaVariableNode createMockNode(String id,
+			Consumer<org.eclipse.milo.opcua.sdk.server.model.UaVariableNode> nodeCustomizer
+			) {
+		
+		final NodeId nodeId = new NodeId(0, id);
+
+		final QualifiedName browseName = new QualifiedName(0, id);
+		final LocalizedText displayName = LocalizedText.english(id);
+
+		final org.eclipse.milo.opcua.sdk.server.model.UaVariableNode node = new org.eclipse.milo.opcua.sdk.server.model.UaVariableNode(
+				null, nodeId, browseName, displayName);
+
+		if (nodeCustomizer != null) {
+			nodeCustomizer.accept(node);
+		}
+
+		return node;
+	}
+}


### PR DESCRIPTION
This change allows to write any value into a node of the
type Variant.

It also adds a unit test for the AttributeWriter which does test for
this case, tests for a simple failure and for the special case of
ByteString to UByte[].

Signed-off-by: Jens Reimann <jreimann@redhat.com>

----

That should do the trick. However I am not entirely sure I got your code style. Please be kind :wink: 