### PR TITLE
New subscription-level data change callbacks

### DIFF
--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/api/subscriptions/UaSubscription.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/api/subscriptions/UaSubscription.java
@@ -28,6 +28,7 @@ import org.eclipse.milo.opcua.stack.core.types.enumerated.MonitoringMode;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.TimestampsToReturn;
 import org.eclipse.milo.opcua.stack.core.types.structured.MonitoredItemCreateRequest;
 import org.eclipse.milo.opcua.stack.core.types.structured.MonitoredItemModifyRequest;
+import org.jooq.lambda.tuple.Tuple2;
 
 public interface UaSubscription {
 
@@ -172,13 +173,11 @@ public interface UaSubscription {
          * callbacks on a per-item basis. Its use is not required.
          *
          * @param subscription the {@link UaSubscription} that received the notification.
-         * @param items        the {@link UaMonitoredItem}s that received change notifications.
-         * @param valueChanges the {@link DataValue}s for each item that changed.
+         * @param itemValues   the {@link UaMonitoredItem}s and their corresponding value change.
          * @param publishTime  the time on the server at which this notification was published.
          */
         default void onDataChangeNotification(UaSubscription subscription,
-                                              ImmutableList<UaMonitoredItem> items,
-                                              ImmutableList<DataValue> valueChanges,
+                                              ImmutableList<Tuple2<UaMonitoredItem, DataValue>> itemValues,
                                               DateTime publishTime) {}
 
         /**
@@ -188,13 +187,11 @@ public interface UaSubscription {
          * callbacks on a per-item basis. Its use is not required.
          *
          * @param subscription the {@link UaSubscription} that received the notification.
-         * @param items        the {@link UaMonitoredItem}s that received change notifications.
-         * @param eventFields  the {@link Variant}s corresponding to the event fields for each item.
+         * @param itemEvents   the {@link UaMonitoredItem}s and their corresponding event fields.
          * @param publishTime  the time on the server at which this notification was published.
          */
         default void onEventNotification(UaSubscription subscription,
-                                         ImmutableList<UaMonitoredItem> items,
-                                         ImmutableList<Variant[]> eventFields,
+                                         ImmutableList<Tuple2<UaMonitoredItem, Variant[]>> itemEvents,
                                          DateTime publishTime) {}
 
         /**

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/api/subscriptions/UaSubscription.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/api/subscriptions/UaSubscription.java
@@ -18,7 +18,10 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.BiConsumer;
 
 import com.google.common.collect.ImmutableList;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
 import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.MonitoringMode;
@@ -144,5 +147,72 @@ public interface UaSubscription {
      * @return a {@link CompletableFuture} containing a {@link StatusCode} representing the result of this operation.
      */
     CompletableFuture<StatusCode> setPublishingMode(boolean publishingEnabled);
+
+    /**
+     * Add a {@link NotificationListener}.
+     *
+     * @param listener the {@link NotificationListener} to add.
+     */
+    void addNotificationListener(NotificationListener listener);
+
+    /**
+     * Remove a {@link NotificationListener}.
+     *
+     * @param listener the {@link NotificationListener} to remove.
+     */
+    void removeNotificationListener(NotificationListener listener);
+
+
+    interface NotificationListener {
+
+        /**
+         * A notification containing data value changes for this {@link UaSubscription} has arrived.
+         * <p>
+         * This callback is invoked after all individual item callbacks and is offered as an alternative to defining
+         * callbacks on a per-item basis. Its use is not required.
+         *
+         * @param subscription the {@link UaSubscription} that received the notification.
+         * @param items        the {@link UaMonitoredItem}s that received change notifications.
+         * @param valueChanges the {@link DataValue}s for each item that changed.
+         * @param publishTime  the time on the server at which this notification was published.
+         */
+        default void onDataChangeNotification(UaSubscription subscription,
+                                              ImmutableList<UaMonitoredItem> items,
+                                              ImmutableList<DataValue> valueChanges,
+                                              DateTime publishTime) {}
+
+        /**
+         * A notification containing events for this {@link UaSubscription} has arrived.
+         * <p>
+         * This callback is invoked after all individual item callbacks and is offered as an alternative to defining
+         * callbacks on a per-item basis. Its use is not required.
+         *
+         * @param subscription the {@link UaSubscription} that received the notification.
+         * @param items        the {@link UaMonitoredItem}s that received change notifications.
+         * @param eventFields  the {@link Variant}s corresponding to the event fields for each item.
+         * @param publishTime  the time on the server at which this notification was published.
+         */
+        default void onEventNotification(UaSubscription subscription,
+                                         ImmutableList<UaMonitoredItem> items,
+                                         ImmutableList<Variant[]> eventFields,
+                                         DateTime publishTime) {}
+
+        /**
+         * A keep-alive message was received.
+         *
+         * @param subscription the {@link UaSubscription} that received the keep-alive.
+         * @param publishTime  the time the server published the keep-alive.
+         */
+        default void onKeepAliveNotification(UaSubscription subscription, DateTime publishTime) {}
+
+        /**
+         * A status change notification was received.
+         *
+         * @param subscription the {@link UaSubscription} that received the status change.
+         * @param status       the new subscription status.
+         */
+        default void onStatusChangedNotification(UaSubscription subscription, StatusCode status) {}
+
+    }
 
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/api/subscriptions/UaSubscriptionManager.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/api/subscriptions/UaSubscriptionManager.java
@@ -22,8 +22,6 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
 import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
-import org.eclipse.milo.opcua.stack.core.types.structured.DataChangeNotification;
-import org.eclipse.milo.opcua.stack.core.types.structured.EventNotificationList;
 
 public interface UaSubscriptionManager {
 
@@ -110,34 +108,6 @@ public interface UaSubscriptionManager {
     void removeSubscriptionListener(SubscriptionListener listener);
 
     interface SubscriptionListener {
-
-        /**
-         * A {@link DataChangeNotification} for a {@link UaSubscription} has arrived.
-         * <p>
-         * This callback is invoked after all individual item callbacks and is offered as an alternative to defining
-         * callbacks on a per-item basis. Its use is not required.
-         *
-         * @param subscription the {@link UaSubscription} that received the notification.
-         * @param notification the {@link DataChangeNotification}.
-         * @param publishTime  the time on the server at which this notification was published.
-         */
-        default void onDataChangeNotification(UaSubscription subscription,
-                                              DataChangeNotification notification,
-                                              DateTime publishTime) {}
-
-        /**
-         * An {@link EventNotificationList} for a {@link UaSubscription} has arrived.
-         * <p>
-         * This callback is invoked after all individual item callbacks and is offered as an alternative to defining
-         * callbacks on a per-item basis. Its use is not required.
-         *
-         * @param subscription the {@link UaSubscription} that received the notification.
-         * @param notification the {@link EventNotificationList}.
-         * @param publishTime  the time on the server at which this notification was published.
-         */
-        default void onEventNotification(UaSubscription subscription,
-                                         EventNotificationList notification,
-                                         DateTime publishTime) {}
 
         /**
          * A keep-alive message was received.

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/api/subscriptions/UaSubscriptionManager.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/api/subscriptions/UaSubscriptionManager.java
@@ -22,6 +22,8 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
 import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.eclipse.milo.opcua.stack.core.types.structured.DataChangeNotification;
+import org.eclipse.milo.opcua.stack.core.types.structured.EventNotificationList;
 
 public interface UaSubscriptionManager {
 
@@ -108,6 +110,34 @@ public interface UaSubscriptionManager {
     void removeSubscriptionListener(SubscriptionListener listener);
 
     interface SubscriptionListener {
+
+        /**
+         * A {@link DataChangeNotification} for a {@link UaSubscription} has arrived.
+         * <p>
+         * This callback is invoked after all individual item callbacks and is offered as an alternative to defining
+         * callbacks on a per-item basis. Its use is not required.
+         *
+         * @param subscription the {@link UaSubscription} that received the notification.
+         * @param notification the {@link DataChangeNotification}.
+         * @param publishTime  the time on the server at which this notification was published.
+         */
+        default void onDataChangeNotification(UaSubscription subscription,
+                                              DataChangeNotification notification,
+                                              DateTime publishTime) {}
+
+        /**
+         * An {@link EventNotificationList} for a {@link UaSubscription} has arrived.
+         * <p>
+         * This callback is invoked after all individual item callbacks and is offered as an alternative to defining
+         * callbacks on a per-item basis. Its use is not required.
+         *
+         * @param subscription the {@link UaSubscription} that received the notification.
+         * @param notification the {@link EventNotificationList}.
+         * @param publishTime  the time on the server at which this notification was published.
+         */
+        default void onEventNotification(UaSubscription subscription,
+                                         EventNotificationList notification,
+                                         DateTime publishTime) {}
 
         /**
          * A keep-alive message was received.

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/subscriptions/OpcUaSubscription.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/subscriptions/OpcUaSubscription.java
@@ -17,6 +17,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 
@@ -47,6 +48,8 @@ public class OpcUaSubscription implements UaSubscription {
 
     private final Map<UInteger, OpcUaMonitoredItem> itemsByClientHandle = Maps.newConcurrentMap();
     private final Map<UInteger, OpcUaMonitoredItem> itemsByServerHandle = Maps.newConcurrentMap();
+
+    private final List<NotificationListener> notificationListeners = new CopyOnWriteArrayList<>();
 
     private final AsyncSemaphore notificationSemaphore = new AsyncSemaphore(1);
 
@@ -286,6 +289,20 @@ public class OpcUaSubscription implements UaSubscription {
     @Override
     public ImmutableList<UaMonitoredItem> getMonitoredItems() {
         return ImmutableList.copyOf(itemsByClientHandle.values());
+    }
+
+    @Override
+    public void addNotificationListener(NotificationListener listener) {
+        notificationListeners.add(listener);
+    }
+
+    @Override
+    public void removeNotificationListener(NotificationListener listener) {
+        notificationListeners.remove(listener);
+    }
+
+    List<NotificationListener> getNotificationListeners() {
+        return notificationListeners;
     }
 
     AsyncSemaphore getNotificationSemaphore() {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/subscriptions/OpcUaSubscriptionManager.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/subscriptions/OpcUaSubscriptionManager.java
@@ -521,7 +521,13 @@ public class OpcUaSubscriptionManager implements UaSubscriptionManager {
 
                         if (notificationCount == 0) {
                             subscriptionListeners.forEach(
-                                l -> l.onKeepAlive(subscription, notificationMessage.getPublishTime()));
+                                listener -> listener.onKeepAlive(subscription, notificationMessage.getPublishTime())
+                            );
+                        } else {
+                            subscriptionListeners.forEach(
+                                listener -> listener.onDataChangeNotification(
+                                    subscription, dcn, notificationMessage.getPublishTime())
+                            );
                         }
                     } else if (o instanceof EventNotificationList) {
                         EventNotificationList enl = (EventNotificationList) o;
@@ -533,12 +539,19 @@ public class OpcUaSubscriptionManager implements UaSubscriptionManager {
                             OpcUaMonitoredItem item = items.get(efl.getClientHandle());
                             if (item != null) item.onEventArrived(efl.getEventFields());
                         }
+
+                        subscriptionListeners.forEach(
+                            listener -> listener.onEventNotification(
+                                subscription, enl, notificationMessage.getPublishTime())
+                        );
                     } else if (o instanceof StatusChangeNotification) {
                         StatusChangeNotification scn = (StatusChangeNotification) o;
 
                         logger.debug("StatusChangeNotification: {}", scn.getStatus());
 
-                        subscriptionListeners.forEach(l -> l.onStatusChanged(subscription, scn.getStatus()));
+                        subscriptionListeners.forEach(
+                            listener -> listener.onStatusChanged(subscription, scn.getStatus())
+                        );
 
                         if (scn.getStatus().getValue() == StatusCodes.Bad_Timeout) {
                             subscriptions.remove(subscription.getSubscriptionId());

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/subscriptions/OpcUaSubscriptionManager.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/subscriptions/OpcUaSubscriptionManager.java
@@ -543,11 +543,14 @@ public class OpcUaSubscriptionManager implements UaSubscriptionManager {
                                     }
                                 }
 
+                                ImmutableList<UaMonitoredItem> itemList = itemsBuilder.build();
+                                ImmutableList<DataValue> valueList = valuesBuilder.build();
+
                                 subscription.getNotificationListeners().forEach(
                                     listener -> listener.onDataChangeNotification(
                                         subscription,
-                                        itemsBuilder.build(),
-                                        valuesBuilder.build(),
+                                        itemList,
+                                        valueList,
                                         notificationMessage.getPublishTime()
                                     )
                                 );
@@ -576,11 +579,14 @@ public class OpcUaSubscriptionManager implements UaSubscriptionManager {
                                 }
                             }
 
+                            ImmutableList<UaMonitoredItem> itemList = itemsBuilder.build();
+                            ImmutableList<Variant[]> fieldsList = fieldsBuilder.build();
+
                             subscription.getNotificationListeners().forEach(
                                 listener -> listener.onEventNotification(
                                     subscription,
-                                    itemsBuilder.build(),
-                                    fieldsBuilder.build(),
+                                    itemList,
+                                    fieldsList,
                                     notificationMessage.getPublishTime()
                                 )
                             );

--- a/opc-ua-sdk/sdk-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/OpcUaClientIT.java
+++ b/opc-ua-sdk/sdk-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/OpcUaClientIT.java
@@ -25,7 +25,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
 
-import com.codepoetics.protonpack.StreamUtils;
 import com.google.common.collect.ImmutableList;
 import org.eclipse.milo.opcua.sdk.client.api.UaSession;
 import org.eclipse.milo.opcua.sdk.client.api.config.OpcUaClientConfig;
@@ -37,7 +36,6 @@ import org.eclipse.milo.opcua.sdk.client.api.subscriptions.UaSubscriptionManager
 import org.eclipse.milo.opcua.sdk.server.OpcUaServer;
 import org.eclipse.milo.opcua.sdk.server.api.config.OpcUaServerConfig;
 import org.eclipse.milo.opcua.sdk.server.identity.UsernameIdentityValidator;
-import org.eclipse.milo.opcua.sdk.server.util.StreamUtil;
 import org.eclipse.milo.opcua.stack.client.UaTcpStackClient;
 import org.eclipse.milo.opcua.stack.core.AttributeId;
 import org.eclipse.milo.opcua.stack.core.Identifiers;
@@ -54,7 +52,6 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.MonitoringMode;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.TimestampsToReturn;
-import org.eclipse.milo.opcua.stack.core.types.structured.DataChangeNotification;
 import org.eclipse.milo.opcua.stack.core.types.structured.EndpointDescription;
 import org.eclipse.milo.opcua.stack.core.types.structured.MonitoredItemCreateRequest;
 import org.eclipse.milo.opcua.stack.core.types.structured.MonitoringParameters;
@@ -62,6 +59,7 @@ import org.eclipse.milo.opcua.stack.core.types.structured.ReadValueId;
 import org.eclipse.milo.opcua.stack.core.types.structured.UserTokenPolicy;
 import org.eclipse.milo.opcua.stack.core.util.FutureUtils;
 import org.eclipse.milo.opcua.stack.server.tcp.SocketServers;
+import org.jooq.lambda.tuple.Tuple2;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterTest;
@@ -266,13 +264,12 @@ public class OpcUaClientIT {
         subscription.addNotificationListener(new UaSubscription.NotificationListener() {
             @Override
             public void onDataChangeNotification(UaSubscription subscription,
-                                                 ImmutableList<UaMonitoredItem> items,
-                                                 ImmutableList<DataValue> valueChanges,
+                                                 ImmutableList<Tuple2<UaMonitoredItem, DataValue>> itemValues,
                                                  DateTime publishTime) {
 
-                for (int i = 0; i < items.size(); i++) {
-                    UaMonitoredItem item = items.get(i);
-                    DataValue value = valueChanges.get(i);
+                for (Tuple2<UaMonitoredItem, DataValue> itemValue : itemValues) {
+                    UaMonitoredItem item = itemValue.v1();
+                    DataValue value = itemValue.v2();
 
                     logger.info("item={}, value={}", item.getReadValueId().getNodeId(), value);
                 }


### PR DESCRIPTION
Adds new callbacks to SubscriptionListener that allow for data and event notifications to be received at the subscription-level rather than per-item, if desired.