### PR TITLE
[#17] copy() methods for config objects

### DIFF
--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/api/config/OpcUaClientConfig.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/api/config/OpcUaClientConfig.java
@@ -13,6 +13,7 @@
 
 package org.eclipse.milo.opcua.sdk.client.api.config;
 
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 import org.eclipse.milo.opcua.sdk.client.api.identity.IdentityProvider;
@@ -52,8 +53,67 @@ public interface OpcUaClientConfig extends UaTcpStackClientConfig {
      */
     IdentityProvider getIdentityProvider();
 
+    /**
+     * @return a new {@link OpcUaClientConfigBuilder}.
+     */
     static OpcUaClientConfigBuilder builder() {
         return new OpcUaClientConfigBuilder();
+    }
+
+    /**
+     * Copy the values from an existing {@link OpcUaClientConfig} into a new {@link OpcUaClientConfigBuilder}. This
+     * builder can be used to make any desired modifications before invoking {@link OpcUaClientConfigBuilder#build()}
+     * to produce a new config.
+     *
+     * @param config the {@link OpcUaClientConfig} to copy from.
+     * @return a {@link OpcUaClientConfigBuilder} pre-populated with values from {@code config}.
+     */
+    static OpcUaClientConfigBuilder copy(OpcUaClientConfig config) {
+        OpcUaClientConfigBuilder builder = new OpcUaClientConfigBuilder();
+
+        // UaTcpStackClientConfig values
+        config.getEndpointUrl().ifPresent(builder::setEndpointUrl);
+        config.getEndpoint().ifPresent(builder::setEndpoint);
+        config.getKeyPair().ifPresent(builder::setKeyPair);
+        config.getCertificate().ifPresent(builder::setCertificate);
+        builder.setApplicationName(config.getApplicationName());
+        builder.setApplicationUri(config.getApplicationUri());
+        builder.setProductUri(config.getProductUri());
+        builder.setChannelConfig(config.getChannelConfig());
+        builder.setChannelLifetime(config.getChannelLifetime());
+        builder.setExecutor(config.getExecutor());
+        builder.setEventLoop(config.getEventLoop());
+        builder.setWheelTimer(config.getWheelTimer());
+        builder.setSecureChannelReauthenticationEnabled(config.isSecureChannelReauthenticationEnabled());
+
+        // OpcUaClientConfig values
+        builder.setSessionName(config.getSessionName());
+        builder.setSessionTimeout(config.getSessionTimeout());
+        builder.setRequestTimeout(config.getRequestTimeout());
+        builder.setMaxResponseMessageSize(config.getMaxResponseMessageSize());
+        builder.setMaxPendingPublishRequests(config.getMaxPendingPublishRequests());
+        builder.setIdentityProvider(config.getIdentityProvider());
+
+        return builder;
+    }
+
+    /**
+     * Copy the values from an existing {@link OpcUaClientConfig} into a new {@link OpcUaClientConfigBuilder} and then
+     * submit the builder to the provided consumer for modification.
+     *
+     * @param config   the {@link OpcUaClientConfig} to copy from.
+     * @param consumer a {@link Consumer} that may modify the builder.
+     * @return a {@link OpcUaClientConfig} built from the builder provided to {@code consumer}.
+     */
+    static OpcUaClientConfig copy(
+        OpcUaClientConfig config,
+        Consumer<OpcUaClientConfigBuilder> consumer) {
+
+        OpcUaClientConfigBuilder builder = copy(config);
+
+        consumer.accept(builder);
+
+        return builder.build();
     }
 
 }

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/api/config/OpcUaServerConfig.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/api/config/OpcUaServerConfig.java
@@ -15,6 +15,7 @@ package org.eclipse.milo.opcua.sdk.server.api.config;
 
 import java.util.EnumSet;
 import java.util.List;
+import java.util.function.Consumer;
 
 import org.eclipse.milo.opcua.sdk.server.identity.AnonymousIdentityValidator;
 import org.eclipse.milo.opcua.sdk.server.identity.IdentityValidator;
@@ -95,6 +96,61 @@ public interface OpcUaServerConfig extends UaTcpStackServerConfig {
      */
     static OpcUaServerConfigBuilder builder() {
         return new OpcUaServerConfigBuilder();
+    }
+
+    /**
+     * Copy the values from an existing {@link OpcUaServerConfig} into a new {@link OpcUaServerConfigBuilder}. This
+     * builder can be used to make any desired modifications before invoking {@link OpcUaServerConfigBuilder#build()}
+     * to produce a new config.
+     *
+     * @param config the {@link OpcUaServerConfig} to copy from.
+     * @return a {@link OpcUaServerConfigBuilder} pre-populated with values from {@code config}.
+     */
+    static OpcUaServerConfigBuilder copy(OpcUaServerConfig config) {
+        OpcUaServerConfigBuilder builder = new OpcUaServerConfigBuilder();
+
+        // UaTcpStackServerConfig values
+        builder.setServerName(config.getServerName());
+        builder.setApplicationName(config.getApplicationName());
+        builder.setApplicationUri(config.getApplicationUri());
+        builder.setProductUri(config.getProductUri());
+        builder.setCertificateManager(config.getCertificateManager());
+        builder.setCertificateValidator(config.getCertificateValidator());
+        builder.setExecutor(config.getExecutor());
+        builder.setUserTokenPolicies(config.getUserTokenPolicies());
+        builder.setSoftwareCertificates(config.getSoftwareCertificates());
+        builder.setChannelConfig(config.getChannelConfig());
+        builder.setStrictEndpointUrlsEnabled(config.isStrictEndpointUrlsEnabled());
+
+        // OpcUaServerConfig values
+        builder.setSecurityPolicies(config.getSecurityPolicies());
+        builder.setHostname(config.getHostname());
+        builder.setBindAddresses(config.getBindAddresses());
+        builder.setBindPort(config.getBindPort());
+        builder.setIdentityValidator(config.getIdentityValidator());
+        builder.setBuildInfo(config.getBuildInfo());
+        builder.setLimits(config.getLimits());
+
+        return builder;
+    }
+
+    /**
+     * Copy the values from an existing {@link OpcUaServerConfig} into a new {@link OpcUaServerConfigBuilder} and then
+     * submit the builder to the provided consumer for modification.
+     *
+     * @param config   the {@link OpcUaServerConfig} to copy from.
+     * @param consumer a {@link Consumer} that may modify the builder.
+     * @return a {@link OpcUaServerConfig} built from the builder provided to {@code consumer}.
+     */
+    static OpcUaServerConfig copy(
+        OpcUaServerConfig config,
+        Consumer<OpcUaServerConfigBuilder> consumer) {
+
+        OpcUaServerConfigBuilder builder = copy(config);
+
+        consumer.accept(builder);
+
+        return builder.build();
     }
 
 }

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/api/config/OpcUaServerConfigTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/api/config/OpcUaServerConfigTest.java
@@ -1,0 +1,43 @@
+package org.eclipse.milo.opcua.sdk.server.api.config;
+
+import java.util.EnumSet;
+
+import com.google.common.collect.Lists;
+import com.google.common.io.Files;
+import org.eclipse.milo.opcua.sdk.server.identity.AnonymousIdentityValidator;
+import org.eclipse.milo.opcua.stack.core.application.DefaultCertificateManager;
+import org.eclipse.milo.opcua.stack.core.application.DefaultCertificateValidator;
+import org.eclipse.milo.opcua.stack.core.security.SecurityPolicy;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
+import org.eclipse.milo.opcua.stack.core.types.structured.BuildInfo;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+public class OpcUaServerConfigTest {
+
+    @Test
+    public void testCopy() {
+        OpcUaServerConfig original = OpcUaServerConfig.builder()
+            .setCertificateManager(new DefaultCertificateManager())
+            .setCertificateValidator(new DefaultCertificateValidator(Files.createTempDir()))
+            .setSecurityPolicies(EnumSet.of(SecurityPolicy.None, SecurityPolicy.Basic128Rsa15))
+            .setHostname("testHostname")
+            .setBindAddresses(Lists.newArrayList("127.0.0.1", "0.0.0.0"))
+            .setBindPort(12345)
+            .setIdentityValidator(new AnonymousIdentityValidator())
+            .setBuildInfo(new BuildInfo("a", "b", "c", "d", "e", DateTime.MIN_VALUE))
+            .setLimits(new OpcUaServerConfigLimits() {})
+            .build();
+
+        OpcUaServerConfig copy = OpcUaServerConfig.copy(original).build();
+
+        assertEquals(copy.getSecurityPolicies(), original.getSecurityPolicies());
+        assertEquals(copy.getHostname(), original.getHostname());
+        assertEquals(copy.getBindAddresses(), original.getBindAddresses());
+        assertEquals(copy.getIdentityValidator(), original.getIdentityValidator());
+        assertEquals(copy.getBuildInfo(), original.getBuildInfo());
+        assertEquals(copy.getLimits(), original.getLimits());
+    }
+
+}

--- a/opc-ua-sdk/sdk-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/config/OpcUaClientConfigTest.java
+++ b/opc-ua-sdk/sdk-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/config/OpcUaClientConfigTest.java
@@ -1,0 +1,65 @@
+package org.eclipse.milo.opcua.sdk.client.config;
+
+import org.eclipse.milo.opcua.sdk.client.api.config.OpcUaClientConfig;
+import org.eclipse.milo.opcua.sdk.client.api.identity.AnonymousProvider;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.testng.annotations.Test;
+
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
+
+public class OpcUaClientConfigTest {
+
+    @Test
+    public void testCopy() {
+        OpcUaClientConfig original = OpcUaClientConfig.builder()
+            .setSessionName(() -> "testSessionName")
+            .setSessionTimeout(uint(60000 * 60))
+            .setRequestTimeout(uint(120000))
+            .setMaxResponseMessageSize(UInteger.MAX)
+            .setMaxPendingPublishRequests(uint(2))
+            .setIdentityProvider(new AnonymousProvider())
+            .build();
+
+        OpcUaClientConfig copy = OpcUaClientConfig.copy(original).build();
+
+        assertEquals(copy.getSessionName(), original.getSessionName());
+        assertEquals(copy.getSessionTimeout(), original.getSessionTimeout());
+        assertEquals(copy.getRequestTimeout(), original.getRequestTimeout());
+        assertEquals(copy.getMaxResponseMessageSize(), original.getMaxResponseMessageSize());
+        assertEquals(copy.getMaxPendingPublishRequests(), original.getMaxPendingPublishRequests());
+        assertEquals(copy.getIdentityProvider(), original.getIdentityProvider());
+    }
+
+    @Test
+    public void testCopyAndModify() {
+        OpcUaClientConfig original = OpcUaClientConfig.builder()
+            .setSessionName(() -> "testSessionName")
+            .setSessionTimeout(uint(60000 * 60))
+            .setRequestTimeout(uint(120000))
+            .setMaxResponseMessageSize(UInteger.MAX)
+            .setMaxPendingPublishRequests(uint(2))
+            .setIdentityProvider(new AnonymousProvider())
+            .build();
+
+        OpcUaClientConfig copy = OpcUaClientConfig.copy(original,
+            builder ->
+                builder.setSessionName(() -> "foo")
+                    .setSessionTimeout(uint(0))
+                    .setRequestTimeout(uint(0))
+                    .setMaxResponseMessageSize(uint(0))
+                    .setMaxPendingPublishRequests(uint(0))
+                    .setIdentityProvider(new AnonymousProvider())
+        );
+
+        assertNotEquals(copy.getSessionName(), original.getSessionName());
+        assertNotEquals(copy.getIdentityProvider(), original.getIdentityProvider());
+
+        assertEquals(copy.getSessionTimeout(), uint(0));
+        assertEquals(copy.getRequestTimeout(), uint(0));
+        assertEquals(copy.getMaxResponseMessageSize(), uint(0));
+        assertEquals(copy.getMaxPendingPublishRequests(), uint(0));
+    }
+
+}

--- a/opc-ua-stack/stack-client/src/main/java/org/eclipse/milo/opcua/stack/client/config/UaTcpStackClientConfig.java
+++ b/opc-ua-stack/stack-client/src/main/java/org/eclipse/milo/opcua/stack/client/config/UaTcpStackClientConfig.java
@@ -17,6 +17,7 @@ import java.security.KeyPair;
 import java.security.cert.X509Certificate;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
+import java.util.function.Consumer;
 
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.util.HashedWheelTimer;
@@ -114,8 +115,58 @@ public interface UaTcpStackClientConfig {
      */
     boolean isSecureChannelReauthenticationEnabled();
 
+    /**
+     * @return a new {@link UaTcpStackClientConfigBuilder}.
+     */
     static UaTcpStackClientConfigBuilder builder() {
         return new UaTcpStackClientConfigBuilder();
+    }
+
+    /**
+     * Copy the values from an existing {@link UaTcpStackClientConfig} into a new {@link UaTcpStackClientConfigBuilder}.
+     * This builder can be used to make any desired modifications before invoking
+     * {@link UaTcpStackClientConfigBuilder#build()} to produce a new config.
+     *
+     * @param config the {@link UaTcpStackClientConfig} to copy from.
+     * @return a {@link UaTcpStackClientConfigBuilder} pre-populated with values from {@code config}.
+     */
+    static UaTcpStackClientConfigBuilder copy(UaTcpStackClientConfig config) {
+        UaTcpStackClientConfigBuilder builder = new UaTcpStackClientConfigBuilder();
+
+        config.getEndpointUrl().ifPresent(builder::setEndpointUrl);
+        config.getEndpoint().ifPresent(builder::setEndpoint);
+        config.getKeyPair().ifPresent(builder::setKeyPair);
+        config.getCertificate().ifPresent(builder::setCertificate);
+        builder.setApplicationName(config.getApplicationName());
+        builder.setApplicationUri(config.getApplicationUri());
+        builder.setProductUri(config.getProductUri());
+        builder.setChannelConfig(config.getChannelConfig());
+        builder.setChannelLifetime(config.getChannelLifetime());
+        builder.setExecutor(config.getExecutor());
+        builder.setEventLoop(config.getEventLoop());
+        builder.setWheelTimer(config.getWheelTimer());
+        builder.setSecureChannelReauthenticationEnabled(config.isSecureChannelReauthenticationEnabled());
+
+        return builder;
+    }
+
+    /**
+     * Copy the values from an existing {@link UaTcpStackClientConfig} into a new {@link UaTcpStackClientConfigBuilder}
+     * and then submit the builder to the provided consumer for modification.
+     *
+     * @param config   the {@link UaTcpStackClientConfig} to copy from.
+     * @param consumer a {@link Consumer} that may modify the builder.
+     * @return a {@link UaTcpStackClientConfig} built from the builder provided to {@code consumer}.
+     */
+    static UaTcpStackClientConfig copy(
+        UaTcpStackClientConfig config,
+        Consumer<UaTcpStackClientConfigBuilder> consumer) {
+
+        UaTcpStackClientConfigBuilder builder = copy(config);
+
+        consumer.accept(builder);
+
+        return builder.build();
     }
 
 }

--- a/opc-ua-stack/stack-server/src/main/java/org/eclipse/milo/opcua/stack/server/config/UaTcpStackServerConfig.java
+++ b/opc-ua-stack/stack-server/src/main/java/org/eclipse/milo/opcua/stack/server/config/UaTcpStackServerConfig.java
@@ -15,6 +15,7 @@ package org.eclipse.milo.opcua.stack.server.config;
 
 import java.util.List;
 import java.util.concurrent.ExecutorService;
+import java.util.function.Consumer;
 
 import org.eclipse.milo.opcua.stack.core.application.CertificateManager;
 import org.eclipse.milo.opcua.stack.core.application.CertificateValidator;
@@ -96,8 +97,56 @@ public interface UaTcpStackServerConfig {
      */
     boolean isStrictEndpointUrlsEnabled();
 
+    /**
+     * @return a new {@link UaTcpStackServerConfigBuilder}.
+     */
     static UaTcpStackServerConfigBuilder builder() {
         return new UaTcpStackServerConfigBuilder();
+    }
+
+    /**
+     * Copy the values from an existing {@link UaTcpStackServerConfig} into a new {@link UaTcpStackServerConfigBuilder}.
+     * This builder can be used to make any desired modifications before invoking
+     * {@link UaTcpStackServerConfigBuilder#build()} to produce a new config.
+     *
+     * @param config the {@link UaTcpStackServerConfig} to copy from.
+     * @return a {@link UaTcpStackServerConfigBuilder} pre-populated with values from {@code config}.
+     */
+    static UaTcpStackServerConfigBuilder copy(UaTcpStackServerConfig config) {
+        UaTcpStackServerConfigBuilder builder = new UaTcpStackServerConfigBuilder();
+
+        builder.setServerName(config.getServerName());
+        builder.setApplicationName(config.getApplicationName());
+        builder.setApplicationUri(config.getApplicationUri());
+        builder.setProductUri(config.getProductUri());
+        builder.setCertificateManager(config.getCertificateManager());
+        builder.setCertificateValidator(config.getCertificateValidator());
+        builder.setExecutor(config.getExecutor());
+        builder.setUserTokenPolicies(config.getUserTokenPolicies());
+        builder.setSoftwareCertificates(config.getSoftwareCertificates());
+        builder.setChannelConfig(config.getChannelConfig());
+        builder.setStrictEndpointUrlsEnabled(config.isStrictEndpointUrlsEnabled());
+
+        return builder;
+    }
+
+    /**
+     * Copy the values from an existing {@link UaTcpStackServerConfig} into a new {@link UaTcpStackServerConfigBuilder}
+     * and then submit the builder to the provided consumer for modification.
+     *
+     * @param config   the {@link UaTcpStackServerConfig} to copy from.
+     * @param consumer a {@link Consumer} that may modify the builder.
+     * @return a {@link UaTcpStackServerConfig} built from the builder provided to {@code consumer}.
+     */
+    static UaTcpStackServerConfig copy(
+        UaTcpStackServerConfig config,
+        Consumer<UaTcpStackServerConfigBuilder> consumer) {
+
+        UaTcpStackServerConfigBuilder builder = copy(config);
+
+        consumer.accept(builder);
+
+        return builder.build();
     }
 
 }

--- a/opc-ua-stack/stack-tests/src/test/java/org/eclipse/milo/opcua/stack/client/config/UaTcpStackClientConfigTest.java
+++ b/opc-ua-stack/stack-tests/src/test/java/org/eclipse/milo/opcua/stack/client/config/UaTcpStackClientConfigTest.java
@@ -1,0 +1,89 @@
+package org.eclipse.milo.opcua.stack.client.config;
+
+import java.util.Optional;
+
+import org.eclipse.milo.opcua.stack.SecurityFixture;
+import org.eclipse.milo.opcua.stack.core.Stack;
+import org.eclipse.milo.opcua.stack.core.channel.ChannelConfig;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.testng.annotations.Test;
+
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.testng.Assert.assertEquals;
+
+public class UaTcpStackClientConfigTest extends SecurityFixture {
+
+    @Test
+    public void testCopy() {
+        UaTcpStackClientConfig original = UaTcpStackClientConfig.builder()
+            .setEndpointUrl("test")
+            .setKeyPair(clientKeyPair)
+            .setCertificate(clientCertificate)
+            .setApplicationName(LocalizedText.english("testName"))
+            .setApplicationUri("testApplicationUri")
+            .setProductUri("testProductUri")
+            .setChannelConfig(ChannelConfig.DEFAULT)
+            .setChannelLifetime(uint(1234))
+            .setExecutor(Stack.sharedExecutor())
+            .setEventLoop(Stack.sharedEventLoop())
+            .setWheelTimer(Stack.sharedWheelTimer())
+            .setSecureChannelReauthenticationEnabled(true)
+            .build();
+
+        UaTcpStackClientConfig copy = UaTcpStackClientConfig.copy(original).build();
+
+        assertEquals(copy.getEndpointUrl(), original.getEndpointUrl());
+        assertEquals(copy.getKeyPair(), original.getKeyPair());
+        assertEquals(copy.getCertificate(), original.getCertificate());
+        assertEquals(copy.getApplicationName(), original.getApplicationName());
+        assertEquals(copy.getApplicationUri(), original.getApplicationUri());
+        assertEquals(copy.getProductUri(), original.getProductUri());
+        assertEquals(copy.getChannelConfig(), original.getChannelConfig());
+        assertEquals(copy.getChannelLifetime(), original.getChannelLifetime());
+        assertEquals(copy.getExecutor(), original.getExecutor());
+        assertEquals(copy.getEventLoop(), original.getEventLoop());
+        assertEquals(copy.getWheelTimer(), original.getWheelTimer());
+        assertEquals(
+            copy.isSecureChannelReauthenticationEnabled(),
+            original.isSecureChannelReauthenticationEnabled());
+    }
+
+    @Test
+    public void testCopyAndModify() {
+        UaTcpStackClientConfig original = UaTcpStackClientConfig.builder()
+            .setEndpointUrl("test")
+            .setKeyPair(clientKeyPair)
+            .setCertificate(clientCertificate)
+            .setApplicationName(LocalizedText.english("testName"))
+            .setApplicationUri("testApplicationUri")
+            .setProductUri("testProductUri")
+            .setChannelConfig(ChannelConfig.DEFAULT)
+            .setChannelLifetime(uint(1234))
+            .setExecutor(Stack.sharedExecutor())
+            .setEventLoop(Stack.sharedEventLoop())
+            .setWheelTimer(Stack.sharedWheelTimer())
+            .setSecureChannelReauthenticationEnabled(true)
+            .build();
+
+        UaTcpStackClientConfig copy = UaTcpStackClientConfig.copy(original,
+            builder -> builder.setEndpointUrl("foo")
+                .setKeyPair(null)
+                .setCertificate(null)
+                .setApplicationName(LocalizedText.english("fooName"))
+                .setApplicationUri("fooApplicationUri")
+                .setProductUri("fooProductUri")
+                .setChannelConfig(null)
+                .setChannelLifetime(uint(0))
+        );
+
+        assertEquals(copy.getEndpointUrl(), Optional.of("foo"));
+        assertEquals(copy.getKeyPair(), Optional.empty());
+        assertEquals(copy.getCertificate(), Optional.empty());
+        assertEquals(copy.getApplicationName(), LocalizedText.english("fooName"));
+        assertEquals(copy.getApplicationUri(), "fooApplicationUri");
+        assertEquals(copy.getProductUri(), "fooProductUri");
+        assertEquals(copy.getChannelConfig(), null);
+        assertEquals(copy.getChannelLifetime(), uint(0));
+    }
+
+}


### PR DESCRIPTION
Adds copy() methods to the client and server config objects that allow for easier copying and modification of an existing config.