### PR TITLE
[#30] Add synchronization to DelegateRegistry initialization

### DIFF
--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/serialization/DelegateRegistry.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/serialization/DelegateRegistry.java
@@ -16,6 +16,7 @@ package org.eclipse.milo.opcua.stack.core.serialization;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
@@ -31,120 +32,88 @@ import org.slf4j.LoggerFactory;
 
 public class DelegateRegistry {
 
-    private static final Map<Class<?>, EncoderDelegate<?>> encodersByClass = Maps.newConcurrentMap();
-
-    private static final Map<NodeId, EncoderDelegate<?>> encodersById = Maps.newConcurrentMap();
-
-    private static final Map<Class<?>, DecoderDelegate<?>> decodersByClass = Maps.newConcurrentMap();
-
-    private static final Map<NodeId, DecoderDelegate<?>> decodersById = Maps.newConcurrentMap();
-
-    public static <T> void registerEncoder(EncoderDelegate<T> delegate, Class<T> clazz, NodeId... ids) {
-        encodersByClass.put(clazz, delegate);
-
-        if (ids != null) {
-            Arrays.stream(ids).forEach(id -> encodersById.put(id, delegate));
-        }
+    /**
+     * Get the singleton instance of the DelegateRegistry: {@link DelegateRegistry.Instance}.
+     *
+     * @return the singleton instance of the DelegateRegistry: {@link DelegateRegistry.Instance}.
+     */
+    public static Instance getInstance() {
+        return InstanceHolder.INSTANCE;
     }
 
-    public static <T> void registerDecoder(DecoderDelegate<T> delegate, Class<T> clazz, NodeId... ids) {
-        decodersByClass.put(clazz, delegate);
-
-        if (ids != null) {
-            Arrays.stream(ids).forEach(id -> decodersById.put(id, delegate));
-        }
+    private static class InstanceHolder {
+        private static final Instance INSTANCE = getOrInitialize();
     }
 
-    @SuppressWarnings("unchecked")
-    public static <T> EncoderDelegate<T> getEncoder(Object t) throws UaSerializationException {
-        try {
-            return (EncoderDelegate<T>) encodersByClass.get(t.getClass());
-        } catch (NullPointerException e) {
-            throw new UaSerializationException(StatusCodes.Bad_EncodingError,
-                "no encoder registered for class=" + t);
-        }
-    }
+    private static final Map<Class<?>, EncoderDelegate<?>> ENCODERS_BY_CLASS = Maps.newConcurrentMap();
+    private static final Map<NodeId, EncoderDelegate<?>> ENCODERS_BY_ID = Maps.newConcurrentMap();
 
-    @SuppressWarnings("unchecked")
-    public static <T> EncoderDelegate<T> getEncoder(Class<?> clazz) throws UaSerializationException {
-        try {
-            return (EncoderDelegate<T>) encodersByClass.get(clazz);
-        } catch (NullPointerException e) {
-            throw new UaSerializationException(StatusCodes.Bad_EncodingError,
-                "no encoder registered for class=" + clazz);
-        }
-    }
+    private static final Map<Class<?>, DecoderDelegate<?>> DECODERS_BY_CLASS = Maps.newConcurrentMap();
+    private static final Map<NodeId, DecoderDelegate<?>> DECODERS_BY_ID = Maps.newConcurrentMap();
 
-    @SuppressWarnings("unchecked")
-    public static <T> EncoderDelegate<T> getEncoder(NodeId encodingId) throws UaSerializationException {
-        try {
-            return (EncoderDelegate<T>) encodersById.get(encodingId);
-        } catch (NullPointerException e) {
-            throw new UaSerializationException(StatusCodes.Bad_EncodingError,
-                "no encoder registered for encodingId=" + encodingId);
-        }
-    }
+    private static final AtomicReference<Instance> INSTANCE_REF = new AtomicReference<>();
 
-    @SuppressWarnings("unchecked")
-    public static <T> DecoderDelegate<T> getDecoder(T t) throws UaSerializationException {
-        try {
-            return (DecoderDelegate<T>) decodersByClass.get(t.getClass());
-        } catch (NullPointerException e) {
-            throw new UaSerializationException(StatusCodes.Bad_DecodingError,
-                "no decoder registered for class=" + t);
-        }
-    }
+    private static synchronized Instance getOrInitialize() {
+        Instance instance = INSTANCE_REF.get();
 
-    @SuppressWarnings("unchecked")
-    public static <T> DecoderDelegate<T> getDecoder(Class<T> clazz) throws UaSerializationException {
-        try {
-            return (DecoderDelegate<T>) decodersByClass.get(clazz);
-        } catch (NullPointerException e) {
-            throw new UaSerializationException(StatusCodes.Bad_DecodingError,
-                "no decoder registered for class=" + clazz);
-        }
-    }
+        if (instance == null) {
+            /*
+             * Reflect-o-magically find all generated structured and enumerated types and force their static initialization
+             * blocks to run, registering their encode/decode methods with the delegate registry.
+             */
+            Logger logger = LoggerFactory.getLogger(DelegateRegistry.class);
 
-    @SuppressWarnings("unchecked")
-    public static <T> DecoderDelegate<T> getDecoder(NodeId encodingId) {
-        DecoderDelegate<T> decoder = (DecoderDelegate<T>) decodersById.get(encodingId);
-
-        if (decoder == null) {
-            throw new UaSerializationException(StatusCodes.Bad_DecodingError,
-                "no decoder registered for encodingId=" + encodingId);
-        }
-
-        return decoder;
-    }
-
-    static {
-        /*
-         * Reflect-o-magically find all generated structured and enumerated types and force their static initialization
-         * blocks to run, registering their encode/decode methods with the delegate registry.
-         */
-        Logger logger = LoggerFactory.getLogger(DelegateRegistry.class);
-
-        ClassLoader classLoader = Stack.getCustomClassLoader()
-            .orElse(DelegateRegistry.class.getClassLoader());
-
-        try {
-            loadGeneratedClasses(classLoader);
-        } catch (Exception e1) {
-            // Temporarily set the thread context ClassLoader to our
-            // ClassLoader and try loading the classes one more time.
-
-            Thread thread = Thread.currentThread();
-            ClassLoader contextClassLoader = thread.getContextClassLoader();
-
-            thread.setContextClassLoader(classLoader);
+            ClassLoader classLoader = Stack.getCustomClassLoader()
+                .orElse(DelegateRegistry.class.getClassLoader());
 
             try {
                 loadGeneratedClasses(classLoader);
-            } catch (Exception e2) {
-                logger.error("Error loading generated classes.", e2);
-            } finally {
-                thread.setContextClassLoader(contextClassLoader);
+            } catch (Exception e1) {
+                // Temporarily set the thread context ClassLoader to our
+                // ClassLoader and try loading the classes one more time.
+
+                Thread thread = Thread.currentThread();
+                ClassLoader contextClassLoader = thread.getContextClassLoader();
+
+                thread.setContextClassLoader(classLoader);
+
+                try {
+                    loadGeneratedClasses(classLoader);
+                } catch (Exception e2) {
+                    logger.error("Error loading generated classes.", e2);
+                } finally {
+                    thread.setContextClassLoader(contextClassLoader);
+                }
             }
+
+            instance = new Instance(
+                ENCODERS_BY_CLASS,
+                ENCODERS_BY_ID,
+                DECODERS_BY_CLASS,
+                DECODERS_BY_ID
+            );
+
+            INSTANCE_REF.set(instance);
+
+            return instance;
+        } else {
+            return instance;
+        }
+    }
+
+    public static synchronized <T> void registerEncoder(EncoderDelegate<T> delegate, Class<T> clazz, NodeId... ids) {
+        ENCODERS_BY_CLASS.put(clazz, delegate);
+
+        if (ids != null) {
+            Arrays.stream(ids).forEach(id -> ENCODERS_BY_ID.put(id, delegate));
+        }
+    }
+
+    public static synchronized <T> void registerDecoder(DecoderDelegate<T> delegate, Class<T> clazz, NodeId... ids) {
+        DECODERS_BY_CLASS.put(clazz, delegate);
+
+        if (ids != null) {
+            Arrays.stream(ids).forEach(id -> DECODERS_BY_ID.put(id, delegate));
         }
     }
 
@@ -161,6 +130,90 @@ public class DelegateRegistry {
             Class<?> clazz = classInfo.load();
             Class.forName(clazz.getName(), true, classLoader);
         }
+    }
+
+    public static class Instance {
+
+        private final Map<Class<?>, EncoderDelegate<?>> encodersByClass;
+        private final Map<NodeId, EncoderDelegate<?>> encodersById;
+
+        private final Map<Class<?>, DecoderDelegate<?>> decodersByClass;
+        private final Map<NodeId, DecoderDelegate<?>> decodersById;
+
+        private Instance(
+            Map<Class<?>, EncoderDelegate<?>> encodersByClass,
+            Map<NodeId, EncoderDelegate<?>> encodersById,
+            Map<Class<?>, DecoderDelegate<?>> decodersByClass,
+            Map<NodeId, DecoderDelegate<?>> decodersById) {
+
+            this.encodersByClass = encodersByClass;
+            this.encodersById = encodersById;
+            this.decodersByClass = decodersByClass;
+            this.decodersById = decodersById;
+        }
+
+        @SuppressWarnings("unchecked")
+        public <T> EncoderDelegate<T> getEncoder(Object t) throws UaSerializationException {
+            try {
+                return (EncoderDelegate<T>) encodersByClass.get(t.getClass());
+            } catch (NullPointerException e) {
+                throw new UaSerializationException(StatusCodes.Bad_EncodingError,
+                    "no encoder registered for class=" + t);
+            }
+        }
+
+        @SuppressWarnings("unchecked")
+        public <T> EncoderDelegate<T> getEncoder(Class<?> clazz) throws UaSerializationException {
+            try {
+                return (EncoderDelegate<T>) encodersByClass.get(clazz);
+            } catch (NullPointerException e) {
+                throw new UaSerializationException(StatusCodes.Bad_EncodingError,
+                    "no encoder registered for class=" + clazz);
+            }
+        }
+
+        @SuppressWarnings("unchecked")
+        public <T> EncoderDelegate<T> getEncoder(NodeId encodingId) throws UaSerializationException {
+            try {
+                return (EncoderDelegate<T>) encodersById.get(encodingId);
+            } catch (NullPointerException e) {
+                throw new UaSerializationException(StatusCodes.Bad_EncodingError,
+                    "no encoder registered for encodingId=" + encodingId);
+            }
+        }
+
+        @SuppressWarnings("unchecked")
+        public <T> DecoderDelegate<T> getDecoder(T t) throws UaSerializationException {
+            try {
+                return (DecoderDelegate<T>) decodersByClass.get(t.getClass());
+            } catch (NullPointerException e) {
+                throw new UaSerializationException(StatusCodes.Bad_DecodingError,
+                    "no decoder registered for class=" + t);
+            }
+        }
+
+        @SuppressWarnings("unchecked")
+        public <T> DecoderDelegate<T> getDecoder(Class<T> clazz) throws UaSerializationException {
+            try {
+                return (DecoderDelegate<T>) decodersByClass.get(clazz);
+            } catch (NullPointerException e) {
+                throw new UaSerializationException(StatusCodes.Bad_DecodingError,
+                    "no decoder registered for class=" + clazz);
+            }
+        }
+
+        @SuppressWarnings("unchecked")
+        public <T> DecoderDelegate<T> getDecoder(NodeId encodingId) {
+            DecoderDelegate<T> decoder = (DecoderDelegate<T>) decodersById.get(encodingId);
+
+            if (decoder == null) {
+                throw new UaSerializationException(StatusCodes.Bad_DecodingError,
+                    "no decoder registered for encodingId=" + encodingId);
+            }
+
+            return decoder;
+        }
+
     }
 
 }

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/serialization/OpcUaDataTypeEncoding.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/serialization/OpcUaDataTypeEncoding.java
@@ -33,11 +33,13 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.XmlElement;
 
 public class OpcUaDataTypeEncoding implements DataTypeEncoding {
 
+    private static final DelegateRegistry.Instance DELEGATE_REGISTRY = DelegateRegistry.getInstance();
+
     private final ByteBufAllocator allocator = ByteBufAllocator.DEFAULT;
 
     @Override
     public ByteString encodeToByteString(Object object, NodeId encodingTypeId) {
-        EncoderDelegate<Object> delegate = DelegateRegistry.getEncoder(encodingTypeId);
+        EncoderDelegate<Object> delegate = DELEGATE_REGISTRY.getEncoder(encodingTypeId);
 
         ByteBuf buffer = allocator.buffer().order(ByteOrder.LITTLE_ENDIAN);
 
@@ -55,7 +57,7 @@ public class OpcUaDataTypeEncoding implements DataTypeEncoding {
 
     @Override
     public Object decodeFromByteString(ByteString encoded, NodeId encodingTypeId) {
-        DecoderDelegate<Object> delegate = DelegateRegistry.getDecoder(encodingTypeId);
+        DecoderDelegate<Object> delegate = DELEGATE_REGISTRY.getDecoder(encodingTypeId);
 
         byte[] bs = encoded.bytes();
         if (bs == null) bs = new byte[0];
@@ -73,7 +75,7 @@ public class OpcUaDataTypeEncoding implements DataTypeEncoding {
     @Override
     public XmlElement encodeToXmlElement(Object object, NodeId encodingTypeId) {
         try {
-            EncoderDelegate<Object> delegate = DelegateRegistry.getEncoder(encodingTypeId);
+            EncoderDelegate<Object> delegate = DELEGATE_REGISTRY.getEncoder(encodingTypeId);
 
             StringWriter stringWriter = new StringWriter();
 
@@ -91,7 +93,7 @@ public class OpcUaDataTypeEncoding implements DataTypeEncoding {
     @Override
     public Object decodeFromXmlElement(XmlElement encoded, NodeId encodingTypeId) {
         try {
-            DecoderDelegate<Object> delegate = DelegateRegistry.getDecoder(encodingTypeId);
+            DecoderDelegate<Object> delegate = DELEGATE_REGISTRY.getDecoder(encodingTypeId);
 
             XmlDecoder decoder = new XmlDecoder();
             decoder.setInput(new StringReader(encoded.getFragment()));

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/serialization/binary/BinaryDecoder.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/serialization/binary/BinaryDecoder.java
@@ -53,6 +53,8 @@ import org.eclipse.milo.opcua.stack.core.util.TypeUtil;
 
 public class BinaryDecoder implements UaDecoder {
 
+    private static final DelegateRegistry.Instance DELEGATE_REGISTRY = DelegateRegistry.getInstance();
+
     private volatile ByteBuf buffer;
 
     private final int maxArrayLength;
@@ -361,21 +363,21 @@ public class BinaryDecoder implements UaDecoder {
     public <T extends UaStructure> T decodeMessage(String field) throws UaSerializationException {
         NodeId encodingId = decodeNodeId(null);
 
-        DecoderDelegate<?> delegate = DelegateRegistry.getDecoder(encodingId);
+        DecoderDelegate<?> delegate = DELEGATE_REGISTRY.getDecoder(encodingId);
 
         return (T) delegate.decode(this);
     }
 
     @Override
     public <T extends UaEnumeration> T decodeEnumeration(String field, Class<T> clazz) throws UaSerializationException {
-        DecoderDelegate<T> delegate = DelegateRegistry.getDecoder(clazz);
+        DecoderDelegate<T> delegate = DELEGATE_REGISTRY.getDecoder(clazz);
 
         return delegate.decode(this);
     }
 
     @Override
     public <T extends UaSerializable> T decodeSerializable(String field, Class<T> clazz) throws UaSerializationException {
-        DecoderDelegate<T> delegate = DelegateRegistry.getDecoder(clazz);
+        DecoderDelegate<T> delegate = DELEGATE_REGISTRY.getDecoder(clazz);
 
         return delegate.decode(this);
     }

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/serialization/binary/BinaryEncoder.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/serialization/binary/BinaryEncoder.java
@@ -54,6 +54,8 @@ import org.slf4j.LoggerFactory;
 
 public class BinaryEncoder implements UaEncoder {
 
+    private static final DelegateRegistry.Instance DELEGATE_REGISTRY = DelegateRegistry.getInstance();
+
     private volatile ByteBuf buffer;
 
     private final int maxArrayLength;
@@ -589,7 +591,7 @@ public class BinaryEncoder implements UaEncoder {
 
     @Override
     public <T extends UaStructure> void encodeMessage(String field, T message) throws UaSerializationException {
-        EncoderDelegate<T> delegate = DelegateRegistry.getEncoder(message.getBinaryEncodingId());
+        EncoderDelegate<T> delegate = DELEGATE_REGISTRY.getEncoder(message.getBinaryEncodingId());
 
         encodeNodeId(null, message.getBinaryEncodingId());
 
@@ -601,7 +603,7 @@ public class BinaryEncoder implements UaEncoder {
         if (value == null) {
             encodeInt32(null, -1);
         } else {
-            EncoderDelegate<T> delegate = DelegateRegistry.getEncoder(value);
+            EncoderDelegate<T> delegate = DELEGATE_REGISTRY.getEncoder(value);
 
             delegate.encode(value, this);
         }
@@ -609,7 +611,7 @@ public class BinaryEncoder implements UaEncoder {
 
     @Override
     public <T extends UaSerializable> void encodeSerializable(String field, T value) throws UaSerializationException {
-        EncoderDelegate<T> delegate = DelegateRegistry.getEncoder(value);
+        EncoderDelegate<T> delegate = DELEGATE_REGISTRY.getEncoder(value);
 
         delegate.encode(value, this);
     }


### PR DESCRIPTION
Ensure the registry cannot be queried for encoders and decoders until
the initial scan for the built-in types and their corresponding
delegates has finished.