### PR TITLE
#19: let the SubscriptionListener interface provide default methods

### DIFF
--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/api/subscriptions/UaSubscriptionManager.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/api/subscriptions/UaSubscriptionManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 Kevin Herron
+ * Copyright (c) 2016 Kevin Herron and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -115,7 +115,7 @@ public interface UaSubscriptionManager {
          * @param subscription the {@link UaSubscription} that received the keep-alive.
          * @param publishTime  the time the server published the keep-alive.
          */
-        void onKeepAlive(UaSubscription subscription, DateTime publishTime);
+        default void onKeepAlive(UaSubscription subscription, DateTime publishTime) {};
 
         /**
          * A status change notification was received.
@@ -123,7 +123,7 @@ public interface UaSubscriptionManager {
          * @param subscription the {@link UaSubscription} that received the status change.
          * @param status       the new subscription status.
          */
-        void onStatusChanged(UaSubscription subscription, StatusCode status);
+        default void onStatusChanged(UaSubscription subscription, StatusCode status) {};
 
         /**
          * A publish failure has occurred.
@@ -132,7 +132,7 @@ public interface UaSubscriptionManager {
          *
          * @param exception the cause of the failure.
          */
-        void onPublishFailure(UaException exception);
+        default void onPublishFailure(UaException exception) {};
 
         /**
          * Attempts to recover missed notification data have failed.
@@ -142,7 +142,7 @@ public interface UaSubscriptionManager {
          *
          * @param subscription the subscription that missed notification data.
          */
-        void onNotificationDataLost(UaSubscription subscription);
+        default void onNotificationDataLost(UaSubscription subscription) {};
 
         /**
          * A new {@link UaSession} was established, and upon attempting to transfer an existing subscription to this
@@ -153,7 +153,7 @@ public interface UaSubscriptionManager {
          * @param subscription the {@link UaSubscription} that could not be transferred.
          * @param statusCode   the {@link StatusCode} for the transfer failure.
          */
-        void onSubscriptionTransferFailed(UaSubscription subscription, StatusCode statusCode);
+        default void onSubscriptionTransferFailed(UaSubscription subscription, StatusCode statusCode) {};
 
     }
 


### PR DESCRIPTION
The interface SubscriptionListener now provides empty default methods
so that consumers of the events can choose to only implement methods
which are relevant for them.

----

I added the empty default to all methods since sometimes users might just be interested in "the other" event and then you would still have a few empty declarations required.