### PR TITLE
slf4j-simple is just a runtime dependency

### DIFF
--- a/opc-ua-stack/stack-examples/pom.xml
+++ b/opc-ua-stack/stack-examples/pom.xml
@@ -25,6 +25,7 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
             <version>${slf4j.version}</version>
+            <scope>runtime</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
This change does declare the slf4j-simple artifact as "runtime only" 