### PR TITLE
Fix NPE if clientSoftwareCertificates is null

### DIFF
--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/SessionManager.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/SessionManager.java
@@ -462,7 +462,7 @@ public class SessionManager implements
 
             session.setClientCertificateBytes(secureChannel.getRemoteCertificateBytes());
 
-            StatusCode[] results = new StatusCode[clientSoftwareCertificates.length];
+            StatusCode[] results = new StatusCode[clientSoftwareCertificates != null ? clientSoftwareCertificates.length : 0];
             Arrays.fill(results, StatusCode.GOOD);
 
             ByteString serverNonce = NonceUtil.generateNonce(32);


### PR DESCRIPTION
If the client doesn't provide any client software certificate, the list is null and causes a NPE.
Fixed with this commit