### PR TITLE
#26: DefaultCertificateValidator may leak resources

### DIFF
--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/application/DefaultCertificateValidatorLifecycleTest.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/application/DefaultCertificateValidatorLifecycleTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2016 Jens Reimann <jreimann@redhat.com>
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *  http://www.eclipse.org/org/documents/edl-v10.html.
+ */
+
+package org.eclipse.milo.opcua.stack.core.application;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Comparator;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class DefaultCertificateValidatorLifecycleTest {
+
+    private Path basePath = Paths.get("certs.test1");
+
+    @Test(timeOut = 5_000)
+    public void testClose() throws IOException {
+        int initialThreadCount = countThreads("init");
+        try (DefaultCertificateValidator validator = new DefaultCertificateValidator(this.basePath.toFile())) {
+            // no-op
+            Assert.assertTrue(countThreads("opened") > initialThreadCount);
+        }
+        Assert.assertEquals(countThreads("closed"), initialThreadCount);
+    }
+
+    private int countThreads(String label) {
+        System.out.format("========================= %s =========================%n", label);
+        Thread[] threads = Thread.getAllStackTraces().keySet().toArray(new Thread[0]);
+        Arrays.sort(threads, Comparator.comparing(Thread::getName));
+
+        for (Thread thread : threads) {
+            System.out.println(thread);
+        }
+        System.out.format("========================= %s =========================%n", label);
+        return threads.length;
+    }
+}


### PR DESCRIPTION
This change allows one to properly close the validator, cleaning up the
internal thread and file system watcher.

It also adds a new constructor which allows to construct the instance
providing all necessary directories and allows one to disable writing
the rejected certificates.

A test case was also added to test the shutdown.

Signed-off-by: Jens Reimann <jreimann@redhat.com>