### PR TITLE
#74: Provide a static instance of AnonymousIdentityValidator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 .settings/
 .project
 .classpath
+.checkstyle
 
 # IntelliJ #
 *.iml

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/api/config/OpcUaServerConfigBuilder.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/api/config/OpcUaServerConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 Kevin Herron
+ * Copyright (c) 2016 Kevin Herron and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -42,7 +42,7 @@ public class OpcUaServerConfigBuilder extends UaTcpStackServerConfigBuilder {
     private List<String> bindAddresses = newArrayList("0.0.0.0");
     private int bindPort = Stack.DEFAULT_PORT;
     private EnumSet<SecurityPolicy> securityPolicies = EnumSet.of(SecurityPolicy.None);
-    private IdentityValidator identityValidator = new AnonymousIdentityValidator();
+    private IdentityValidator identityValidator = AnonymousIdentityValidator.INSTANCE;
 
     private BuildInfo buildInfo = new BuildInfo(
         "", "", "", "", "", DateTime.MIN_VALUE);

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/AnonymousIdentityValidator.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/AnonymousIdentityValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 Kevin Herron
+ * Copyright (c) 2016 Kevin Herron and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -20,8 +20,20 @@ import org.eclipse.milo.opcua.stack.core.types.structured.AnonymousIdentityToken
 import org.eclipse.milo.opcua.stack.core.types.structured.SignatureData;
 import org.eclipse.milo.opcua.stack.core.types.structured.UserTokenPolicy;
 
-public class AnonymousIdentityValidator extends AbstractIdentityValidator {
+public final class AnonymousIdentityValidator extends AbstractIdentityValidator {
 
+    /**
+     * A static instance implementing AnonymousIdentityValidator
+     */
+    public static final IdentityValidator INSTANCE = new AnonymousIdentityValidator();
+    
+    /**
+     * @deprecated Use {@link #INSTANCE} instead 
+     */
+    @Deprecated
+    public AnonymousIdentityValidator() {
+    }
+    
     @Override
     public Object validateAnonymousToken(
         SecureChannel channel,

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/api/config/OpcUaServerConfigTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/api/config/OpcUaServerConfigTest.java
@@ -25,7 +25,7 @@ public class OpcUaServerConfigTest {
             .setHostname("testHostname")
             .setBindAddresses(Lists.newArrayList("127.0.0.1", "0.0.0.0"))
             .setBindPort(12345)
-            .setIdentityValidator(new AnonymousIdentityValidator())
+            .setIdentityValidator(AnonymousIdentityValidator.INSTANCE)
             .setBuildInfo(new BuildInfo("a", "b", "c", "d", "e", DateTime.MIN_VALUE))
             .setLimits(new OpcUaServerConfigLimits() {})
             .build();


### PR DESCRIPTION
This change provides a static instance for the 
AnonymousIdentityValidator and deprecates the default constructor.

Signed-off-by: Jens Reimann <jreimann@redhat.com>