### PR TITLE
Add (some) support for historyRead and historyUpdate operations.

### DIFF
--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/OpcUaServer.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/OpcUaServer.java
@@ -46,6 +46,7 @@ import org.eclipse.milo.opcua.stack.core.BuiltinReferenceType;
 import org.eclipse.milo.opcua.stack.core.ReferenceType;
 import org.eclipse.milo.opcua.stack.core.Stack;
 import org.eclipse.milo.opcua.stack.core.application.UaStackServer;
+import org.eclipse.milo.opcua.stack.core.application.services.AttributeHistoryServiceSet;
 import org.eclipse.milo.opcua.stack.core.application.services.AttributeServiceSet;
 import org.eclipse.milo.opcua.stack.core.application.services.MethodServiceSet;
 import org.eclipse.milo.opcua.stack.core.application.services.MonitoredItemServiceSet;
@@ -104,6 +105,7 @@ public class OpcUaServer {
         stackServer = new UaTcpStackServer(config);
 
         stackServer.addServiceSet((AttributeServiceSet) sessionManager);
+        stackServer.addServiceSet((AttributeHistoryServiceSet) sessionManager);
         stackServer.addServiceSet((MethodServiceSet) sessionManager);
         stackServer.addServiceSet((MonitoredItemServiceSet) sessionManager);
         stackServer.addServiceSet((NodeManagementServiceSet) sessionManager);

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/Session.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/Session.java
@@ -20,6 +20,7 @@ import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 
 import com.google.common.collect.Lists;
+import org.eclipse.milo.opcua.sdk.server.services.AttributeHistoryServices;
 import org.eclipse.milo.opcua.sdk.server.services.AttributeServices;
 import org.eclipse.milo.opcua.sdk.server.services.MethodServices;
 import org.eclipse.milo.opcua.sdk.server.services.MonitoredItemServices;
@@ -67,6 +68,7 @@ public class Session implements SessionServiceSet {
     private volatile ScheduledFuture<?> checkTimeoutFuture;
 
     private final AttributeServices attributeServices;
+    private final AttributeHistoryServices attributeHistoryServices;
     private final MethodServices methodServices;
     private final MonitoredItemServices monitoredItemServices;
     private final NodeManagementServiceSet nodeManagementServices;
@@ -94,6 +96,7 @@ public class Session implements SessionServiceSet {
         subscriptionManager = new SubscriptionManager(this, server);
 
         attributeServices = new AttributeServices();
+        attributeHistoryServices = new AttributeHistoryServices();
         methodServices = new MethodServices();
         monitoredItemServices = new MonitoredItemServices(subscriptionManager);
         nodeManagementServices = new NodeManagementServices();
@@ -176,6 +179,10 @@ public class Session implements SessionServiceSet {
 
     public AttributeServices getAttributeServices() {
         return attributeServices;
+    }
+
+    public AttributeHistoryServices getAttributeHistoryServices() {
+        return attributeHistoryServices;
     }
 
     public MethodServices getMethodServices() {

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/SessionManager.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/SessionManager.java
@@ -37,6 +37,7 @@ import org.eclipse.milo.opcua.sdk.server.services.ServiceAttributes;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.UaRuntimeException;
+import org.eclipse.milo.opcua.stack.core.application.services.AttributeHistoryServiceSet;
 import org.eclipse.milo.opcua.stack.core.application.services.AttributeServiceSet;
 import org.eclipse.milo.opcua.stack.core.application.services.MethodServiceSet;
 import org.eclipse.milo.opcua.stack.core.application.services.MonitoredItemServiceSet;
@@ -134,6 +135,7 @@ import static org.eclipse.milo.opcua.stack.core.util.ConversionUtil.l;
 
 public class SessionManager implements
     AttributeServiceSet,
+    AttributeHistoryServiceSet,
     MethodServiceSet,
     MonitoredItemServiceSet,
     NodeManagementServiceSet,
@@ -609,7 +611,7 @@ public class SessionManager implements
     public void onHistoryRead(ServiceRequest<HistoryReadRequest, HistoryReadResponse> service) throws UaException {
         Session session = session(service);
 
-        session.getAttributeServices().onHistoryRead(service);
+        session.getAttributeHistoryServices().onHistoryRead(service);
     }
 
     @Override
@@ -618,7 +620,7 @@ public class SessionManager implements
 
         Session session = session(service);
 
-        session.getAttributeServices().onHistoryUpdate(service);
+        session.getAttributeHistoryServices().onHistoryUpdate(service);
     }
     //endregion
 

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/api/AttributeHistoryManager.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/api/AttributeHistoryManager.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2017 Ari Suutari
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *   http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *   http://www.eclipse.org/org/documents/edl-v10.html.
+ */
+
+package org.eclipse.milo.opcua.sdk.server.api;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import javax.annotation.Nullable;
+
+import com.google.common.collect.Lists;
+
+import org.eclipse.milo.opcua.sdk.server.DiagnosticsContext;
+import org.eclipse.milo.opcua.sdk.server.OpcUaServer;
+import org.eclipse.milo.opcua.sdk.server.Session;
+import org.eclipse.milo.opcua.sdk.server.nodes.AttributeContext;
+import org.eclipse.milo.opcua.sdk.server.nodes.ServerNode;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.TimestampsToReturn;
+import org.eclipse.milo.opcua.stack.core.types.structured.HistoryReadDetails;
+import org.eclipse.milo.opcua.stack.core.types.structured.HistoryReadResult;
+import org.eclipse.milo.opcua.stack.core.types.structured.HistoryReadValueId;
+import org.eclipse.milo.opcua.stack.core.types.structured.HistoryUpdateDetails;
+import org.eclipse.milo.opcua.stack.core.types.structured.HistoryUpdateResult;
+import org.eclipse.milo.opcua.stack.core.types.structured.ReadValueId;
+import org.eclipse.milo.opcua.stack.core.types.structured.WriteValue;
+
+public interface AttributeHistoryManager {
+
+    /**
+     * Read history values from nodes belonging to this {@link AttributeHistoryManager}.
+     * <p>
+     * Complete the operation with {@link HistoryReadContext#complete(List)}.
+     *
+     * @param context      the {@link HistoryReadContext}.
+     * @param timestamps   requested timestamp values.
+     * @param readValueIds the values to read.
+     */
+    default void historyRead(HistoryReadContext context,
+                             HistoryReadDetails readDetails,
+                             TimestampsToReturn timestamps,
+                             List<HistoryReadValueId> readValueIds) {
+
+        List<HistoryReadResult> results = Lists.newArrayListWithCapacity(readValueIds.size());
+
+        for (HistoryReadValueId readValueId : readValueIds) {
+
+            results.add(new HistoryReadResult(new StatusCode(StatusCodes.Bad_NotSupported), null, null));
+        }
+
+        context.complete(results);
+    }
+
+    /**
+     * Update history values in nodes belonging to this {@link AttributeHistoryManager}.
+     * <p>
+     * Complete the operation with {@link HistoryUpdateContext#complete(List)}.
+     *
+     * @param context       the {@link HistoryUpdateContext}.
+     * @param updateDetails the values to read.
+     */
+    default void historyUpdate(HistoryUpdateContext context,
+                               List<HistoryUpdateDetails> updateDetails) {
+
+        List<HistoryUpdateResult> results = Lists.newArrayListWithCapacity(updateDetails.size());
+
+        for (HistoryUpdateDetails details : updateDetails) {
+
+            results.add(new HistoryUpdateResult(new StatusCode(StatusCodes.Bad_NotSupported), null, null));
+        }
+
+        context.complete(results);
+    }
+
+    final class HistoryReadContext extends OperationContext<HistoryReadValueId, HistoryReadResult> {
+        public HistoryReadContext(OpcUaServer server,
+                                  @Nullable Session session,
+                                  DiagnosticsContext<HistoryReadValueId> diagnosticsContext) {
+
+            super(server, session, diagnosticsContext);
+        }
+
+        public HistoryReadContext(OpcUaServer server,
+                                  @Nullable Session session,
+                                  CompletableFuture<List<HistoryReadResult>> future,
+                                  DiagnosticsContext<HistoryReadValueId> diagnosticsContext) {
+
+            super(server, session, future, diagnosticsContext);
+        }
+    }
+
+    final class HistoryUpdateContext extends OperationContext<HistoryUpdateDetails, HistoryUpdateResult> {
+        public HistoryUpdateContext(OpcUaServer server,
+                                    @Nullable Session session,
+                                    DiagnosticsContext<HistoryUpdateDetails> diagnosticsContext) {
+
+            super(server, session, diagnosticsContext);
+        }
+
+        public HistoryUpdateContext(OpcUaServer server,
+                                    @Nullable Session session,
+                                    CompletableFuture<List<HistoryUpdateResult>> future,
+                                    DiagnosticsContext<HistoryUpdateDetails> diagnosticsContext) {
+
+            super(server, session, future, diagnosticsContext);
+        }
+    }
+}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/api/AttributeManager.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/api/AttributeManager.java
@@ -17,12 +17,20 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import javax.annotation.Nullable;
 
+import com.google.common.collect.Lists;
+
 import org.eclipse.milo.opcua.sdk.server.DiagnosticsContext;
 import org.eclipse.milo.opcua.sdk.server.OpcUaServer;
 import org.eclipse.milo.opcua.sdk.server.Session;
+import org.eclipse.milo.opcua.sdk.server.nodes.AttributeContext;
+import org.eclipse.milo.opcua.sdk.server.nodes.ServerNode;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
 import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.TimestampsToReturn;
+import org.eclipse.milo.opcua.stack.core.types.structured.HistoryReadDetails;
+import org.eclipse.milo.opcua.stack.core.types.structured.HistoryReadResult;
+import org.eclipse.milo.opcua.stack.core.types.structured.HistoryReadValueId;
 import org.eclipse.milo.opcua.stack.core.types.structured.ReadValueId;
 import org.eclipse.milo.opcua.stack.core.types.structured.WriteValue;
 

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/api/Namespace.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/api/Namespace.java
@@ -15,7 +15,8 @@ package org.eclipse.milo.opcua.sdk.server.api;
 
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UShort;
 
-public interface Namespace extends AttributeManager, MethodServices, MonitoredItemManager, NodeManager, ViewManager {
+public interface Namespace extends AttributeManager, AttributeHistoryManager, 
+                                   MethodServices, MonitoredItemManager, NodeManager, ViewManager {
 
     /**
      * @return the index of this {@link Namespace} in the server's namespace array.

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/services/AttributeHistoryServices.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/services/AttributeHistoryServices.java
@@ -1,0 +1,223 @@
+/*
+ * Copyright (c) 2017 Ari Suutari
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *   http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *   http://www.eclipse.org/org/documents/edl-v10.html.
+ */
+
+package org.eclipse.milo.opcua.sdk.server.services;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+
+import org.eclipse.milo.opcua.sdk.server.DiagnosticsContext;
+import org.eclipse.milo.opcua.sdk.server.OpcUaServer;
+import org.eclipse.milo.opcua.sdk.server.Session;
+import org.eclipse.milo.opcua.sdk.server.api.AttributeHistoryManager.HistoryReadContext;
+import org.eclipse.milo.opcua.sdk.server.api.AttributeHistoryManager.HistoryUpdateContext;
+import org.eclipse.milo.opcua.sdk.server.api.Namespace;
+import org.eclipse.milo.opcua.sdk.server.util.PendingHistoryRead;
+import org.eclipse.milo.opcua.sdk.server.util.PendingHistoryUpdate;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
+import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.application.services.AttributeHistoryServiceSet;
+import org.eclipse.milo.opcua.stack.core.application.services.ServiceRequest;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DiagnosticInfo;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UShort;
+import org.eclipse.milo.opcua.stack.core.types.structured.HistoryReadDetails;
+import org.eclipse.milo.opcua.stack.core.types.structured.HistoryReadRequest;
+import org.eclipse.milo.opcua.stack.core.types.structured.HistoryReadResponse;
+import org.eclipse.milo.opcua.stack.core.types.structured.HistoryReadResult;
+import org.eclipse.milo.opcua.stack.core.types.structured.HistoryReadValueId;
+import org.eclipse.milo.opcua.stack.core.types.structured.HistoryUpdateDetails;
+import org.eclipse.milo.opcua.stack.core.types.structured.HistoryUpdateRequest;
+import org.eclipse.milo.opcua.stack.core.types.structured.HistoryUpdateResponse;
+import org.eclipse.milo.opcua.stack.core.types.structured.HistoryUpdateResult;
+import org.eclipse.milo.opcua.stack.core.types.structured.ResponseHeader;
+import org.eclipse.milo.opcua.stack.core.util.FutureUtils;
+
+import static com.google.common.collect.Lists.newArrayListWithCapacity;
+import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.toList;
+import static org.eclipse.milo.opcua.stack.core.util.ConversionUtil.a;
+import static org.eclipse.milo.opcua.stack.core.util.ConversionUtil.l;
+
+public class AttributeHistoryServices implements AttributeHistoryServiceSet {
+
+    private final ServiceMetric historyReadMetric = new ServiceMetric();
+    private final ServiceMetric historyUpdateMetric = new ServiceMetric();
+
+    @Override
+    public void onHistoryRead(ServiceRequest<HistoryReadRequest, HistoryReadResponse> service) {
+        historyReadMetric.record(service);
+
+        HistoryReadRequest request = service.getRequest();
+
+        DiagnosticsContext<HistoryReadValueId> diagnosticsContext = new DiagnosticsContext<>();
+
+        OpcUaServer server = service.attr(ServiceAttributes.SERVER_KEY).get();
+        Session session = service.attr(ServiceAttributes.SESSION_KEY).get();
+
+        List<HistoryReadValueId> nodesToRead = l(request.getNodesToRead());
+
+        if (nodesToRead.isEmpty()) {
+            service.setServiceFault(StatusCodes.Bad_NothingToDo);
+            return;
+        }
+
+        if (nodesToRead.size() > server.getConfig().getLimits().getMaxNodesPerRead().longValue()) {
+            service.setServiceFault(StatusCodes.Bad_TooManyOperations);
+            return;
+        }
+
+        if (request.getTimestampsToReturn() == null) {
+            service.setServiceFault(StatusCodes.Bad_TimestampsToReturnInvalid);
+            return;
+        }
+
+
+        List<PendingHistoryRead> pendingReads = newArrayListWithCapacity(nodesToRead.size());
+        List<CompletableFuture<HistoryReadResult>> futures = newArrayListWithCapacity(nodesToRead.size());
+
+        for (HistoryReadValueId id : nodesToRead) {
+            PendingHistoryRead pending = new PendingHistoryRead(id);
+
+            pendingReads.add(pending);
+            futures.add(pending.getFuture());
+        }
+
+        // Group PendingReads by namespace and call read for each.
+
+        Map<UShort, List<PendingHistoryRead>> byNamespace = pendingReads.stream()
+            .collect(groupingBy(pending -> pending.getInput().getNodeId().getNamespaceIndex()));
+
+        byNamespace.keySet().forEach(index -> {
+            List<PendingHistoryRead> pending = byNamespace.get(index);
+
+            CompletableFuture<List<HistoryReadResult>> future = new CompletableFuture<>();
+
+            HistoryReadContext context = new HistoryReadContext(
+                server, session, future, diagnosticsContext);
+
+            server.getExecutorService().execute(() -> {
+                Namespace namespace = server.getNamespaceManager().getNamespace(index);
+
+                List<HistoryReadValueId> readValueIds = pending.stream()
+                    .map(PendingHistoryRead::getInput)
+                    .collect(toList());
+
+                namespace.historyRead(
+                    context,
+                    (HistoryReadDetails) request.getHistoryReadDetails().decode(),
+                    request.getTimestampsToReturn(),
+                    readValueIds);
+            });
+
+            future.thenAccept(values -> {
+                for (int i = 0; i < values.size(); i++) {
+                    pending.get(i).getFuture().complete(values.get(i));
+                }
+            });
+        });
+
+        // When all PendingReads have been completed send a HistoryReadResponse with the values.
+
+        FutureUtils.sequence(futures).thenAcceptAsync(values -> {
+            ResponseHeader header = service.createResponseHeader();
+
+            DiagnosticInfo[] diagnosticInfos =
+                diagnosticsContext.getDiagnosticInfos(nodesToRead);
+
+            HistoryReadResponse response = new HistoryReadResponse(
+                header, a(values, HistoryReadResult.class), diagnosticInfos);
+
+            service.setResponse(response);
+        }, server.getExecutorService());
+    }
+    
+    @Override
+    public void onHistoryUpdate(ServiceRequest<HistoryUpdateRequest, HistoryUpdateResponse> service)
+            throws UaException {
+        historyUpdateMetric.record(service);
+
+        HistoryUpdateRequest request = service.getRequest();
+
+        DiagnosticsContext<HistoryUpdateDetails> diagnosticsContext = new DiagnosticsContext<>();
+
+        OpcUaServer server = service.attr(ServiceAttributes.SERVER_KEY).get();
+        Session session = service.attr(ServiceAttributes.SESSION_KEY).get();
+
+        List<HistoryUpdateDetails> nodesToUpdate = l(request.getHistoryUpdateDetails())
+                .stream().map(e -> (HistoryUpdateDetails) e.decode())
+                .collect(Collectors.toList());
+
+        if (nodesToUpdate.isEmpty()) {
+            service.setServiceFault(StatusCodes.Bad_NothingToDo);
+            return;
+        }
+
+        if (nodesToUpdate.size() > server.getConfig().getLimits().getMaxNodesPerWrite().intValue()) {
+            service.setServiceFault(StatusCodes.Bad_TooManyOperations);
+            return;
+        }
+
+        List<PendingHistoryUpdate> pendingUpdates = newArrayListWithCapacity(nodesToUpdate.size());
+        List<CompletableFuture<HistoryUpdateResult>> futures = newArrayListWithCapacity(nodesToUpdate.size());
+
+        for (HistoryUpdateDetails details : nodesToUpdate) {
+            PendingHistoryUpdate pending = new PendingHistoryUpdate(details);
+
+            pendingUpdates.add(pending);
+            futures.add(pending.getFuture());
+        }
+
+        Map<UShort, List<PendingHistoryUpdate>> byNamespace = pendingUpdates.stream()
+            .collect(groupingBy(pending -> pending.getInput().getNodeId().getNamespaceIndex()));
+
+        byNamespace.keySet().forEach(index -> {
+            List<PendingHistoryUpdate> pending = byNamespace.get(index);
+
+            CompletableFuture<List<HistoryUpdateResult>> future = new CompletableFuture<>();
+
+            HistoryUpdateContext context = new HistoryUpdateContext(
+                server, session, future, diagnosticsContext);
+
+            server.getExecutorService().execute(() -> {
+                Namespace namespace = server.getNamespaceManager().getNamespace(index);
+
+                List<HistoryUpdateDetails> updateDetails = pending.stream()
+                    .map(PendingHistoryUpdate::getInput)
+                    .collect(toList());
+
+                namespace.historyUpdate(context, updateDetails);
+            });
+
+            future.thenAccept(statusCodes -> {
+                for (int i = 0; i < statusCodes.size(); i++) {
+                    pending.get(i).getFuture().complete(statusCodes.get(i));
+                }
+            });
+        });
+
+        FutureUtils.sequence(futures).thenAcceptAsync(values -> {
+            ResponseHeader header = service.createResponseHeader();
+
+            DiagnosticInfo[] diagnosticInfos =
+                diagnosticsContext.getDiagnosticInfos(nodesToUpdate);
+
+            HistoryUpdateResponse response = new HistoryUpdateResponse(
+                header, a(values, HistoryUpdateResult.class), diagnosticInfos);
+
+            service.setResponse(response);
+        }, server.getExecutorService());
+
+    }
+}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/util/PendingHistoryRead.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/util/PendingHistoryRead.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2017 Ari Suutari
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *   http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *   http://www.eclipse.org/org/documents/edl-v10.html.
+ */
+
+package org.eclipse.milo.opcua.sdk.server.util;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.eclipse.milo.opcua.stack.core.types.structured.HistoryReadResult;
+import org.eclipse.milo.opcua.stack.core.types.structured.HistoryReadValueId;
+
+public class PendingHistoryRead implements Pending<HistoryReadValueId, HistoryReadResult> {
+
+    private final CompletableFuture<HistoryReadResult> future = new CompletableFuture<>();
+
+    private final HistoryReadValueId id;
+
+    public PendingHistoryRead(HistoryReadValueId id) {
+        this.id = id;
+    }
+
+    @Override
+    public HistoryReadValueId getInput() {
+        return id;
+    }
+
+    @Override
+    public CompletableFuture<HistoryReadResult> getFuture() {
+        return future;
+    }
+}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/util/PendingHistoryUpdate.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/util/PendingHistoryUpdate.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2017 Ari Suutari
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *   http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *   http://www.eclipse.org/org/documents/edl-v10.html.
+ */
+
+package org.eclipse.milo.opcua.sdk.server.util;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.eclipse.milo.opcua.stack.core.types.structured.HistoryUpdateDetails;
+import org.eclipse.milo.opcua.stack.core.types.structured.HistoryUpdateResult;
+
+public class PendingHistoryUpdate implements Pending<HistoryUpdateDetails, HistoryUpdateResult> {
+
+    private final CompletableFuture<HistoryUpdateResult> future = new CompletableFuture<>();
+
+    private final HistoryUpdateDetails details;
+
+    public PendingHistoryUpdate(HistoryUpdateDetails details) {
+        this.details = details;
+    }
+
+    @Override
+    public HistoryUpdateDetails getInput() {
+        return details;
+    }
+
+    @Override
+    public CompletableFuture<HistoryUpdateResult> getFuture() {
+        return future;
+    }
+}

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/application/UaStackServer.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/application/UaStackServer.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 
+import org.eclipse.milo.opcua.stack.core.application.services.AttributeHistoryServiceSet;
 import org.eclipse.milo.opcua.stack.core.application.services.AttributeServiceSet;
 import org.eclipse.milo.opcua.stack.core.application.services.DiscoveryServiceSet;
 import org.eclipse.milo.opcua.stack.core.application.services.MethodServiceSet;
@@ -139,6 +140,9 @@ public interface UaStackServer {
     default void addServiceSet(AttributeServiceSet serviceSet) {
         addRequestHandler(ReadRequest.class, serviceSet::onRead);
         addRequestHandler(WriteRequest.class, serviceSet::onWrite);
+    }
+
+    default void addServiceSet(AttributeHistoryServiceSet serviceSet) {
         addRequestHandler(HistoryReadRequest.class, serviceSet::onHistoryRead);
         addRequestHandler(HistoryUpdateRequest.class, serviceSet::onHistoryUpdate);
     }

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/application/services/AttributeHistoryServiceSet.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/application/services/AttributeHistoryServiceSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 Kevin Herron
+ * Copyright (c) 2017 Ari Suutari
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -15,18 +15,22 @@ package org.eclipse.milo.opcua.stack.core.application.services;
 
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.UaException;
-import org.eclipse.milo.opcua.stack.core.types.structured.ReadRequest;
-import org.eclipse.milo.opcua.stack.core.types.structured.ReadResponse;
-import org.eclipse.milo.opcua.stack.core.types.structured.WriteRequest;
-import org.eclipse.milo.opcua.stack.core.types.structured.WriteResponse;
+import org.eclipse.milo.opcua.stack.core.types.structured.HistoryReadRequest;
+import org.eclipse.milo.opcua.stack.core.types.structured.HistoryReadResponse;
+import org.eclipse.milo.opcua.stack.core.types.structured.HistoryUpdateRequest;
+import org.eclipse.milo.opcua.stack.core.types.structured.HistoryUpdateResponse;
 
-public interface AttributeServiceSet {
+public interface AttributeHistoryServiceSet {
 
-    default void onRead(ServiceRequest<ReadRequest, ReadResponse> serviceRequest) throws UaException {
+    default void onHistoryRead(
+        ServiceRequest<HistoryReadRequest, HistoryReadResponse> serviceRequest) throws UaException {
+
         serviceRequest.setServiceFault(StatusCodes.Bad_ServiceUnsupported);
     }
 
-    default void onWrite(ServiceRequest<WriteRequest, WriteResponse> serviceRequest) throws UaException {
+    default void onHistoryUpdate(
+        ServiceRequest<HistoryUpdateRequest, HistoryUpdateResponse> serviceRequest) throws UaException {
+
         serviceRequest.setServiceFault(StatusCodes.Bad_ServiceUnsupported);
     }
 


### PR DESCRIPTION
This adds functionality that is required to get the historyRead request to arrive at namespace implementation. It works for me, but I'm not happy about the default historyRead implementation
in AtttributeManager, which just returns StatusCode.BAD for all requested items. I guess it should be polished to return Bad_NotSupported at operation level (but that wouldn't be perfect either, because there might be one namespace that supports history and another that doesn't).

Signed-off-by: Ari Suutari <ari.suutari@syncrontech.com>