### PR TITLE
[#63] Fix NPE in OpcUaSubscriptionManager

### DIFF
--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/subscriptions/OpcUaSubscriptionManager.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/subscriptions/OpcUaSubscriptionManager.java
@@ -412,13 +412,17 @@ public class OpcUaSubscriptionManager implements UaSubscriptionManager {
 
         subscription.setLastSequenceNumber(sequenceNumber);
 
-        synchronized (acknowledgements) {
-            for (UInteger available : response.getAvailableSequenceNumbers()) {
-                acknowledgements.add(new SubscriptionAcknowledgement(subscriptionId, available));
+        UInteger[] availableSequenceNumbers = response.getAvailableSequenceNumbers();
+
+        if (availableSequenceNumbers != null && availableSequenceNumbers.length > 0) {
+            synchronized (acknowledgements) {
+                for (UInteger available : availableSequenceNumbers) {
+                    acknowledgements.add(new SubscriptionAcknowledgement(subscriptionId, available));
+                }
             }
 
             if (logger.isDebugEnabled()) {
-                String[] seqStrings = Arrays.stream(response.getAvailableSequenceNumbers())
+                String[] seqStrings = Arrays.stream(availableSequenceNumbers)
                     .map(sequence -> String.format("id=%s/seq=%s", subscriptionId, sequence))
                     .toArray(String[]::new);
 


### PR DESCRIPTION
The recent change to preserve the distinction between null and empty arrays while decoding (as per the spec) has lead to instances where a previously always-empty array is now null depending on the server implementation, leading to NPEs.