### PR TITLE
[#23] shut down and remove unused SocketServers

### DIFF
--- a/opc-ua-stack/stack-tests/src/test/java/org/eclipse/milo/opcua/stack/server/tcp/SocketServerTest.java
+++ b/opc-ua-stack/stack-tests/src/test/java/org/eclipse/milo/opcua/stack/server/tcp/SocketServerTest.java
@@ -1,0 +1,31 @@
+package org.eclipse.milo.opcua.stack.server.tcp;
+
+import org.eclipse.milo.opcua.stack.SecurityFixture;
+import org.eclipse.milo.opcua.stack.server.config.UaTcpStackServerConfig;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class SocketServerTest extends SecurityFixture {
+
+    @Test
+    public void testShutdownRemovesInstance() {
+        UaTcpStackServerConfig config = UaTcpStackServerConfig.builder()
+            .setServerName("test")
+            .setCertificateManager(serverCertificateManager)
+            .setCertificateValidator(serverCertificateValidator)
+            .build();
+
+        UaTcpStackServer server = new UaTcpStackServer(config);
+
+        server.addEndpoint("opc.tcp://localhost:12685/test", null);
+
+        server.startup();
+        assertFalse(SocketServer.SOCKET_SERVERS.isEmpty());
+
+        server.shutdown();
+        assertTrue(SocketServer.SOCKET_SERVERS.isEmpty());
+    }
+
+}


### PR DESCRIPTION
Once a SocketServer is no longer used by any UaTcpStackServers it should be shut down and removed to prevent leaking SocketServer instances.