### PR TITLE
NPE prevention

### DIFF
--- a/milo-examples/client-examples/src/main/java/org/eclipse/milo/examples/client/BrowseExample.java
+++ b/milo-examples/client-examples/src/main/java/org/eclipse/milo/examples/client/BrowseExample.java
@@ -13,6 +13,7 @@
 
 package org.eclipse.milo.examples.client;
 
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
@@ -29,6 +30,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.eclipse.milo.opcua.stack.core.util.ConversionUtil.toList;
 
 public class BrowseExample implements ClientExample {
 
@@ -64,7 +66,9 @@ public class BrowseExample implements ClientExample {
         try {
             BrowseResult browseResult = client.browse(browse).get();
 
-            for (ReferenceDescription rd : browseResult.getReferences()) {
+            List<ReferenceDescription> references = toList(browseResult.getReferences());
+
+            for (ReferenceDescription rd : references) {
                 logger.info("{} Node={}", indent, rd.getBrowseName().getName());
 
                 // recursively browse to children

--- a/milo-examples/client-examples/src/main/java/org/eclipse/milo/examples/client/MethodExample.java
+++ b/milo-examples/client-examples/src/main/java/org/eclipse/milo/examples/client/MethodExample.java
@@ -25,6 +25,8 @@ import org.eclipse.milo.opcua.stack.core.types.structured.CallMethodRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.eclipse.milo.opcua.stack.core.util.ConversionUtil.l;
+
 public class MethodExample implements ClientExample {
 
     public static void main(String[] args) throws Exception {
@@ -62,7 +64,7 @@ public class MethodExample implements ClientExample {
             StatusCode statusCode = result.getStatusCode();
 
             if (statusCode.isGood()) {
-                Double value = (Double) result.getOutputArguments()[0].getValue();
+                Double value = (Double) l(result.getOutputArguments()).get(0).getValue();
                 return CompletableFuture.completedFuture(value);
             } else {
                 CompletableFuture<Double> f = new CompletableFuture<>();

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/ClientSessionManager.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/ClientSessionManager.java
@@ -68,6 +68,7 @@ import org.slf4j.LoggerFactory;
 import static com.google.common.collect.Lists.newCopyOnWriteArrayList;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.eclipse.milo.opcua.stack.core.util.ConversionUtil.l;
 
 class ClientSessionManager {
 
@@ -576,10 +577,10 @@ class ClientSessionManager {
             CompletableFuture<OpcUaSession> sessionFuture = transferringState.sessionFuture;
 
             if (tsr != null) {
-                TransferResult[] results = tsr.getResults();
+                List<TransferResult> results = l(tsr.getResults());
 
-                for (int i = 0; i < results.length; i++) {
-                    TransferResult result = results[i];
+                for (int i = 0; i < results.size(); i++) {
+                    TransferResult result = results.get(i);
 
                     if (!result.getStatusCode().isGood()) {
                         UaSubscription subscription = subscriptions.get(i);
@@ -594,7 +595,7 @@ class ClientSessionManager {
                 if (logger.isDebugEnabled()) {
                     Stream<UInteger> subscriptionIds = subscriptions.stream()
                         .map(UaSubscription::getSubscriptionId);
-                    Stream<StatusCode> statusCodes = Arrays.stream(results)
+                    Stream<StatusCode> statusCodes = results.stream()
                         .map(TransferResult::getStatusCode);
 
                     String[] ss = StreamUtils.zip(

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/api/identity/AnonymousProvider.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/api/identity/AnonymousProvider.java
@@ -14,6 +14,7 @@
 package org.eclipse.milo.opcua.sdk.client.api.identity;
 
 import java.util.Arrays;
+import java.util.List;
 
 import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.UserTokenType;
@@ -23,6 +24,8 @@ import org.eclipse.milo.opcua.stack.core.types.structured.SignatureData;
 import org.eclipse.milo.opcua.stack.core.types.structured.UserIdentityToken;
 import org.eclipse.milo.opcua.stack.core.types.structured.UserTokenPolicy;
 import org.jooq.lambda.tuple.Tuple2;
+
+import static org.eclipse.milo.opcua.stack.core.util.ConversionUtil.l;
 
 /**
  * An {@link IdentityProvider} that will choose the first available anonymous {@link UserTokenPolicy}.
@@ -34,7 +37,9 @@ public class AnonymousProvider implements IdentityProvider {
         EndpointDescription endpoint,
         ByteString serverNonce) throws Exception {
 
-        return Arrays.stream(endpoint.getUserIdentityTokens())
+        List<UserTokenPolicy> userIdentityTokens = l(endpoint.getUserIdentityTokens());
+
+        return userIdentityTokens.stream()
             .filter(t -> t.getTokenType() == UserTokenType.Anonymous)
             .findFirst()
             .map(policy -> {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/api/identity/UsernameProvider.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/api/identity/UsernameProvider.java
@@ -20,6 +20,7 @@ import java.security.PublicKey;
 import java.security.cert.X509Certificate;
 import java.security.interfaces.RSAPublicKey;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 import javax.crypto.Cipher;
 
@@ -41,6 +42,8 @@ import org.jooq.lambda.tuple.Tuple2;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.eclipse.milo.opcua.stack.core.util.ConversionUtil.l;
+
 /**
  * An {@link IdentityProvider} that will choose the first available username+password {@link UserTokenPolicy}.
  */
@@ -60,7 +63,9 @@ public class UsernameProvider implements IdentityProvider {
     public Tuple2<UserIdentityToken, SignatureData> getIdentityToken(EndpointDescription endpoint,
                                                                      ByteString serverNonce) throws Exception {
 
-        UserTokenPolicy tokenPolicy = Arrays.stream(endpoint.getUserIdentityTokens())
+        List<UserTokenPolicy> userIdentityTokens = l(endpoint.getUserIdentityTokens());
+
+        UserTokenPolicy tokenPolicy = userIdentityTokens.stream()
             .filter(t -> t.getTokenType() == UserTokenType.UserName)
             .findFirst().orElseThrow(() -> new Exception("no username token policy found"));
 

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/api/identity/X509IdentityProvider.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/api/identity/X509IdentityProvider.java
@@ -16,7 +16,7 @@ package org.eclipse.milo.opcua.sdk.client.api.identity;
 import java.nio.ByteBuffer;
 import java.security.PrivateKey;
 import java.security.cert.X509Certificate;
-import java.util.Arrays;
+import java.util.List;
 
 import org.eclipse.milo.opcua.stack.core.security.SecurityPolicy;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
@@ -30,6 +30,8 @@ import org.eclipse.milo.opcua.stack.core.util.SignatureUtil;
 import org.jooq.lambda.tuple.Tuple2;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.eclipse.milo.opcua.stack.core.util.ConversionUtil.l;
 
 public class X509IdentityProvider implements IdentityProvider {
 
@@ -47,7 +49,9 @@ public class X509IdentityProvider implements IdentityProvider {
     public Tuple2<UserIdentityToken, SignatureData> getIdentityToken(EndpointDescription endpoint,
                                                                      ByteString serverNonce) throws Exception {
 
-        UserTokenPolicy tokenPolicy = Arrays.stream(endpoint.getUserIdentityTokens())
+        List<UserTokenPolicy> userIdentityTokens = l(endpoint.getUserIdentityTokens());
+
+        UserTokenPolicy tokenPolicy = userIdentityTokens.stream()
             .filter(t -> t.getTokenType() == UserTokenType.Certificate)
             .findFirst().orElseThrow(() -> new Exception("no x509 certificate token policy found"));
 

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/api/services/AttributeServices.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/api/services/AttributeServices.java
@@ -37,8 +37,8 @@ import org.eclipse.milo.opcua.stack.core.types.structured.ReadValueId;
 import org.eclipse.milo.opcua.stack.core.types.structured.WriteResponse;
 import org.eclipse.milo.opcua.stack.core.types.structured.WriteValue;
 
-import static com.google.common.collect.Lists.newArrayList;
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.eclipse.milo.opcua.stack.core.util.ConversionUtil.l;
 
 public interface AttributeServices {
 
@@ -85,7 +85,7 @@ public interface AttributeServices {
                 (nId, aId) -> new ReadValueId(nId, aId, null, QualifiedName.NULL_VALUE));
 
             return read(maxAge, timestampsToReturn, stream.collect(Collectors.toList()))
-                .thenApply(r -> newArrayList(r.getResults()));
+                .thenApply(r -> l(r.getResults()));
         }
     }
 
@@ -129,7 +129,7 @@ public interface AttributeServices {
             .collect(Collectors.toList());
 
         return read(maxAge, timestampsToReturn, readValueIds)
-            .thenApply(r -> newArrayList(r.getResults()));
+            .thenApply(r -> l(r.getResults()));
     }
 
     /**
@@ -158,7 +158,7 @@ public interface AttributeServices {
                 (nodeId, value) -> new WriteValue(nodeId, uint(13), null, value));
 
             return write(stream.collect(Collectors.toList()))
-                .thenApply(response -> newArrayList(response.getResults()));
+                .thenApply(response -> l(response.getResults()));
         }
     }
     
@@ -171,7 +171,7 @@ public interface AttributeServices {
      */
     default CompletableFuture<StatusCode> writeValue(NodeId nodeId, DataValue value) {
         return write(Collections.singletonList(new WriteValue(nodeId, uint(13), null, value)))
-            .thenApply(response -> response.getResults()[0]);
+            .thenApply(response -> l(response.getResults()).get(0));
     }
 
     /**

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/api/services/MethodServices.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/api/services/MethodServices.java
@@ -21,6 +21,7 @@ import org.eclipse.milo.opcua.stack.core.types.structured.CallMethodResult;
 import org.eclipse.milo.opcua.stack.core.types.structured.CallResponse;
 
 import static com.google.common.collect.Lists.newArrayList;
+import static org.eclipse.milo.opcua.stack.core.util.ConversionUtil.l;
 
 public interface MethodServices {
 
@@ -43,7 +44,7 @@ public interface MethodServices {
      */
     default CompletableFuture<CallMethodResult> call(CallMethodRequest request) {
         return call(newArrayList(request))
-            .thenApply(response -> response.getResults()[0]);
+            .thenApply(response -> l(response.getResults()).get(0));
     }
 
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/api/services/ViewServices.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/api/services/ViewServices.java
@@ -33,6 +33,7 @@ import org.eclipse.milo.opcua.stack.core.types.structured.ViewDescription;
 
 import static com.google.common.collect.Lists.newArrayList;
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.eclipse.milo.opcua.stack.core.util.ConversionUtil.l;
 
 public interface ViewServices {
 
@@ -71,7 +72,7 @@ public interface ViewServices {
      */
     default CompletableFuture<List<BrowseResult>> browse(List<BrowseDescription> nodesToBrowse) {
         return browse(new ViewDescription(NodeId.NULL_VALUE, DateTime.MIN_VALUE, uint(0)), uint(0), nodesToBrowse)
-            .thenApply(r -> newArrayList(r.getResults()));
+            .thenApply(r -> l(r.getResults()));
     }
 
     /**

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/nodes/DefaultAddressSpace.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/nodes/DefaultAddressSpace.java
@@ -45,6 +45,7 @@ import org.eclipse.milo.opcua.stack.core.types.structured.ReadResponse;
 import org.eclipse.milo.opcua.stack.core.types.structured.ReadValueId;
 
 import static com.google.common.collect.Lists.newArrayList;
+import static org.eclipse.milo.opcua.stack.core.util.ConversionUtil.l;
 
 public class DefaultAddressSpace implements AddressSpace {
 
@@ -63,7 +64,7 @@ public class DefaultAddressSpace implements AddressSpace {
             client.read(0.0, TimestampsToReturn.Neither, newArrayList(readValueId));
 
         return future.thenCompose(response -> {
-            DataValue value = response.getResults()[0];
+            DataValue value = l(response.getResults()).get(0);
             NodeClass nodeClass = (NodeClass) value.getValue().getValue();
 
             if (nodeClass != null) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/nodes/attached/AttachedNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/nodes/attached/AttachedNode.java
@@ -30,6 +30,7 @@ import org.eclipse.milo.opcua.stack.core.types.structured.ReadValueId;
 import org.eclipse.milo.opcua.stack.core.types.structured.WriteValue;
 
 import static com.google.common.collect.Lists.newArrayList;
+import static org.eclipse.milo.opcua.stack.core.util.ConversionUtil.l;
 
 public class AttachedNode implements UaNode {
 
@@ -93,7 +94,7 @@ public class AttachedNode implements UaNode {
                 client.read(0.0, TimestampsToReturn.Neither, newArrayList(readValueId));
 
             return future.thenApply(response -> {
-                DataValue value = response.getResults()[0];
+                DataValue value = l(response.getResults()).get(0);
 
                 if (attributeId != AttributeId.Value) {
                     nodeCache.putAttribute(nodeId, attributeId, value);
@@ -144,7 +145,7 @@ public class AttachedNode implements UaNode {
             nodeId, attributeId.uid(), null, value);
 
         return client.write(newArrayList(writeValue)).thenApply(response -> {
-            StatusCode statusCode = response.getResults()[0];
+            StatusCode statusCode = l(response.getResults()).get(0);
 
             if (statusCode.isGood()) {
                 nodeCache.invalidate(nodeId, attributeId);

--- a/opc-ua-sdk/sdk-core/src/main/java/org/eclipse/milo/opcua/sdk/core/NumericRange.java
+++ b/opc-ua-sdk/sdk-core/src/main/java/org/eclipse/milo/opcua/sdk/core/NumericRange.java
@@ -141,7 +141,7 @@ public final class NumericRange {
                 return s.substring(low, high + 1);
             } else if (array instanceof ByteString) {
                 ByteString bs = (ByteString) array;
-                byte[] copy = Arrays.copyOfRange(bs.bytes(), low, high + 1);
+                byte[] copy = Arrays.copyOfRange(bs.bytesOrEmpty(), low, high + 1);
                 return new ByteString(copy);
             } else {
                 throw new UaException(StatusCodes.Bad_IndexRangeNoData);

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/DiagnosticsContext.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/DiagnosticsContext.java
@@ -13,7 +13,9 @@
 
 package org.eclipse.milo.opcua.sdk.server;
 
+import java.util.Arrays;
 import java.util.EnumSet;
+import java.util.List;
 import java.util.Map;
 
 import com.google.common.collect.Maps;
@@ -36,14 +38,18 @@ public class DiagnosticsContext<T> {
     }
 
     public DiagnosticInfo[] getDiagnosticInfos(T[] ts) {
+        return getDiagnosticInfos(Arrays.asList(ts));
+    }
+
+    public DiagnosticInfo[] getDiagnosticInfos(List<T> ts) {
         if (diagnosticsMap.isEmpty()) {
             return new DiagnosticInfo[0];
         } else {
-            DiagnosticInfo[] diagnostics = new DiagnosticInfo[ts.length];
+            DiagnosticInfo[] diagnostics = new DiagnosticInfo[ts.size()];
 
-            for (int i = 0; i < ts.length; i++) {
+            for (int i = 0; i < ts.size(); i++) {
                 DiagnosticInfo diagnosticInfo = diagnosticsMap.getOrDefault(
-                    ts[i], DiagnosticInfo.NULL_VALUE);
+                    ts.get(i), DiagnosticInfo.NULL_VALUE);
 
                 diagnostics[i] = diagnosticInfo;
             }

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/SessionManager.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/SessionManager.java
@@ -129,6 +129,7 @@ import org.slf4j.LoggerFactory;
 
 import static com.google.common.collect.Lists.newCopyOnWriteArrayList;
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.eclipse.milo.opcua.stack.core.util.ConversionUtil.l;
 
 public class SessionManager implements
     AttributeServiceSet,
@@ -364,7 +365,7 @@ public class SessionManager implements
         ServerSecureChannel secureChannel = serviceRequest.getSecureChannel();
         long secureChannelId = secureChannel.getChannelId();
         NodeId authToken = request.getRequestHeader().getAuthenticationToken();
-        SignedSoftwareCertificate[] clientSoftwareCertificates = request.getClientSoftwareCertificates();
+        List<SignedSoftwareCertificate> clientSoftwareCertificates = l(request.getClientSoftwareCertificates());
 
         Session session = createdSessions.get(authToken);
 
@@ -387,7 +388,7 @@ public class SessionManager implements
                     );
                     session.setIdentityObject(identityObject);
 
-                    StatusCode[] results = new StatusCode[clientSoftwareCertificates.length];
+                    StatusCode[] results = new StatusCode[clientSoftwareCertificates.size()];
                     Arrays.fill(results, StatusCode.GOOD);
 
                     ByteString serverNonce = NonceUtil.generateNonce(32);
@@ -428,7 +429,7 @@ public class SessionManager implements
                         logger.debug("Session id={} is now associated with secureChannelId={}",
                             session.getSessionId(), secureChannelId);
 
-                        StatusCode[] results = new StatusCode[clientSoftwareCertificates.length];
+                        StatusCode[] results = new StatusCode[clientSoftwareCertificates.size()];
                         Arrays.fill(results, StatusCode.GOOD);
 
                         ByteString serverNonce = NonceUtil.generateNonce(32);
@@ -471,8 +472,7 @@ public class SessionManager implements
 
             session.setClientCertificateBytes(secureChannel.getRemoteCertificateBytes());
 
-            int length = clientSoftwareCertificates != null ? clientSoftwareCertificates.length : 0;
-            StatusCode[] results = new StatusCode[length];
+            StatusCode[] results = new StatusCode[clientSoftwareCertificates.size()];
             Arrays.fill(results, StatusCode.GOOD);
 
             ByteString serverNonce = NonceUtil.generateNonce(32);

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/services/AttributeServices.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/services/AttributeServices.java
@@ -45,6 +45,7 @@ import static com.google.common.collect.Lists.newArrayListWithCapacity;
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.toList;
 import static org.eclipse.milo.opcua.stack.core.util.ConversionUtil.a;
+import static org.eclipse.milo.opcua.stack.core.util.ConversionUtil.l;
 
 public class AttributeServices implements AttributeServiceSet {
 
@@ -62,12 +63,14 @@ public class AttributeServices implements AttributeServiceSet {
         OpcUaServer server = service.attr(ServiceAttributes.SERVER_KEY).get();
         Session session = service.attr(ServiceAttributes.SESSION_KEY).get();
 
-        if (request.getNodesToRead().length == 0) {
+        List<ReadValueId> nodesToRead = l(request.getNodesToRead());
+
+        if (nodesToRead.isEmpty()) {
             service.setServiceFault(StatusCodes.Bad_NothingToDo);
             return;
         }
 
-        if (request.getNodesToRead().length > server.getConfig().getLimits().getMaxNodesPerRead().longValue()) {
+        if (nodesToRead.size() > server.getConfig().getLimits().getMaxNodesPerRead().longValue()) {
             service.setServiceFault(StatusCodes.Bad_TooManyOperations);
             return;
         }
@@ -82,9 +85,9 @@ public class AttributeServices implements AttributeServiceSet {
             return;
         }
 
-        ReadValueId[] nodesToRead = request.getNodesToRead();
-        List<PendingRead> pendingReads = newArrayListWithCapacity(nodesToRead.length);
-        List<CompletableFuture<DataValue>> futures = newArrayListWithCapacity(nodesToRead.length);
+
+        List<PendingRead> pendingReads = newArrayListWithCapacity(nodesToRead.size());
+        List<CompletableFuture<DataValue>> futures = newArrayListWithCapacity(nodesToRead.size());
 
         for (ReadValueId id : nodesToRead) {
             PendingRead pending = new PendingRead(id);
@@ -153,19 +156,20 @@ public class AttributeServices implements AttributeServiceSet {
         OpcUaServer server = service.attr(ServiceAttributes.SERVER_KEY).get();
         Session session = service.attr(ServiceAttributes.SESSION_KEY).get();
 
-        if (request.getNodesToWrite().length == 0) {
+        List<WriteValue> nodesToWrite = l(request.getNodesToWrite());
+
+        if (nodesToWrite.isEmpty()) {
             service.setServiceFault(StatusCodes.Bad_NothingToDo);
             return;
         }
 
-        if (request.getNodesToWrite().length > server.getConfig().getLimits().getMaxNodesPerWrite().intValue()) {
+        if (nodesToWrite.size() > server.getConfig().getLimits().getMaxNodesPerWrite().intValue()) {
             service.setServiceFault(StatusCodes.Bad_TooManyOperations);
             return;
         }
 
-        WriteValue[] nodesToWrite = request.getNodesToWrite();
-        List<PendingWrite> pendingWrites = newArrayListWithCapacity(nodesToWrite.length);
-        List<CompletableFuture<StatusCode>> futures = newArrayListWithCapacity(nodesToWrite.length);
+        List<PendingWrite> pendingWrites = newArrayListWithCapacity(nodesToWrite.size());
+        List<CompletableFuture<StatusCode>> futures = newArrayListWithCapacity(nodesToWrite.size());
 
         for (WriteValue value : nodesToWrite) {
             PendingWrite pending = new PendingWrite(value);

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/services/MethodServices.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/services/MethodServices.java
@@ -37,6 +37,7 @@ import org.eclipse.milo.opcua.stack.core.types.structured.ResponseHeader;
 import org.eclipse.milo.opcua.stack.core.util.FutureUtils;
 
 import static org.eclipse.milo.opcua.stack.core.util.ConversionUtil.a;
+import static org.eclipse.milo.opcua.stack.core.util.ConversionUtil.l;
 
 public class MethodServices implements MethodServiceSet {
 
@@ -53,7 +54,8 @@ public class MethodServices implements MethodServiceSet {
 
         CallRequest request = service.getRequest();
 
-        List<PendingCall> pendingCalls = Arrays.stream(request.getMethodsToCall())
+        List<PendingCall> pendingCalls = l(request.getMethodsToCall())
+            .stream()
             .map(PendingCall::new)
             .collect(Collectors.toList());
 

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/services/SubscriptionServices.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/services/SubscriptionServices.java
@@ -45,6 +45,7 @@ import org.eclipse.milo.opcua.stack.core.types.structured.TransferSubscriptionsR
 import org.eclipse.milo.opcua.stack.core.types.structured.TransferSubscriptionsResponse;
 
 import static org.eclipse.milo.opcua.stack.core.util.ConversionUtil.a;
+import static org.eclipse.milo.opcua.stack.core.util.ConversionUtil.l;
 
 public class SubscriptionServices implements SubscriptionServiceSet {
 
@@ -92,9 +93,9 @@ public class SubscriptionServices implements SubscriptionServiceSet {
         Session session = service.attr(ServiceAttributes.SESSION_KEY).get();
 
         TransferSubscriptionsRequest request = service.getRequest();
-        UInteger[] subscriptionIds = request.getSubscriptionIds();
+        List<UInteger> subscriptionIds = l(request.getSubscriptionIds());
 
-        if (subscriptionIds.length == 0) {
+        if (subscriptionIds.isEmpty()) {
             service.setServiceFault(StatusCodes.Bad_NothingToDo);
             return;
         }

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/services/ViewServices.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/services/ViewServices.java
@@ -53,6 +53,7 @@ import static com.google.common.collect.Lists.newArrayListWithCapacity;
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.toList;
 import static org.eclipse.milo.opcua.stack.core.util.ConversionUtil.a;
+import static org.eclipse.milo.opcua.stack.core.util.ConversionUtil.l;
 
 public class ViewServices implements ViewServiceSet {
 
@@ -73,14 +74,15 @@ public class ViewServices implements ViewServiceSet {
         OpcUaServer server = service.attr(ServiceAttributes.SERVER_KEY).get();
         Session session = service.attr(ServiceAttributes.SESSION_KEY).get();
 
-        if (request.getNodesToBrowse().length > server.getConfig().getLimits().getMaxNodesPerBrowse().intValue()) {
+        List<BrowseDescription> nodesToBrowse = l(request.getNodesToBrowse());
+
+        if (nodesToBrowse.size() > server.getConfig().getLimits().getMaxNodesPerBrowse().intValue()) {
             service.setServiceFault(StatusCodes.Bad_TooManyOperations);
             return;
         }
 
-        BrowseDescription[] nodesToBrowse = request.getNodesToBrowse();
-        List<PendingBrowse> pendingBrowses = newArrayListWithCapacity(nodesToBrowse.length);
-        List<CompletableFuture<BrowseResult>> futures = newArrayListWithCapacity(nodesToBrowse.length);
+        List<PendingBrowse> pendingBrowses = newArrayListWithCapacity(nodesToBrowse.size());
+        List<CompletableFuture<BrowseResult>> futures = newArrayListWithCapacity(nodesToBrowse.size());
 
         for (BrowseDescription browseDescription : nodesToBrowse) {
             PendingBrowse pending = new PendingBrowse(browseDescription);
@@ -161,19 +163,19 @@ public class ViewServices implements ViewServiceSet {
 
         RegisterNodesRequest request = service.getRequest();
 
-        NodeId[] nodeIds = request.getNodesToRegister();
+        List<NodeId> nodeIds = l(request.getNodesToRegister());
 
-        if (nodeIds.length == 0) {
+        if (nodeIds.isEmpty()) {
             throw new UaException(StatusCodes.Bad_NothingToDo);
         }
 
-        if (nodeIds.length > server.getConfig().getLimits().getMaxNodesPerRegisterNodes().intValue()) {
+        if (nodeIds.size() > server.getConfig().getLimits().getMaxNodesPerRegisterNodes().intValue()) {
             throw new UaException(StatusCodes.Bad_TooManyOperations);
         }
 
         service.setResponse(new RegisterNodesResponse(
             service.createResponseHeader(StatusCode.GOOD),
-            nodeIds
+            a(nodeIds, NodeId.class)
         ));
     }
 
@@ -185,13 +187,13 @@ public class ViewServices implements ViewServiceSet {
 
         UnregisterNodesRequest request = service.getRequest();
 
-        NodeId[] nodeIds = request.getNodesToUnregister();
+        List<NodeId> nodeIds = l(request.getNodesToUnregister());
 
-        if (nodeIds.length == 0) {
+        if (nodeIds.isEmpty()) {
             throw new UaException(StatusCodes.Bad_NothingToDo);
         }
 
-        if (nodeIds.length > server.getConfig().getLimits().getMaxNodesPerRegisterNodes().intValue()) {
+        if (nodeIds.size() > server.getConfig().getLimits().getMaxNodesPerRegisterNodes().intValue()) {
             throw new UaException(StatusCodes.Bad_TooManyOperations);
         }
 

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/services/helpers/BrowseHelper.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/services/helpers/BrowseHelper.java
@@ -58,6 +58,7 @@ import org.jooq.lambda.tuple.Tuple3;
 import static java.util.stream.Collectors.toList;
 import static org.eclipse.milo.opcua.sdk.server.util.UaEnumUtil.browseResultMasks;
 import static org.eclipse.milo.opcua.sdk.server.util.UaEnumUtil.nodeClasses;
+import static org.eclipse.milo.opcua.stack.core.util.ConversionUtil.l;
 
 public class BrowseHelper {
 
@@ -76,7 +77,9 @@ public class BrowseHelper {
 
         BrowseNextRequest request = service.getRequest();
 
-        if (request.getContinuationPoints().length >
+        List<ByteString> continuationPoints = l(request.getContinuationPoints());
+
+        if (continuationPoints.size() >
             server.getConfig().getLimits().getMaxBrowseContinuationPoints().intValue()) {
 
             service.setServiceFault(StatusCodes.Bad_TooManyOperations);

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/services/helpers/BrowsePathsHelper.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/services/helpers/BrowsePathsHelper.java
@@ -51,6 +51,7 @@ import static java.util.concurrent.CompletableFuture.completedFuture;
 import static java.util.stream.Collectors.toList;
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
 import static org.eclipse.milo.opcua.stack.core.util.ConversionUtil.a;
+import static org.eclipse.milo.opcua.stack.core.util.ConversionUtil.l;
 import static org.eclipse.milo.opcua.stack.core.util.FutureUtils.sequence;
 
 public class BrowsePathsHelper {
@@ -68,14 +69,14 @@ public class BrowsePathsHelper {
 
         OpcUaServer server = service.attr(ServiceAttributes.SERVER_KEY).get();
 
-        BrowsePath[] browsePaths = service.getRequest().getBrowsePaths();
+        List<BrowsePath> browsePaths = l(service.getRequest().getBrowsePaths());
 
-        if (browsePaths.length >
+        if (browsePaths.size() >
             server.getConfig().getLimits().getMaxNodesPerTranslateBrowsePathsToNodeIds().intValue()) {
 
             service.setServiceFault(StatusCodes.Bad_TooManyOperations);
         } else {
-            List<CompletableFuture<BrowsePathResult>> futures = newArrayListWithCapacity(browsePaths.length);
+            List<CompletableFuture<BrowsePathResult>> futures = newArrayListWithCapacity(browsePaths.size());
 
             for (BrowsePath browsePath : browsePaths) {
                 futures.add(translate(browsePath));
@@ -97,7 +98,7 @@ public class BrowsePathsHelper {
         NodeId startingNode = browsePath.getStartingNode();
         RelativePath relativePath = browsePath.getRelativePath();
 
-        follow(startingNode, newArrayList(relativePath.getElements())).whenComplete((targets, ex) -> {
+        follow(startingNode, l(relativePath.getElements())).whenComplete((targets, ex) -> {
             if (targets != null) {
                 BrowsePathResult result;
 

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/util/AnnotationBasedInvocationHandler.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/util/AnnotationBasedInvocationHandler.java
@@ -46,6 +46,7 @@ import org.eclipse.milo.opcua.stack.core.types.structured.CallMethodResult;
 import org.eclipse.milo.opcua.stack.core.util.TypeUtil;
 
 import static org.eclipse.milo.opcua.stack.core.util.ConversionUtil.a;
+import static org.eclipse.milo.opcua.stack.core.util.ConversionUtil.l;
 
 public class AnnotationBasedInvocationHandler implements MethodInvocationHandler {
 
@@ -93,22 +94,22 @@ public class AnnotationBasedInvocationHandler implements MethodInvocationHandler
     public void invoke(CallMethodRequest request, CompletableFuture<CallMethodResult> future) {
         NodeId objectId = request.getObjectId();
 
-        Variant[] inputVariants = request.getInputArguments();
+        List<Variant> inputVariants = l(request.getInputArguments());
 
-        if (inputVariants.length != inputArguments.size()) {
+        if (inputVariants.size() != inputArguments.size()) {
             future.complete(new CallMethodResult(
                 new StatusCode(StatusCodes.Bad_ArgumentsMissing),
                 new StatusCode[0], new DiagnosticInfo[0], new Variant[0]
             ));
         }
 
-        Object[] inputs = new Object[inputVariants.length];
-        StatusCode[] inputArgumentResults = new StatusCode[inputVariants.length];
+        Object[] inputs = new Object[inputVariants.size()];
+        StatusCode[] inputArgumentResults = new StatusCode[inputVariants.size()];
 
-        for (int i = 0; i < inputVariants.length; i++) {
+        for (int i = 0; i < inputVariants.size(); i++) {
             Argument argument = inputArguments.get(i);
 
-            Variant variant = inputVariants[i];
+            Variant variant = inputVariants.get(i);
 
             boolean dataTypeMatch = variant.getDataType()
                 .map(type -> type.equals(argument.getDataType()))

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/util/ContentFilterUtil.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/util/ContentFilterUtil.java
@@ -14,6 +14,7 @@
 package org.eclipse.milo.opcua.sdk.server.util;
 
 import java.util.Arrays;
+import java.util.List;
 
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.UaException;
@@ -25,6 +26,8 @@ import org.eclipse.milo.opcua.stack.core.types.structured.ContentFilterElement;
 import org.eclipse.milo.opcua.stack.core.types.structured.FilterOperand;
 import org.eclipse.milo.opcua.stack.core.types.structured.SimpleAttributeOperand;
 
+import static org.eclipse.milo.opcua.stack.core.util.ConversionUtil.l;
+
 public class ContentFilterUtil {
 
     /*
@@ -34,10 +37,10 @@ public class ContentFilterUtil {
      */
 
     public void apply(ContentFilter filter) throws UaException {
-        ContentFilterElement[] elements = filter.getElements();
+        List<ContentFilterElement> elements = l(filter.getElements());
 
-        for (int i = 0; i < elements.length; i++) {
-            ContentFilterElement element = elements[i];
+        for (int i = 0; i < elements.size(); i++) {
+            ContentFilterElement element = elements.get(i);
 
             FilterOperator operator = element.getFilterOperator();
             SimpleAttributeOperand[] operands = extract(element.getFilterOperands());

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/Stack.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/Stack.java
@@ -20,6 +20,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
+import javax.annotation.Nonnull;
 
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.util.HashedWheelTimer;
@@ -53,7 +54,7 @@ public final class Stack {
                 private final AtomicLong threadNumber = new AtomicLong(0L);
 
                 @Override
-                public Thread newThread(Runnable r) {
+                public Thread newThread(@Nonnull Runnable r) {
                     Thread thread = new Thread(r, "ua-netty-event-loop-" + threadNumber.getAndIncrement());
                     thread.setDaemon(true);
                     return thread;
@@ -75,7 +76,7 @@ public final class Stack {
                 private final AtomicLong threadNumber = new AtomicLong(0L);
 
                 @Override
-                public Thread newThread(Runnable r) {
+                public Thread newThread(@Nonnull Runnable r) {
                     Thread thread = new Thread(r, "ua-shared-pool-" + threadNumber.getAndIncrement());
                     thread.setDaemon(true);
                     return thread;
@@ -97,7 +98,7 @@ public final class Stack {
                 private final AtomicLong threadNumber = new AtomicLong(0L);
 
                 @Override
-                public Thread newThread(Runnable r) {
+                public Thread newThread(@Nonnull Runnable r) {
                     Thread thread = new Thread(r, "ua-shared-scheduled-executor-" + threadNumber.getAndIncrement());
                     thread.setDaemon(true);
                     return thread;

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/serialization/xml/XmlEncoder.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/serialization/xml/XmlEncoder.java
@@ -355,7 +355,8 @@ public class XmlEncoder implements UaEncoder {
 
     @Override
     public <T extends UaEnumeration> void encodeEnumeration(String field, T value) throws UaSerializationException {
-        writeValue(field, value == null ? null : value.toString() + "_" + value.getValue());
+        String s = value == null ? null : value.toString() + "_" + value.getValue();
+        writeValue(field, s != null ? s : "");
     }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/builtin/unsigned/UByte.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/builtin/unsigned/UByte.java
@@ -17,6 +17,7 @@ package org.eclipse.milo.opcua.stack.core.types.builtin.unsigned;
 
 import java.io.ObjectStreamException;
 import java.math.BigInteger;
+import javax.annotation.Nonnull;
 
 /**
  * The <code>unsigned byte</code> type
@@ -279,7 +280,7 @@ public final class UByte extends UNumber implements Comparable<UByte> {
     }
 
     @Override
-    public int compareTo(UByte o) {
+    public int compareTo(@Nonnull UByte o) {
         return (value < o.value ? -1 : (value == o.value ? 0 : 1));
     }
 

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/builtin/unsigned/UInteger.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/builtin/unsigned/UInteger.java
@@ -16,6 +16,7 @@
 package org.eclipse.milo.opcua.stack.core.types.builtin.unsigned;
 
 import java.io.ObjectStreamException;
+import javax.annotation.Nonnull;
 
 /**
  * The <code>unsigned int</code> type
@@ -306,7 +307,7 @@ public final class UInteger extends UNumber implements Comparable<UInteger> {
     }
 
     @Override
-    public int compareTo(UInteger o) {
+    public int compareTo(@Nonnull UInteger o) {
         return (value < o.value ? -1 : (value == o.value ? 0 : 1));
     }
 

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/builtin/unsigned/ULong.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/builtin/unsigned/ULong.java
@@ -16,6 +16,7 @@
 package org.eclipse.milo.opcua.stack.core.types.builtin.unsigned;
 
 import java.math.BigInteger;
+import javax.annotation.Nonnull;
 
 /**
  * The <code>unsigned long</code> type
@@ -216,7 +217,7 @@ public final class ULong extends UNumber implements Comparable<ULong> {
     }
 
     @Override
-    public int compareTo(ULong o) {
+    public int compareTo(@Nonnull ULong o) {
         return compare(value, o.value);
     }
 

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/builtin/unsigned/UShort.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/builtin/unsigned/UShort.java
@@ -15,6 +15,8 @@
  */
 package org.eclipse.milo.opcua.stack.core.types.builtin.unsigned;
 
+import javax.annotation.Nonnull;
+
 /**
  * The <code>unsigned short</code> type
  *
@@ -163,7 +165,7 @@ public final class UShort extends UNumber implements Comparable<UShort> {
     }
 
     @Override
-    public int compareTo(UShort o) {
+    public int compareTo(@Nonnull UShort o) {
         return (value < o.value ? -1 : (value == o.value ? 0 : 1));
     }
 

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/ActivateSessionRequest.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/ActivateSessionRequest.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -58,8 +60,10 @@ public class ActivateSessionRequest implements UaRequestMessage {
 
     public SignatureData getClientSignature() { return _clientSignature; }
 
+    @Nullable
     public SignedSoftwareCertificate[] getClientSoftwareCertificates() { return _clientSoftwareCertificates; }
 
+    @Nullable
     public String[] getLocaleIds() { return _localeIds; }
 
     public ExtensionObject getUserIdentityToken() { return _userIdentityToken; }

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/ActivateSessionResponse.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/ActivateSessionResponse.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -54,8 +56,10 @@ public class ActivateSessionResponse implements UaResponseMessage {
 
     public ByteString getServerNonce() { return _serverNonce; }
 
+    @Nullable
     public StatusCode[] getResults() { return _results; }
 
+    @Nullable
     public DiagnosticInfo[] getDiagnosticInfos() { return _diagnosticInfos; }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/AddNodesRequest.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/AddNodesRequest.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -43,6 +45,7 @@ public class AddNodesRequest implements UaRequestMessage {
 
     public RequestHeader getRequestHeader() { return _requestHeader; }
 
+    @Nullable
     public AddNodesItem[] getNodesToAdd() { return _nodesToAdd; }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/AddNodesResponse.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/AddNodesResponse.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -47,8 +49,10 @@ public class AddNodesResponse implements UaResponseMessage {
 
     public ResponseHeader getResponseHeader() { return _responseHeader; }
 
+    @Nullable
     public AddNodesResult[] getResults() { return _results; }
 
+    @Nullable
     public DiagnosticInfo[] getDiagnosticInfos() { return _diagnosticInfos; }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/AddReferencesRequest.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/AddReferencesRequest.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -43,6 +45,7 @@ public class AddReferencesRequest implements UaRequestMessage {
 
     public RequestHeader getRequestHeader() { return _requestHeader; }
 
+    @Nullable
     public AddReferencesItem[] getReferencesToAdd() { return _referencesToAdd; }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/AddReferencesResponse.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/AddReferencesResponse.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -48,8 +50,10 @@ public class AddReferencesResponse implements UaResponseMessage {
 
     public ResponseHeader getResponseHeader() { return _responseHeader; }
 
+    @Nullable
     public StatusCode[] getResults() { return _results; }
 
+    @Nullable
     public DiagnosticInfo[] getDiagnosticInfos() { return _diagnosticInfos; }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/ApplicationDescription.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/ApplicationDescription.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -70,6 +72,7 @@ public class ApplicationDescription implements UaStructure {
 
     public String getDiscoveryProfileUri() { return _discoveryProfileUri; }
 
+    @Nullable
     public String[] getDiscoveryUrls() { return _discoveryUrls; }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/Argument.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/Argument.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -58,6 +60,7 @@ public class Argument implements UaStructure {
 
     public Integer getValueRank() { return _valueRank; }
 
+    @Nullable
     public UInteger[] getArrayDimensions() { return _arrayDimensions; }
 
     public LocalizedText getDescription() { return _description; }

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/AxisInformation.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/AxisInformation.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -60,6 +62,7 @@ public class AxisInformation implements UaStructure {
 
     public AxisScaleEnumeration getAxisScaleType() { return _axisScaleType; }
 
+    @Nullable
     public Double[] getAxisSteps() { return _axisSteps; }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/BrowseNextRequest.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/BrowseNextRequest.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -49,6 +51,7 @@ public class BrowseNextRequest implements UaRequestMessage {
 
     public Boolean getReleaseContinuationPoints() { return _releaseContinuationPoints; }
 
+    @Nullable
     public ByteString[] getContinuationPoints() { return _continuationPoints; }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/BrowseNextResponse.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/BrowseNextResponse.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -47,8 +49,10 @@ public class BrowseNextResponse implements UaResponseMessage {
 
     public ResponseHeader getResponseHeader() { return _responseHeader; }
 
+    @Nullable
     public BrowseResult[] getResults() { return _results; }
 
+    @Nullable
     public DiagnosticInfo[] getDiagnosticInfos() { return _diagnosticInfos; }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/BrowsePathResult.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/BrowsePathResult.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -44,6 +46,7 @@ public class BrowsePathResult implements UaStructure {
 
     public StatusCode getStatusCode() { return _statusCode; }
 
+    @Nullable
     public BrowsePathTarget[] getTargets() { return _targets; }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/BrowseRequest.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/BrowseRequest.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -54,6 +56,7 @@ public class BrowseRequest implements UaRequestMessage {
 
     public UInteger getRequestedMaxReferencesPerNode() { return _requestedMaxReferencesPerNode; }
 
+    @Nullable
     public BrowseDescription[] getNodesToBrowse() { return _nodesToBrowse; }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/BrowseResponse.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/BrowseResponse.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -47,8 +49,10 @@ public class BrowseResponse implements UaResponseMessage {
 
     public ResponseHeader getResponseHeader() { return _responseHeader; }
 
+    @Nullable
     public BrowseResult[] getResults() { return _results; }
 
+    @Nullable
     public DiagnosticInfo[] getDiagnosticInfos() { return _diagnosticInfos; }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/BrowseResult.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/BrowseResult.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -50,6 +52,7 @@ public class BrowseResult implements UaStructure {
 
     public ByteString getContinuationPoint() { return _continuationPoint; }
 
+    @Nullable
     public ReferenceDescription[] getReferences() { return _references; }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/CallMethodRequest.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/CallMethodRequest.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -49,6 +51,7 @@ public class CallMethodRequest implements UaStructure {
 
     public NodeId getMethodId() { return _methodId; }
 
+    @Nullable
     public Variant[] getInputArguments() { return _inputArguments; }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/CallMethodResult.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/CallMethodResult.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -52,10 +54,13 @@ public class CallMethodResult implements UaStructure {
 
     public StatusCode getStatusCode() { return _statusCode; }
 
+    @Nullable
     public StatusCode[] getInputArgumentResults() { return _inputArgumentResults; }
 
+    @Nullable
     public DiagnosticInfo[] getInputArgumentDiagnosticInfos() { return _inputArgumentDiagnosticInfos; }
 
+    @Nullable
     public Variant[] getOutputArguments() { return _outputArguments; }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/CallRequest.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/CallRequest.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -43,6 +45,7 @@ public class CallRequest implements UaRequestMessage {
 
     public RequestHeader getRequestHeader() { return _requestHeader; }
 
+    @Nullable
     public CallMethodRequest[] getMethodsToCall() { return _methodsToCall; }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/CallResponse.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/CallResponse.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -47,8 +49,10 @@ public class CallResponse implements UaResponseMessage {
 
     public ResponseHeader getResponseHeader() { return _responseHeader; }
 
+    @Nullable
     public CallMethodResult[] getResults() { return _results; }
 
+    @Nullable
     public DiagnosticInfo[] getDiagnosticInfos() { return _diagnosticInfos; }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/ContentFilter.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/ContentFilter.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -38,6 +40,7 @@ public class ContentFilter implements UaStructure {
         this._elements = _elements;
     }
 
+    @Nullable
     public ContentFilterElement[] getElements() { return _elements; }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/ContentFilterElement.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/ContentFilterElement.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -45,6 +47,7 @@ public class ContentFilterElement implements UaStructure {
 
     public FilterOperator getFilterOperator() { return _filterOperator; }
 
+    @Nullable
     public ExtensionObject[] getFilterOperands() { return _filterOperands; }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/ContentFilterElementResult.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/ContentFilterElementResult.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -48,8 +50,10 @@ public class ContentFilterElementResult implements UaStructure {
 
     public StatusCode getStatusCode() { return _statusCode; }
 
+    @Nullable
     public StatusCode[] getOperandStatusCodes() { return _operandStatusCodes; }
 
+    @Nullable
     public DiagnosticInfo[] getOperandDiagnosticInfos() { return _operandDiagnosticInfos; }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/ContentFilterResult.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/ContentFilterResult.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -42,8 +44,10 @@ public class ContentFilterResult implements UaStructure {
         this._elementDiagnosticInfos = _elementDiagnosticInfos;
     }
 
+    @Nullable
     public ContentFilterElementResult[] getElementResults() { return _elementResults; }
 
+    @Nullable
     public DiagnosticInfo[] getElementDiagnosticInfos() { return _elementDiagnosticInfos; }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/CreateMonitoredItemsRequest.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/CreateMonitoredItemsRequest.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -55,6 +57,7 @@ public class CreateMonitoredItemsRequest implements UaRequestMessage {
 
     public TimestampsToReturn getTimestampsToReturn() { return _timestampsToReturn; }
 
+    @Nullable
     public MonitoredItemCreateRequest[] getItemsToCreate() { return _itemsToCreate; }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/CreateMonitoredItemsResponse.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/CreateMonitoredItemsResponse.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -47,8 +49,10 @@ public class CreateMonitoredItemsResponse implements UaResponseMessage {
 
     public ResponseHeader getResponseHeader() { return _responseHeader; }
 
+    @Nullable
     public MonitoredItemCreateResult[] getResults() { return _results; }
 
+    @Nullable
     public DiagnosticInfo[] getDiagnosticInfos() { return _diagnosticInfos; }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/CreateSessionResponse.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/CreateSessionResponse.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -79,8 +81,10 @@ public class CreateSessionResponse implements UaResponseMessage {
 
     public ByteString getServerCertificate() { return _serverCertificate; }
 
+    @Nullable
     public EndpointDescription[] getServerEndpoints() { return _serverEndpoints; }
 
+    @Nullable
     public SignedSoftwareCertificate[] getServerSoftwareCertificates() { return _serverSoftwareCertificates; }
 
     public SignatureData getServerSignature() { return _serverSignature; }

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/DataChangeNotification.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/DataChangeNotification.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -43,8 +45,10 @@ public class DataChangeNotification extends NotificationData {
         this._diagnosticInfos = _diagnosticInfos;
     }
 
+    @Nullable
     public MonitoredItemNotification[] getMonitoredItems() { return _monitoredItems; }
 
+    @Nullable
     public DiagnosticInfo[] getDiagnosticInfos() { return _diagnosticInfos; }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/DeleteAtTimeDetails.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/DeleteAtTimeDetails.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -40,6 +42,7 @@ public class DeleteAtTimeDetails extends HistoryUpdateDetails {
         this._reqTimes = _reqTimes;
     }
 
+    @Nullable
     public DateTime[] getReqTimes() { return _reqTimes; }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/DeleteEventDetails.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/DeleteEventDetails.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -40,6 +42,7 @@ public class DeleteEventDetails extends HistoryUpdateDetails {
         this._eventIds = _eventIds;
     }
 
+    @Nullable
     public ByteString[] getEventIds() { return _eventIds; }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/DeleteMonitoredItemsRequest.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/DeleteMonitoredItemsRequest.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -49,6 +51,7 @@ public class DeleteMonitoredItemsRequest implements UaRequestMessage {
 
     public UInteger getSubscriptionId() { return _subscriptionId; }
 
+    @Nullable
     public UInteger[] getMonitoredItemIds() { return _monitoredItemIds; }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/DeleteMonitoredItemsResponse.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/DeleteMonitoredItemsResponse.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -48,8 +50,10 @@ public class DeleteMonitoredItemsResponse implements UaResponseMessage {
 
     public ResponseHeader getResponseHeader() { return _responseHeader; }
 
+    @Nullable
     public StatusCode[] getResults() { return _results; }
 
+    @Nullable
     public DiagnosticInfo[] getDiagnosticInfos() { return _diagnosticInfos; }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/DeleteNodesRequest.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/DeleteNodesRequest.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -43,6 +45,7 @@ public class DeleteNodesRequest implements UaRequestMessage {
 
     public RequestHeader getRequestHeader() { return _requestHeader; }
 
+    @Nullable
     public DeleteNodesItem[] getNodesToDelete() { return _nodesToDelete; }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/DeleteNodesResponse.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/DeleteNodesResponse.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -48,8 +50,10 @@ public class DeleteNodesResponse implements UaResponseMessage {
 
     public ResponseHeader getResponseHeader() { return _responseHeader; }
 
+    @Nullable
     public StatusCode[] getResults() { return _results; }
 
+    @Nullable
     public DiagnosticInfo[] getDiagnosticInfos() { return _diagnosticInfos; }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/DeleteReferencesRequest.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/DeleteReferencesRequest.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -43,6 +45,7 @@ public class DeleteReferencesRequest implements UaRequestMessage {
 
     public RequestHeader getRequestHeader() { return _requestHeader; }
 
+    @Nullable
     public DeleteReferencesItem[] getReferencesToDelete() { return _referencesToDelete; }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/DeleteReferencesResponse.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/DeleteReferencesResponse.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -48,8 +50,10 @@ public class DeleteReferencesResponse implements UaResponseMessage {
 
     public ResponseHeader getResponseHeader() { return _responseHeader; }
 
+    @Nullable
     public StatusCode[] getResults() { return _results; }
 
+    @Nullable
     public DiagnosticInfo[] getDiagnosticInfos() { return _diagnosticInfos; }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/DeleteSubscriptionsRequest.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/DeleteSubscriptionsRequest.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -44,6 +46,7 @@ public class DeleteSubscriptionsRequest implements UaRequestMessage {
 
     public RequestHeader getRequestHeader() { return _requestHeader; }
 
+    @Nullable
     public UInteger[] getSubscriptionIds() { return _subscriptionIds; }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/DeleteSubscriptionsResponse.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/DeleteSubscriptionsResponse.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -48,8 +50,10 @@ public class DeleteSubscriptionsResponse implements UaResponseMessage {
 
     public ResponseHeader getResponseHeader() { return _responseHeader; }
 
+    @Nullable
     public StatusCode[] getResults() { return _results; }
 
+    @Nullable
     public DiagnosticInfo[] getDiagnosticInfos() { return _diagnosticInfos; }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/DiscoveryConfiguration.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/DiscoveryConfiguration.java
@@ -32,7 +32,6 @@ public class DiscoveryConfiguration implements UaStructure {
     public DiscoveryConfiguration() {
     }
 
-
     @Override
     public NodeId getTypeId() { return TypeId; }
 

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/EndpointDescription.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/EndpointDescription.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -72,6 +74,7 @@ public class EndpointDescription implements UaStructure {
 
     public String getSecurityPolicyUri() { return _securityPolicyUri; }
 
+    @Nullable
     public UserTokenPolicy[] getUserIdentityTokens() { return _userIdentityTokens; }
 
     public String getTransportProfileUri() { return _transportProfileUri; }

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/EndpointUrlListDataType.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/EndpointUrlListDataType.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -38,6 +40,7 @@ public class EndpointUrlListDataType implements UaStructure {
         this._endpointUrlList = _endpointUrlList;
     }
 
+    @Nullable
     public String[] getEndpointUrlList() { return _endpointUrlList; }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/EventFieldList.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/EventFieldList.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -45,6 +47,7 @@ public class EventFieldList implements UaStructure {
 
     public UInteger getClientHandle() { return _clientHandle; }
 
+    @Nullable
     public Variant[] getEventFields() { return _eventFields; }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/EventFilter.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/EventFilter.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -42,6 +44,7 @@ public class EventFilter extends MonitoringFilter {
         this._whereClause = _whereClause;
     }
 
+    @Nullable
     public SimpleAttributeOperand[] getSelectClauses() { return _selectClauses; }
 
     public ContentFilter getWhereClause() { return _whereClause; }

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/EventFilterResult.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/EventFilterResult.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -47,8 +49,10 @@ public class EventFilterResult extends MonitoringFilterResult {
         this._whereClauseResult = _whereClauseResult;
     }
 
+    @Nullable
     public StatusCode[] getSelectClauseResults() { return _selectClauseResults; }
 
+    @Nullable
     public DiagnosticInfo[] getSelectClauseDiagnosticInfos() { return _selectClauseDiagnosticInfos; }
 
     public ContentFilterResult getWhereClauseResult() { return _whereClauseResult; }

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/EventNotificationList.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/EventNotificationList.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -39,6 +41,7 @@ public class EventNotificationList extends NotificationData {
         this._events = _events;
     }
 
+    @Nullable
     public EventFieldList[] getEvents() { return _events; }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/FilterOperand.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/FilterOperand.java
@@ -32,7 +32,6 @@ public class FilterOperand implements UaStructure {
     public FilterOperand() {
     }
 
-
     @Override
     public NodeId getTypeId() { return TypeId; }
 

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/FindServersOnNetworkRequest.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/FindServersOnNetworkRequest.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -54,6 +56,7 @@ public class FindServersOnNetworkRequest implements UaRequestMessage {
 
     public UInteger getMaxRecordsToReturn() { return _maxRecordsToReturn; }
 
+    @Nullable
     public String[] getServerCapabilityFilter() { return _serverCapabilityFilter; }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/FindServersOnNetworkResponse.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/FindServersOnNetworkResponse.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -49,6 +51,7 @@ public class FindServersOnNetworkResponse implements UaResponseMessage {
 
     public DateTime getLastCounterResetTime() { return _lastCounterResetTime; }
 
+    @Nullable
     public ServerOnNetwork[] getServers() { return _servers; }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/FindServersRequest.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/FindServersRequest.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -51,8 +53,10 @@ public class FindServersRequest implements UaRequestMessage {
 
     public String getEndpointUrl() { return _endpointUrl; }
 
+    @Nullable
     public String[] getLocaleIds() { return _localeIds; }
 
+    @Nullable
     public String[] getServerUris() { return _serverUris; }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/FindServersResponse.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/FindServersResponse.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -43,6 +45,7 @@ public class FindServersResponse implements UaResponseMessage {
 
     public ResponseHeader getResponseHeader() { return _responseHeader; }
 
+    @Nullable
     public ApplicationDescription[] getServers() { return _servers; }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/GetEndpointsRequest.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/GetEndpointsRequest.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -51,8 +53,10 @@ public class GetEndpointsRequest implements UaRequestMessage {
 
     public String getEndpointUrl() { return _endpointUrl; }
 
+    @Nullable
     public String[] getLocaleIds() { return _localeIds; }
 
+    @Nullable
     public String[] getProfileUris() { return _profileUris; }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/GetEndpointsResponse.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/GetEndpointsResponse.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -43,6 +45,7 @@ public class GetEndpointsResponse implements UaResponseMessage {
 
     public ResponseHeader getResponseHeader() { return _responseHeader; }
 
+    @Nullable
     public EndpointDescription[] getEndpoints() { return _endpoints; }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/HistoryData.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/HistoryData.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -39,6 +41,7 @@ public class HistoryData implements UaStructure {
         this._dataValues = _dataValues;
     }
 
+    @Nullable
     public DataValue[] getDataValues() { return _dataValues; }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/HistoryEvent.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/HistoryEvent.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -38,6 +40,7 @@ public class HistoryEvent implements UaStructure {
         this._events = _events;
     }
 
+    @Nullable
     public HistoryEventFieldList[] getEvents() { return _events; }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/HistoryEventFieldList.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/HistoryEventFieldList.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -39,6 +41,7 @@ public class HistoryEventFieldList implements UaStructure {
         this._eventFields = _eventFields;
     }
 
+    @Nullable
     public Variant[] getEventFields() { return _eventFields; }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/HistoryModifiedData.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/HistoryModifiedData.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -43,8 +45,10 @@ public class HistoryModifiedData extends HistoryData {
         this._modificationInfos = _modificationInfos;
     }
 
+    @Nullable
     public DataValue[] getDataValues() { return _dataValues; }
 
+    @Nullable
     public ModificationInfo[] getModificationInfos() { return _modificationInfos; }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/HistoryReadDetails.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/HistoryReadDetails.java
@@ -32,7 +32,6 @@ public class HistoryReadDetails implements UaStructure {
     public HistoryReadDetails() {
     }
 
-
     @Override
     public NodeId getTypeId() { return TypeId; }
 

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/HistoryReadRequest.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/HistoryReadRequest.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -60,6 +62,7 @@ public class HistoryReadRequest implements UaRequestMessage {
 
     public Boolean getReleaseContinuationPoints() { return _releaseContinuationPoints; }
 
+    @Nullable
     public HistoryReadValueId[] getNodesToRead() { return _nodesToRead; }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/HistoryReadResponse.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/HistoryReadResponse.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -47,8 +49,10 @@ public class HistoryReadResponse implements UaResponseMessage {
 
     public ResponseHeader getResponseHeader() { return _responseHeader; }
 
+    @Nullable
     public HistoryReadResult[] getResults() { return _results; }
 
+    @Nullable
     public DiagnosticInfo[] getDiagnosticInfos() { return _diagnosticInfos; }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/HistoryUpdateRequest.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/HistoryUpdateRequest.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -44,6 +46,7 @@ public class HistoryUpdateRequest implements UaRequestMessage {
 
     public RequestHeader getRequestHeader() { return _requestHeader; }
 
+    @Nullable
     public ExtensionObject[] getHistoryUpdateDetails() { return _historyUpdateDetails; }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/HistoryUpdateResponse.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/HistoryUpdateResponse.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -47,8 +49,10 @@ public class HistoryUpdateResponse implements UaResponseMessage {
 
     public ResponseHeader getResponseHeader() { return _responseHeader; }
 
+    @Nullable
     public HistoryUpdateResult[] getResults() { return _results; }
 
+    @Nullable
     public DiagnosticInfo[] getDiagnosticInfos() { return _diagnosticInfos; }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/HistoryUpdateResult.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/HistoryUpdateResult.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -48,8 +50,10 @@ public class HistoryUpdateResult implements UaStructure {
 
     public StatusCode getStatusCode() { return _statusCode; }
 
+    @Nullable
     public StatusCode[] getOperationResults() { return _operationResults; }
 
+    @Nullable
     public DiagnosticInfo[] getDiagnosticInfos() { return _diagnosticInfos; }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/MdnsDiscoveryConfiguration.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/MdnsDiscoveryConfiguration.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -44,6 +46,7 @@ public class MdnsDiscoveryConfiguration extends DiscoveryConfiguration {
 
     public String getMdnsServerName() { return _mdnsServerName; }
 
+    @Nullable
     public String[] getServerCapabilities() { return _serverCapabilities; }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/ModifyMonitoredItemsRequest.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/ModifyMonitoredItemsRequest.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -55,6 +57,7 @@ public class ModifyMonitoredItemsRequest implements UaRequestMessage {
 
     public TimestampsToReturn getTimestampsToReturn() { return _timestampsToReturn; }
 
+    @Nullable
     public MonitoredItemModifyRequest[] getItemsToModify() { return _itemsToModify; }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/ModifyMonitoredItemsResponse.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/ModifyMonitoredItemsResponse.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -47,8 +49,10 @@ public class ModifyMonitoredItemsResponse implements UaResponseMessage {
 
     public ResponseHeader getResponseHeader() { return _responseHeader; }
 
+    @Nullable
     public MonitoredItemModifyResult[] getResults() { return _results; }
 
+    @Nullable
     public DiagnosticInfo[] getDiagnosticInfos() { return _diagnosticInfos; }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/MonitoringFilter.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/MonitoringFilter.java
@@ -32,7 +32,6 @@ public class MonitoringFilter implements UaStructure {
     public MonitoringFilter() {
     }
 
-
     @Override
     public NodeId getTypeId() { return TypeId; }
 

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/MonitoringFilterResult.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/MonitoringFilterResult.java
@@ -32,7 +32,6 @@ public class MonitoringFilterResult implements UaStructure {
     public MonitoringFilterResult() {
     }
 
-
     @Override
     public NodeId getTypeId() { return TypeId; }
 

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/NetworkGroupDataType.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/NetworkGroupDataType.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -43,6 +45,7 @@ public class NetworkGroupDataType implements UaStructure {
 
     public String getServerUri() { return _serverUri; }
 
+    @Nullable
     public EndpointUrlListDataType[] getNetworkPaths() { return _networkPaths; }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/Node.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/Node.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -77,6 +79,7 @@ public class Node implements UaStructure {
 
     public UInteger getUserWriteMask() { return _userWriteMask; }
 
+    @Nullable
     public ReferenceNode[] getReferences() { return _references; }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/NodeReference.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/NodeReference.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -53,6 +55,7 @@ public class NodeReference implements UaStructure {
 
     public Boolean getIsForward() { return _isForward; }
 
+    @Nullable
     public NodeId[] getReferencedNodeIds() { return _referencedNodeIds; }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/NodeTypeDescription.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/NodeTypeDescription.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -49,6 +51,7 @@ public class NodeTypeDescription implements UaStructure {
 
     public Boolean getIncludeSubTypes() { return _includeSubTypes; }
 
+    @Nullable
     public QueryDataDescription[] getDataToReturn() { return _dataToReturn; }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/NotificationMessage.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/NotificationMessage.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -51,6 +53,7 @@ public class NotificationMessage implements UaStructure {
 
     public DateTime getPublishTime() { return _publishTime; }
 
+    @Nullable
     public ExtensionObject[] getNotificationData() { return _notificationData; }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/ParsingResult.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/ParsingResult.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -48,8 +50,10 @@ public class ParsingResult implements UaStructure {
 
     public StatusCode getStatusCode() { return _statusCode; }
 
+    @Nullable
     public StatusCode[] getDataStatusCodes() { return _dataStatusCodes; }
 
+    @Nullable
     public DiagnosticInfo[] getDataDiagnosticInfos() { return _dataDiagnosticInfos; }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/ProgramDiagnosticDataType.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/ProgramDiagnosticDataType.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -78,8 +80,10 @@ public class ProgramDiagnosticDataType implements UaStructure {
 
     public NodeId getLastMethodSessionId() { return _lastMethodSessionId; }
 
+    @Nullable
     public Argument[] getLastMethodInputArguments() { return _lastMethodInputArguments; }
 
+    @Nullable
     public Argument[] getLastMethodOutputArguments() { return _lastMethodOutputArguments; }
 
     public DateTime getLastMethodCallTime() { return _lastMethodCallTime; }

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/PublishRequest.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/PublishRequest.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -43,6 +45,7 @@ public class PublishRequest implements UaRequestMessage {
 
     public RequestHeader getRequestHeader() { return _requestHeader; }
 
+    @Nullable
     public SubscriptionAcknowledgement[] getSubscriptionAcknowledgements() { return _subscriptionAcknowledgements; }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/PublishResponse.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/PublishResponse.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -63,14 +65,17 @@ public class PublishResponse implements UaResponseMessage {
 
     public UInteger getSubscriptionId() { return _subscriptionId; }
 
+    @Nullable
     public UInteger[] getAvailableSequenceNumbers() { return _availableSequenceNumbers; }
 
     public Boolean getMoreNotifications() { return _moreNotifications; }
 
     public NotificationMessage getNotificationMessage() { return _notificationMessage; }
 
+    @Nullable
     public StatusCode[] getResults() { return _results; }
 
+    @Nullable
     public DiagnosticInfo[] getDiagnosticInfos() { return _diagnosticInfos; }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/QueryDataSet.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/QueryDataSet.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -50,6 +52,7 @@ public class QueryDataSet implements UaStructure {
 
     public ExpandedNodeId getTypeDefinitionNode() { return _typeDefinitionNode; }
 
+    @Nullable
     public Variant[] getValues() { return _values; }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/QueryFirstRequest.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/QueryFirstRequest.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -58,6 +60,7 @@ public class QueryFirstRequest implements UaRequestMessage {
 
     public ViewDescription getView() { return _view; }
 
+    @Nullable
     public NodeTypeDescription[] getNodeTypes() { return _nodeTypes; }
 
     public ContentFilter getFilter() { return _filter; }

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/QueryFirstResponse.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/QueryFirstResponse.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -57,12 +59,15 @@ public class QueryFirstResponse implements UaResponseMessage {
 
     public ResponseHeader getResponseHeader() { return _responseHeader; }
 
+    @Nullable
     public QueryDataSet[] getQueryDataSets() { return _queryDataSets; }
 
     public ByteString getContinuationPoint() { return _continuationPoint; }
 
+    @Nullable
     public ParsingResult[] getParsingResults() { return _parsingResults; }
 
+    @Nullable
     public DiagnosticInfo[] getDiagnosticInfos() { return _diagnosticInfos; }
 
     public ContentFilterResult getFilterResult() { return _filterResult; }

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/QueryNextResponse.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/QueryNextResponse.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -47,6 +49,7 @@ public class QueryNextResponse implements UaResponseMessage {
 
     public ResponseHeader getResponseHeader() { return _responseHeader; }
 
+    @Nullable
     public QueryDataSet[] getQueryDataSets() { return _queryDataSets; }
 
     public ByteString getRevisedContinuationPoint() { return _revisedContinuationPoint; }

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/ReadAtTimeDetails.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/ReadAtTimeDetails.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -43,6 +45,7 @@ public class ReadAtTimeDetails extends HistoryReadDetails {
         this._useSimpleBounds = _useSimpleBounds;
     }
 
+    @Nullable
     public DateTime[] getReqTimes() { return _reqTimes; }
 
     public Boolean getUseSimpleBounds() { return _useSimpleBounds; }

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/ReadProcessedDetails.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/ReadProcessedDetails.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -58,6 +60,7 @@ public class ReadProcessedDetails extends HistoryReadDetails {
 
     public Double getProcessingInterval() { return _processingInterval; }
 
+    @Nullable
     public NodeId[] getAggregateType() { return _aggregateType; }
 
     public AggregateConfiguration getAggregateConfiguration() { return _aggregateConfiguration; }

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/ReadRequest.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/ReadRequest.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -54,6 +56,7 @@ public class ReadRequest implements UaRequestMessage {
 
     public TimestampsToReturn getTimestampsToReturn() { return _timestampsToReturn; }
 
+    @Nullable
     public ReadValueId[] getNodesToRead() { return _nodesToRead; }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/ReadResponse.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/ReadResponse.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -48,8 +50,10 @@ public class ReadResponse implements UaResponseMessage {
 
     public ResponseHeader getResponseHeader() { return _responseHeader; }
 
+    @Nullable
     public DataValue[] getResults() { return _results; }
 
+    @Nullable
     public DiagnosticInfo[] getDiagnosticInfos() { return _diagnosticInfos; }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/ReferenceTypeNode.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/ReferenceTypeNode.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -52,6 +54,7 @@ public class ReferenceTypeNode extends TypeNode {
         this._inverseName = _inverseName;
     }
 
+    @Nullable
     public ReferenceNode[] getReferences() { return _references; }
 
     public Boolean getIsAbstract() { return _isAbstract; }

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/RegisterNodesRequest.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/RegisterNodesRequest.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -43,6 +45,7 @@ public class RegisterNodesRequest implements UaRequestMessage {
 
     public RequestHeader getRequestHeader() { return _requestHeader; }
 
+    @Nullable
     public NodeId[] getNodesToRegister() { return _nodesToRegister; }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/RegisterNodesResponse.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/RegisterNodesResponse.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -43,6 +45,7 @@ public class RegisterNodesResponse implements UaResponseMessage {
 
     public ResponseHeader getResponseHeader() { return _responseHeader; }
 
+    @Nullable
     public NodeId[] getRegisteredNodeIds() { return _registeredNodeIds; }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/RegisterServer2Request.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/RegisterServer2Request.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -49,6 +51,7 @@ public class RegisterServer2Request implements UaRequestMessage {
 
     public RegisteredServer getServer() { return _server; }
 
+    @Nullable
     public ExtensionObject[] getDiscoveryConfiguration() { return _discoveryConfiguration; }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/RegisterServer2Response.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/RegisterServer2Response.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -48,8 +50,10 @@ public class RegisterServer2Response implements UaResponseMessage {
 
     public ResponseHeader getResponseHeader() { return _responseHeader; }
 
+    @Nullable
     public StatusCode[] getConfigurationResults() { return _configurationResults; }
 
+    @Nullable
     public DiagnosticInfo[] getDiagnosticInfos() { return _diagnosticInfos; }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/RegisteredServer.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/RegisteredServer.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -65,12 +67,14 @@ public class RegisteredServer implements UaStructure {
 
     public String getProductUri() { return _productUri; }
 
+    @Nullable
     public LocalizedText[] getServerNames() { return _serverNames; }
 
     public ApplicationType getServerType() { return _serverType; }
 
     public String getGatewayServerUri() { return _gatewayServerUri; }
 
+    @Nullable
     public String[] getDiscoveryUrls() { return _discoveryUrls; }
 
     public String getSemaphoreFilePath() { return _semaphoreFilePath; }

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/RelativePath.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/RelativePath.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -38,6 +40,7 @@ public class RelativePath implements UaStructure {
         this._elements = _elements;
     }
 
+    @Nullable
     public RelativePathElement[] getElements() { return _elements; }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/ResponseHeader.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/ResponseHeader.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -66,6 +68,7 @@ public class ResponseHeader implements UaStructure {
 
     public DiagnosticInfo getServiceDiagnostics() { return _serviceDiagnostics; }
 
+    @Nullable
     public String[] getStringTable() { return _stringTable; }
 
     public ExtensionObject getAdditionalHeader() { return _additionalHeader; }

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/ServerOnNetwork.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/ServerOnNetwork.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -54,6 +56,7 @@ public class ServerOnNetwork implements UaStructure {
 
     public String getDiscoveryUrl() { return _discoveryUrl; }
 
+    @Nullable
     public String[] getServerCapabilities() { return _serverCapabilities; }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/SessionDiagnosticsDataType.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/SessionDiagnosticsDataType.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -176,6 +178,7 @@ public class SessionDiagnosticsDataType implements UaStructure {
 
     public String getEndpointUrl() { return _endpointUrl; }
 
+    @Nullable
     public String[] getLocaleIds() { return _localeIds; }
 
     public Double getActualSessionTimeout() { return _actualSessionTimeout; }

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/SessionSecurityDiagnosticsDataType.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/SessionSecurityDiagnosticsDataType.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -68,6 +70,7 @@ public class SessionSecurityDiagnosticsDataType implements UaStructure {
 
     public String getClientUserIdOfSession() { return _clientUserIdOfSession; }
 
+    @Nullable
     public String[] getClientUserIdHistory() { return _clientUserIdHistory; }
 
     public String getAuthenticationMechanism() { return _authenticationMechanism; }

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/SetMonitoringModeRequest.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/SetMonitoringModeRequest.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -55,6 +57,7 @@ public class SetMonitoringModeRequest implements UaRequestMessage {
 
     public MonitoringMode getMonitoringMode() { return _monitoringMode; }
 
+    @Nullable
     public UInteger[] getMonitoredItemIds() { return _monitoredItemIds; }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/SetMonitoringModeResponse.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/SetMonitoringModeResponse.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -48,8 +50,10 @@ public class SetMonitoringModeResponse implements UaResponseMessage {
 
     public ResponseHeader getResponseHeader() { return _responseHeader; }
 
+    @Nullable
     public StatusCode[] getResults() { return _results; }
 
+    @Nullable
     public DiagnosticInfo[] getDiagnosticInfos() { return _diagnosticInfos; }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/SetPublishingModeRequest.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/SetPublishingModeRequest.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -49,6 +51,7 @@ public class SetPublishingModeRequest implements UaRequestMessage {
 
     public Boolean getPublishingEnabled() { return _publishingEnabled; }
 
+    @Nullable
     public UInteger[] getSubscriptionIds() { return _subscriptionIds; }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/SetPublishingModeResponse.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/SetPublishingModeResponse.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -48,8 +50,10 @@ public class SetPublishingModeResponse implements UaResponseMessage {
 
     public ResponseHeader getResponseHeader() { return _responseHeader; }
 
+    @Nullable
     public StatusCode[] getResults() { return _results; }
 
+    @Nullable
     public DiagnosticInfo[] getDiagnosticInfos() { return _diagnosticInfos; }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/SetTriggeringRequest.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/SetTriggeringRequest.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -57,8 +59,10 @@ public class SetTriggeringRequest implements UaRequestMessage {
 
     public UInteger getTriggeringItemId() { return _triggeringItemId; }
 
+    @Nullable
     public UInteger[] getLinksToAdd() { return _linksToAdd; }
 
+    @Nullable
     public UInteger[] getLinksToRemove() { return _linksToRemove; }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/SetTriggeringResponse.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/SetTriggeringResponse.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -54,12 +56,16 @@ public class SetTriggeringResponse implements UaResponseMessage {
 
     public ResponseHeader getResponseHeader() { return _responseHeader; }
 
+    @Nullable
     public StatusCode[] getAddResults() { return _addResults; }
 
+    @Nullable
     public DiagnosticInfo[] getAddDiagnosticInfos() { return _addDiagnosticInfos; }
 
+    @Nullable
     public StatusCode[] getRemoveResults() { return _removeResults; }
 
+    @Nullable
     public DiagnosticInfo[] getRemoveDiagnosticInfos() { return _removeDiagnosticInfos; }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/SimpleAttributeOperand.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/SimpleAttributeOperand.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -52,6 +54,7 @@ public class SimpleAttributeOperand extends FilterOperand {
 
     public NodeId getTypeDefinitionId() { return _typeDefinitionId; }
 
+    @Nullable
     public QualifiedName[] getBrowsePath() { return _browsePath; }
 
     public UInteger getAttributeId() { return _attributeId; }

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/SoftwareCertificate.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/SoftwareCertificate.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -85,6 +87,7 @@ public class SoftwareCertificate implements UaStructure {
 
     public DateTime getIssueDate() { return _issueDate; }
 
+    @Nullable
     public SupportedProfile[] getSupportedProfiles() { return _supportedProfiles; }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/SupportedProfile.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/SupportedProfile.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -65,6 +67,7 @@ public class SupportedProfile implements UaStructure {
 
     public ComplianceLevel getComplianceLevel() { return _complianceLevel; }
 
+    @Nullable
     public String[] getUnsupportedUnitIds() { return _unsupportedUnitIds; }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/TransferResult.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/TransferResult.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -45,6 +47,7 @@ public class TransferResult implements UaStructure {
 
     public StatusCode getStatusCode() { return _statusCode; }
 
+    @Nullable
     public UInteger[] getAvailableSequenceNumbers() { return _availableSequenceNumbers; }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/TransferSubscriptionsRequest.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/TransferSubscriptionsRequest.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -47,6 +49,7 @@ public class TransferSubscriptionsRequest implements UaRequestMessage {
 
     public RequestHeader getRequestHeader() { return _requestHeader; }
 
+    @Nullable
     public UInteger[] getSubscriptionIds() { return _subscriptionIds; }
 
     public Boolean getSendInitialValues() { return _sendInitialValues; }

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/TransferSubscriptionsResponse.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/TransferSubscriptionsResponse.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -47,8 +49,10 @@ public class TransferSubscriptionsResponse implements UaResponseMessage {
 
     public ResponseHeader getResponseHeader() { return _responseHeader; }
 
+    @Nullable
     public TransferResult[] getResults() { return _results; }
 
+    @Nullable
     public DiagnosticInfo[] getDiagnosticInfos() { return _diagnosticInfos; }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/TranslateBrowsePathsToNodeIdsRequest.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/TranslateBrowsePathsToNodeIdsRequest.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -43,6 +45,7 @@ public class TranslateBrowsePathsToNodeIdsRequest implements UaRequestMessage {
 
     public RequestHeader getRequestHeader() { return _requestHeader; }
 
+    @Nullable
     public BrowsePath[] getBrowsePaths() { return _browsePaths; }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/TranslateBrowsePathsToNodeIdsResponse.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/TranslateBrowsePathsToNodeIdsResponse.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -47,8 +49,10 @@ public class TranslateBrowsePathsToNodeIdsResponse implements UaResponseMessage 
 
     public ResponseHeader getResponseHeader() { return _responseHeader; }
 
+    @Nullable
     public BrowsePathResult[] getResults() { return _results; }
 
+    @Nullable
     public DiagnosticInfo[] getDiagnosticInfos() { return _diagnosticInfos; }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/TrustListDataType.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/TrustListDataType.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -54,12 +56,16 @@ public class TrustListDataType implements UaStructure {
 
     public UInteger getSpecifiedLists() { return _specifiedLists; }
 
+    @Nullable
     public ByteString[] getTrustedCertificates() { return _trustedCertificates; }
 
+    @Nullable
     public ByteString[] getTrustedCrls() { return _trustedCrls; }
 
+    @Nullable
     public ByteString[] getIssuerCertificates() { return _issuerCertificates; }
 
+    @Nullable
     public ByteString[] getIssuerCrls() { return _issuerCrls; }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/Union.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/Union.java
@@ -32,7 +32,6 @@ public class Union implements UaStructure {
     public Union() {
     }
 
-
     @Override
     public NodeId getTypeId() { return TypeId; }
 

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/UnregisterNodesRequest.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/UnregisterNodesRequest.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -43,6 +45,7 @@ public class UnregisterNodesRequest implements UaRequestMessage {
 
     public RequestHeader getRequestHeader() { return _requestHeader; }
 
+    @Nullable
     public NodeId[] getNodesToUnregister() { return _nodesToUnregister; }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/UpdateDataDetails.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/UpdateDataDetails.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -46,6 +48,7 @@ public class UpdateDataDetails extends HistoryUpdateDetails {
 
     public PerformUpdateType getPerformInsertReplace() { return _performInsertReplace; }
 
+    @Nullable
     public DataValue[] getUpdateValues() { return _updateValues; }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/UpdateEventDetails.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/UpdateEventDetails.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -50,6 +52,7 @@ public class UpdateEventDetails extends HistoryUpdateDetails {
 
     public EventFilter getFilter() { return _filter; }
 
+    @Nullable
     public HistoryEventFieldList[] getEventData() { return _eventData; }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/UpdateStructureDataDetails.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/UpdateStructureDataDetails.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -46,6 +48,7 @@ public class UpdateStructureDataDetails extends HistoryUpdateDetails {
 
     public PerformUpdateType getPerformInsertReplace() { return _performInsertReplace; }
 
+    @Nullable
     public DataValue[] getUpdateValues() { return _updateValues; }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/VariableAttributes.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/VariableAttributes.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -70,6 +72,7 @@ public class VariableAttributes extends NodeAttributes {
 
     public Integer getValueRank() { return _valueRank; }
 
+    @Nullable
     public UInteger[] getArrayDimensions() { return _arrayDimensions; }
 
     public UByte getAccessLevel() { return _accessLevel; }

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/VariableNode.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/VariableNode.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -72,6 +74,7 @@ public class VariableNode extends InstanceNode {
 
     public Integer getValueRank() { return _valueRank; }
 
+    @Nullable
     public UInteger[] getArrayDimensions() { return _arrayDimensions; }
 
     public UByte getAccessLevel() { return _accessLevel; }

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/VariableTypeAttributes.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/VariableTypeAttributes.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -60,6 +62,7 @@ public class VariableTypeAttributes extends NodeAttributes {
 
     public Integer getValueRank() { return _valueRank; }
 
+    @Nullable
     public UInteger[] getArrayDimensions() { return _arrayDimensions; }
 
     public Boolean getIsAbstract() { return _isAbstract; }

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/VariableTypeNode.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/VariableTypeNode.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -62,6 +64,7 @@ public class VariableTypeNode extends TypeNode {
 
     public Integer getValueRank() { return _valueRank; }
 
+    @Nullable
     public UInteger[] getArrayDimensions() { return _arrayDimensions; }
 
     public Boolean getIsAbstract() { return _isAbstract; }

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/WriteRequest.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/WriteRequest.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -43,6 +45,7 @@ public class WriteRequest implements UaRequestMessage {
 
     public RequestHeader getRequestHeader() { return _requestHeader; }
 
+    @Nullable
     public WriteValue[] getNodesToWrite() { return _nodesToWrite; }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/WriteResponse.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/WriteResponse.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.milo.opcua.stack.core.types.structured;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.milo.opcua.stack.core.Identifiers;
 import org.eclipse.milo.opcua.stack.core.serialization.DelegateRegistry;
 import org.eclipse.milo.opcua.stack.core.serialization.UaDecoder;
@@ -48,8 +50,10 @@ public class WriteResponse implements UaResponseMessage {
 
     public ResponseHeader getResponseHeader() { return _responseHeader; }
 
+    @Nullable
     public StatusCode[] getResults() { return _results; }
 
+    @Nullable
     public DiagnosticInfo[] getDiagnosticInfos() { return _diagnosticInfos; }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/util/ConversionUtil.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/util/ConversionUtil.java
@@ -14,7 +14,12 @@
 package org.eclipse.milo.opcua.stack.core.util;
 
 import java.lang.reflect.Array;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.function.Supplier;
+import javax.annotation.Nullable;
 
 public class ConversionUtil {
 
@@ -27,8 +32,16 @@ public class ConversionUtil {
         return (T[]) array;
     }
 
+    public static <T> List<T> toList(T[] array) {
+        return array != null ? Arrays.asList(array) : Collections.emptyList();
+    }
+
     public static <T> T[] a(List<T> list, Class<T> c) {
         return toArray(list, c);
+    }
+
+    public static <T> List<T> l(T[] array) {
+        return toList(array);
     }
 
 }

--- a/opc-ua-stack/stack-server/src/main/java/org/eclipse/milo/opcua/stack/server/tcp/FallbackServer.java
+++ b/opc-ua-stack/stack-server/src/main/java/org/eclipse/milo/opcua/stack/server/tcp/FallbackServer.java
@@ -35,6 +35,8 @@ import org.eclipse.milo.opcua.stack.core.types.structured.GetEndpointsResponse;
 import org.eclipse.milo.opcua.stack.core.types.structured.ResponseHeader;
 import org.eclipse.milo.opcua.stack.server.config.UaTcpStackServerConfig;
 
+import static org.eclipse.milo.opcua.stack.core.util.ConversionUtil.l;
+
 /**
  * Provides a "fallback" server for when a UA TCP Hello contains an unknown endpoint URL.
  */
@@ -120,7 +122,7 @@ public class FallbackServer {
             FindServersRequest request = service.getRequest();
 
             List<ApplicationDescription> servers = new ArrayList<>();
-            List<String> serverUris = Lists.newArrayList(request.getServerUris());
+            List<String> serverUris = l(request.getServerUris());
 
             for (UaTcpStackServer server : registered) {
                 ApplicationDescription description = server.getApplicationDescription();


### PR DESCRIPTION
Generate new structures that use the `@Nullable` annotation on getters for array members. This became necessary after merging #48 caused NPEs to start popping up all over the place when arrays previously decoded into empty arrays were suddenly null instead.

After adding the annotations static analysis was used to find and fix all locations where a possibly-null array value was being dereferenced.