### PR TITLE
Provide AccessContext to browse calls

### DIFF
--- a/milo-examples/server-examples/src/main/java/org/eclipse/milo/examples/server/ExampleNamespace.java
+++ b/milo-examples/server-examples/src/main/java/org/eclipse/milo/examples/server/ExampleNamespace.java
@@ -280,7 +280,7 @@ public class ExampleNamespace implements Namespace {
     }
 
     @Override
-    public CompletableFuture<List<Reference>> getReferences(AccessContext context, NodeId nodeId) {
+    public CompletableFuture<List<Reference>> browse(AccessContext context, NodeId nodeId) {
         UaNode node = server.getNodeManager().get(nodeId);
 
         if (node != null) {

--- a/milo-examples/server-examples/src/main/java/org/eclipse/milo/examples/server/ExampleNamespace.java
+++ b/milo-examples/server-examples/src/main/java/org/eclipse/milo/examples/server/ExampleNamespace.java
@@ -25,6 +25,7 @@ import org.eclipse.milo.opcua.sdk.core.AccessLevel;
 import org.eclipse.milo.opcua.sdk.core.Reference;
 import org.eclipse.milo.opcua.sdk.core.ValueRank;
 import org.eclipse.milo.opcua.sdk.server.OpcUaServer;
+import org.eclipse.milo.opcua.sdk.server.api.AccessContext;
 import org.eclipse.milo.opcua.sdk.server.api.DataItem;
 import org.eclipse.milo.opcua.sdk.server.api.MethodInvocationHandler;
 import org.eclipse.milo.opcua.sdk.server.api.MonitoredItem;
@@ -279,7 +280,7 @@ public class ExampleNamespace implements Namespace {
     }
 
     @Override
-    public CompletableFuture<List<Reference>> getReferences(NodeId nodeId) {
+    public CompletableFuture<List<Reference>> getReferences(AccessContext context, NodeId nodeId) {
         UaNode node = server.getNodeManager().get(nodeId);
 
         if (node != null) {

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/api/AccessContext.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/api/AccessContext.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2016 Kevin Herron
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *   http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *   http://www.eclipse.org/org/documents/edl-v10.html.
+ */
+
+package org.eclipse.milo.opcua.sdk.server.api;
+
+import java.util.Optional;
+
+import org.eclipse.milo.opcua.sdk.server.Session;
+
+public interface AccessContext {
+
+    /**
+     * Get the {@link Session} associated with this access request, if present.
+     * <p>
+     * If empty, the access request is internal and no user- or session-related restrictions should be applied.
+     *
+     * @return the {@link Session} associated with this access request, if present.
+     */
+    Optional<Session> getSession();
+
+}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/api/ViewManager.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/api/ViewManager.java
@@ -60,7 +60,7 @@ public interface ViewManager {
      * @return a {@link CompletableFuture} containing the {@link Reference}s. If the node is unknown, complete the
      * future exceptionally.
      */
-    CompletableFuture<List<Reference>> getReferences(AccessContext context, NodeId nodeId);
+    CompletableFuture<List<Reference>> browse(AccessContext context, NodeId nodeId);
 
     final class BrowseContext extends OperationContext<BrowseDescription, BrowseResult> implements AccessContext {
         public BrowseContext(OpcUaServer server,

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/namespaces/OpcUaNamespace.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/namespaces/OpcUaNamespace.java
@@ -22,6 +22,7 @@ import java.util.concurrent.TimeUnit;
 import org.eclipse.milo.opcua.sdk.core.NamespaceTable;
 import org.eclipse.milo.opcua.sdk.core.Reference;
 import org.eclipse.milo.opcua.sdk.server.OpcUaServer;
+import org.eclipse.milo.opcua.sdk.server.api.AccessContext;
 import org.eclipse.milo.opcua.sdk.server.api.DataItem;
 import org.eclipse.milo.opcua.sdk.server.api.EventItem;
 import org.eclipse.milo.opcua.sdk.server.api.MethodInvocationHandler;
@@ -100,7 +101,7 @@ public class OpcUaNamespace implements Namespace {
     }
 
     @Override
-    public CompletableFuture<List<Reference>> getReferences(NodeId nodeId) {
+    public CompletableFuture<List<Reference>> getReferences(AccessContext context, NodeId nodeId) {
         UaNode node = nodeManager.get(nodeId);
 
         if (node != null) {

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/namespaces/OpcUaNamespace.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/namespaces/OpcUaNamespace.java
@@ -101,7 +101,7 @@ public class OpcUaNamespace implements Namespace {
     }
 
     @Override
-    public CompletableFuture<List<Reference>> getReferences(AccessContext context, NodeId nodeId) {
+    public CompletableFuture<List<Reference>> browse(AccessContext context, NodeId nodeId) {
         UaNode node = nodeManager.get(nodeId);
 
         if (node != null) {

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/namespaces/VendorNamespace.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/namespaces/VendorNamespace.java
@@ -23,6 +23,7 @@ import com.sun.management.OperatingSystemMXBean;
 import com.sun.management.UnixOperatingSystemMXBean;
 import org.eclipse.milo.opcua.sdk.core.Reference;
 import org.eclipse.milo.opcua.sdk.server.OpcUaServer;
+import org.eclipse.milo.opcua.sdk.server.api.AccessContext;
 import org.eclipse.milo.opcua.sdk.server.api.DataItem;
 import org.eclipse.milo.opcua.sdk.server.api.MonitoredItem;
 import org.eclipse.milo.opcua.sdk.server.api.Namespace;
@@ -79,7 +80,7 @@ public class VendorNamespace implements Namespace {
     }
 
     @Override
-    public CompletableFuture<List<Reference>> getReferences(NodeId nodeId) {
+    public CompletableFuture<List<Reference>> getReferences(AccessContext context, NodeId nodeId) {
         UaNode node = nodeManager.get(nodeId);
 
         if (node != null) {

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/namespaces/VendorNamespace.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/namespaces/VendorNamespace.java
@@ -80,7 +80,7 @@ public class VendorNamespace implements Namespace {
     }
 
     @Override
-    public CompletableFuture<List<Reference>> getReferences(AccessContext context, NodeId nodeId) {
+    public CompletableFuture<List<Reference>> browse(AccessContext context, NodeId nodeId) {
         UaNode node = nodeManager.get(nodeId);
 
         if (node != null) {

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/services/ViewServices.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/services/ViewServices.java
@@ -15,6 +15,7 @@ package org.eclipse.milo.opcua.sdk.server.services;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 import org.eclipse.milo.opcua.sdk.server.DiagnosticsContext;
@@ -150,9 +151,16 @@ public class ViewServices implements ViewServiceSet {
         translateBrowsePathsCounter.record(service);
 
         OpcUaServer server = service.attr(ServiceAttributes.SERVER_KEY).get();
+        Session session = service.attr(ServiceAttributes.SESSION_KEY).get();
         NamespaceManager namespaceManager = server.getNamespaceManager();
 
-        new BrowsePathsHelper(server, namespaceManager).onTranslateBrowsePaths(service);
+        BrowsePathsHelper browsePathsHelper = new BrowsePathsHelper(
+            () -> Optional.ofNullable(session),
+            server,
+            namespaceManager
+        );
+
+        browsePathsHelper.onTranslateBrowsePaths(service);
     }
 
     @Override

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/services/helpers/BrowseHelper.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/services/helpers/BrowseHelper.java
@@ -138,7 +138,7 @@ public class BrowseHelper {
             Namespace namespace = namespaceManager.getNamespace(browseDescription.getNodeId().getNamespaceIndex());
 
             CompletableFuture<List<Reference>> referencesFuture =
-                namespace.getReferences(context, browseDescription.getNodeId());
+                namespace.browse(context, browseDescription.getNodeId());
 
             referencesFuture.whenComplete((references, ex) -> {
                 if (references != null) {
@@ -301,7 +301,7 @@ public class BrowseHelper {
         private CompletableFuture<ExpandedNodeId> getTypeDefinition(NodeId nodeId) {
             Namespace namespace = server.getNamespaceManager().getNamespace(nodeId.getNamespaceIndex());
 
-            return namespace.getReferences(context, nodeId).thenApply(references ->
+            return namespace.browse(context, nodeId).thenApply(references ->
                 references.stream()
                     .filter(r -> Identifiers.HasTypeDefinition.equals(r.getReferenceTypeId()))
                     .findFirst()

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/services/helpers/BrowsePathsHelper.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/services/helpers/BrowsePathsHelper.java
@@ -170,7 +170,7 @@ public class BrowsePathsHelper {
 
         Namespace namespace = namespaceManager.getNamespace(nodeId.getNamespaceIndex());
 
-        CompletableFuture<List<Reference>> future = namespace.getReferences(context, nodeId);
+        CompletableFuture<List<Reference>> future = namespace.browse(context, nodeId);
 
         return future.thenCompose(references -> {
             List<ExpandedNodeId> targetNodeIds = references.stream()
@@ -207,7 +207,7 @@ public class BrowsePathsHelper {
 
         Namespace namespace = namespaceManager.getNamespace(nodeId.getNamespaceIndex());
 
-        CompletableFuture<List<Reference>> future = namespace.getReferences(context, nodeId);
+        CompletableFuture<List<Reference>> future = namespace.browse(context, nodeId);
 
         return future.thenCompose(references -> {
             List<ExpandedNodeId> targetNodeIds = references.stream()

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/services/helpers/BrowsePathsHelper.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/services/helpers/BrowsePathsHelper.java
@@ -21,6 +21,7 @@ import org.eclipse.milo.opcua.sdk.core.Reference;
 import org.eclipse.milo.opcua.sdk.server.DiagnosticsContext;
 import org.eclipse.milo.opcua.sdk.server.NamespaceManager;
 import org.eclipse.milo.opcua.sdk.server.OpcUaServer;
+import org.eclipse.milo.opcua.sdk.server.api.AccessContext;
 import org.eclipse.milo.opcua.sdk.server.api.AttributeManager.ReadContext;
 import org.eclipse.milo.opcua.sdk.server.api.Namespace;
 import org.eclipse.milo.opcua.sdk.server.services.ServiceAttributes;
@@ -57,10 +58,12 @@ import static org.eclipse.milo.opcua.stack.core.util.FutureUtils.sequence;
 
 public class BrowsePathsHelper {
 
+    private final AccessContext context;
     private final OpcUaServer server;
     private final NamespaceManager namespaceManager;
 
-    public BrowsePathsHelper(OpcUaServer server, NamespaceManager namespaceManager) {
+    public BrowsePathsHelper(AccessContext context, OpcUaServer server, NamespaceManager namespaceManager) {
+        this.context = context;
         this.server = server;
         this.namespaceManager = namespaceManager;
     }
@@ -167,7 +170,7 @@ public class BrowsePathsHelper {
 
         Namespace namespace = namespaceManager.getNamespace(nodeId.getNamespaceIndex());
 
-        CompletableFuture<List<Reference>> future = namespace.getReferences(nodeId);
+        CompletableFuture<List<Reference>> future = namespace.getReferences(context, nodeId);
 
         return future.thenCompose(references -> {
             List<ExpandedNodeId> targetNodeIds = references.stream()
@@ -204,7 +207,7 @@ public class BrowsePathsHelper {
 
         Namespace namespace = namespaceManager.getNamespace(nodeId.getNamespaceIndex());
 
-        CompletableFuture<List<Reference>> future = namespace.getReferences(nodeId);
+        CompletableFuture<List<Reference>> future = namespace.getReferences(context, nodeId);
 
         return future.thenCompose(references -> {
             List<ExpandedNodeId> targetNodeIds = references.stream()

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/util/NoOpNamespace.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/util/NoOpNamespace.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 import org.eclipse.milo.opcua.sdk.core.Reference;
+import org.eclipse.milo.opcua.sdk.server.api.AccessContext;
 import org.eclipse.milo.opcua.sdk.server.api.DataItem;
 import org.eclipse.milo.opcua.sdk.server.api.EventItem;
 import org.eclipse.milo.opcua.sdk.server.api.MonitoredItem;
@@ -47,7 +48,7 @@ public class NoOpNamespace implements Namespace {
     }
 
     @Override
-    public CompletableFuture<List<Reference>> getReferences(NodeId nodeId) {
+    public CompletableFuture<List<Reference>> getReferences(AccessContext context, NodeId nodeId) {
         CompletableFuture<List<Reference>> f = new CompletableFuture<>();
         f.completeExceptionally(new UaException(StatusCodes.Bad_NodeIdUnknown));
         return f;

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/util/NoOpNamespace.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/util/NoOpNamespace.java
@@ -48,7 +48,7 @@ public class NoOpNamespace implements Namespace {
     }
 
     @Override
-    public CompletableFuture<List<Reference>> getReferences(AccessContext context, NodeId nodeId) {
+    public CompletableFuture<List<Reference>> browse(AccessContext context, NodeId nodeId) {
         CompletableFuture<List<Reference>> f = new CompletableFuture<>();
         f.completeExceptionally(new UaException(StatusCodes.Bad_NodeIdUnknown));
         return f;

--- a/opc-ua-sdk/sdk-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/TestNamespace.java
+++ b/opc-ua-sdk/sdk-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/TestNamespace.java
@@ -120,7 +120,7 @@ public class TestNamespace implements Namespace {
     }
 
     @Override
-    public CompletableFuture<List<Reference>> getReferences(AccessContext context, NodeId nodeId) {
+    public CompletableFuture<List<Reference>> browse(AccessContext context, NodeId nodeId) {
         UaNode node = nodeManager.get(nodeId);
 
         if (node != null) {

--- a/opc-ua-sdk/sdk-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/TestNamespace.java
+++ b/opc-ua-sdk/sdk-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/TestNamespace.java
@@ -25,6 +25,7 @@ import com.google.common.collect.PeekingIterator;
 import org.eclipse.milo.opcua.sdk.core.AccessLevel;
 import org.eclipse.milo.opcua.sdk.core.Reference;
 import org.eclipse.milo.opcua.sdk.server.OpcUaServer;
+import org.eclipse.milo.opcua.sdk.server.api.AccessContext;
 import org.eclipse.milo.opcua.sdk.server.api.DataItem;
 import org.eclipse.milo.opcua.sdk.server.api.MethodInvocationHandler;
 import org.eclipse.milo.opcua.sdk.server.api.MonitoredItem;
@@ -119,7 +120,7 @@ public class TestNamespace implements Namespace {
     }
 
     @Override
-    public CompletableFuture<List<Reference>> getReferences(NodeId nodeId) {
+    public CompletableFuture<List<Reference>> getReferences(AccessContext context, NodeId nodeId) {
         UaNode node = nodeManager.get(nodeId);
 
         if (node != null) {


### PR DESCRIPTION
Provides an `AccessContext` that can be used to identify the session or user associated with a browse request.

Issue #93 

@AriSuutariST  