### PR TITLE
Add support for configuring a certificate chain on client and server

### DIFF
--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/api/config/OpcUaClientConfig.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/api/config/OpcUaClientConfig.java
@@ -76,6 +76,7 @@ public interface OpcUaClientConfig extends UaTcpStackClientConfig {
         config.getEndpoint().ifPresent(builder::setEndpoint);
         config.getKeyPair().ifPresent(builder::setKeyPair);
         config.getCertificate().ifPresent(builder::setCertificate);
+        config.getCertificateChain().ifPresent(builder::setCertificateChain);
         builder.setApplicationName(config.getApplicationName());
         builder.setApplicationUri(config.getApplicationUri());
         builder.setProductUri(config.getProductUri());

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/api/config/OpcUaClientConfigBuilder.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/api/config/OpcUaClientConfigBuilder.java
@@ -249,6 +249,11 @@ public class OpcUaClientConfigBuilder extends UaTcpStackClientConfigBuilder {
         }
 
         @Override
+        public Optional<X509Certificate[]> getCertificateChain() {
+            return stackClientConfig.getCertificateChain();
+        }
+
+        @Override
         public LocalizedText getApplicationName() {
             return stackClientConfig.getApplicationName();
         }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/api/config/OpcUaClientConfigBuilder.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/api/config/OpcUaClientConfigBuilder.java
@@ -97,6 +97,12 @@ public class OpcUaClientConfigBuilder extends UaTcpStackClientConfigBuilder {
     }
 
     @Override
+    public OpcUaClientConfigBuilder setCertificateChain(X509Certificate[] certificateChain) {
+        super.setCertificateChain(certificateChain);
+        return this;
+    }
+
+    @Override
     public OpcUaClientConfigBuilder setApplicationName(LocalizedText applicationName) {
         super.setApplicationName(applicationName);
         return this;

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/OpcUaServer.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/OpcUaServer.java
@@ -224,6 +224,10 @@ public class OpcUaServer {
         return stackServer.getCertificateManager().getCertificate(thumbprint);
     }
 
+    public Optional<X509Certificate[]> getCertificateChain(ByteString thumbprint) {
+        return stackServer.getCertificateManager().getCertificateChain(thumbprint);
+    }
+
     public ExecutorService getExecutorService() {
         return stackServer.getExecutorService();
     }
@@ -310,6 +314,7 @@ public class OpcUaServer {
         return hostnames;
     }
 
-    private static class OpcUaServerNodeMap extends AbstractServerNodeMap {}
+    private static class OpcUaServerNodeMap extends AbstractServerNodeMap {
+    }
 
 }

--- a/opc-ua-stack/stack-client/src/main/java/org/eclipse/milo/opcua/stack/client/config/UaTcpStackClientConfig.java
+++ b/opc-ua-stack/stack-client/src/main/java/org/eclipse/milo/opcua/stack/client/config/UaTcpStackClientConfig.java
@@ -63,6 +63,13 @@ public interface UaTcpStackClientConfig {
     Optional<X509Certificate> getCertificate();
 
     /**
+     * Get the {@link X509Certificate} to use as well as any certificates in the certificate chain.
+     *
+     * @return the {@link X509Certificate} to use as well as any certificates in the certificate chain.
+     */
+    Optional<X509Certificate[]> getCertificateChain();
+
+    /**
      * @return the name of the client application, as a {@link LocalizedText}.
      */
     LocalizedText getApplicationName();
@@ -137,6 +144,7 @@ public interface UaTcpStackClientConfig {
         config.getEndpoint().ifPresent(builder::setEndpoint);
         config.getKeyPair().ifPresent(builder::setKeyPair);
         config.getCertificate().ifPresent(builder::setCertificate);
+        config.getCertificateChain().ifPresent(builder::setCertificateChain);
         builder.setApplicationName(config.getApplicationName());
         builder.setApplicationUri(config.getApplicationUri());
         builder.setProductUri(config.getProductUri());

--- a/opc-ua-stack/stack-client/src/main/java/org/eclipse/milo/opcua/stack/client/config/UaTcpStackClientConfigBuilder.java
+++ b/opc-ua-stack/stack-client/src/main/java/org/eclipse/milo/opcua/stack/client/config/UaTcpStackClientConfigBuilder.java
@@ -71,7 +71,6 @@ public class UaTcpStackClientConfigBuilder {
 
     public UaTcpStackClientConfigBuilder setCertificateChain(X509Certificate[] certificateChain) {
         this.certificateChain = certificateChain;
-        this.certificate = certificateChain != null ? certificateChain[0] : null;
         return this;
     }
 
@@ -224,7 +223,15 @@ public class UaTcpStackClientConfigBuilder {
 
         @Override
         public Optional<X509Certificate[]> getCertificateChain() {
-            return Optional.ofNullable(certificateChain);
+            if (certificateChain != null) {
+                return Optional.of(certificateChain);
+            } else {
+                if (certificate != null) {
+                    return Optional.of(new X509Certificate[]{certificate});
+                } else {
+                    return Optional.empty();
+                }
+            }
         }
 
         @Override

--- a/opc-ua-stack/stack-client/src/main/java/org/eclipse/milo/opcua/stack/client/config/UaTcpStackClientConfigBuilder.java
+++ b/opc-ua-stack/stack-client/src/main/java/org/eclipse/milo/opcua/stack/client/config/UaTcpStackClientConfigBuilder.java
@@ -71,7 +71,7 @@ public class UaTcpStackClientConfigBuilder {
 
     public UaTcpStackClientConfigBuilder setCertificateChain(X509Certificate[] certificateChain) {
         this.certificateChain = certificateChain;
-        this.certificate = certificateChain[0];
+        this.certificate = certificateChain != null ? certificateChain[0] : null;
         return this;
     }
 

--- a/opc-ua-stack/stack-client/src/main/java/org/eclipse/milo/opcua/stack/client/config/UaTcpStackClientConfigBuilder.java
+++ b/opc-ua-stack/stack-client/src/main/java/org/eclipse/milo/opcua/stack/client/config/UaTcpStackClientConfigBuilder.java
@@ -35,6 +35,7 @@ public class UaTcpStackClientConfigBuilder {
     private EndpointDescription endpoint;
     private KeyPair keyPair;
     private X509Certificate certificate;
+    private X509Certificate[] certificateChain;
 
     private LocalizedText applicationName = LocalizedText.english("client application name not configured");
     private String applicationUri = "client application uri not configured";
@@ -65,6 +66,12 @@ public class UaTcpStackClientConfigBuilder {
 
     public UaTcpStackClientConfigBuilder setCertificate(X509Certificate certificate) {
         this.certificate = certificate;
+        return this;
+    }
+
+    public UaTcpStackClientConfigBuilder setCertificateChain(X509Certificate[] certificateChain) {
+        this.certificateChain = certificateChain;
+        this.certificate = certificateChain[0];
         return this;
     }
 
@@ -131,6 +138,7 @@ public class UaTcpStackClientConfigBuilder {
             endpoint,
             keyPair,
             certificate,
+            certificateChain,
             applicationName,
             applicationUri,
             productUri,
@@ -148,6 +156,7 @@ public class UaTcpStackClientConfigBuilder {
         private final EndpointDescription endpoint;
         private final KeyPair keyPair;
         private final X509Certificate certificate;
+        private final X509Certificate[] certificateChain;
 
         private final LocalizedText applicationName;
         private final String applicationUri;
@@ -166,6 +175,7 @@ public class UaTcpStackClientConfigBuilder {
             @Nullable EndpointDescription endpoint,
             @Nullable KeyPair keyPair,
             @Nullable X509Certificate certificate,
+            @Nullable X509Certificate[] certificateChain,
             LocalizedText applicationName,
             String applicationUri,
             String productUri,
@@ -180,6 +190,7 @@ public class UaTcpStackClientConfigBuilder {
             this.endpoint = endpoint;
             this.keyPair = keyPair;
             this.certificate = certificate;
+            this.certificateChain = certificateChain;
             this.applicationName = applicationName;
             this.applicationUri = applicationUri;
             this.productUri = productUri;
@@ -209,6 +220,11 @@ public class UaTcpStackClientConfigBuilder {
         @Override
         public Optional<X509Certificate> getCertificate() {
             return Optional.ofNullable(certificate);
+        }
+
+        @Override
+        public Optional<X509Certificate[]> getCertificateChain() {
+            return Optional.ofNullable(certificateChain);
         }
 
         @Override

--- a/opc-ua-stack/stack-client/src/main/java/org/eclipse/milo/opcua/stack/client/handlers/UaTcpClientAcknowledgeHandler.java
+++ b/opc-ua-stack/stack-client/src/main/java/org/eclipse/milo/opcua/stack/client/handlers/UaTcpClientAcknowledgeHandler.java
@@ -16,6 +16,7 @@ package org.eclipse.milo.opcua.stack.client.handlers;
 import java.nio.ByteOrder;
 import java.security.KeyPair;
 import java.security.cert.X509Certificate;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -93,11 +94,12 @@ public class UaTcpClientAcknowledgeHandler extends ByteToMessageCodec<UaRequestF
                     }
                 })
                 .flatMap(t1 -> config.getKeyPair().map(t1::concat))
-                .flatMap(t2 -> config.getCertificate().map(t2::concat))
+                .flatMap(t2 -> config.getCertificateChain().map(t2::concat))
                 .flatMap(t3 -> {
                     EndpointDescription endpoint = t3.v1();
                     KeyPair keyPair = t3.v2();
-                    X509Certificate localCertificate = t3.v3();
+                    List<X509Certificate> localCertificateChain = Arrays.asList(t3.v3());
+                    X509Certificate localCertificate = localCertificateChain.get(0);
 
                     try {
                         X509Certificate remoteCertificate = CertificateUtil
@@ -111,6 +113,7 @@ public class UaTcpClientAcknowledgeHandler extends ByteToMessageCodec<UaRequestF
                         ClientSecureChannel secureChannel = new ClientSecureChannel(
                             keyPair,
                             localCertificate,
+                            localCertificateChain,
                             remoteCertificate,
                             remoteCertificateChain,
                             securityPolicy,

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/application/CertificateManager.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/application/CertificateManager.java
@@ -43,6 +43,18 @@ public interface CertificateManager {
     Optional<X509Certificate> getCertificate(ByteString thumbprint);
 
     /**
+     * Get the {@link X509Certificate} identified by {@code thumbprint} as well as any certificates in its chain.
+     *
+     * // TODO remove default implementation in next API-breaking version
+     *
+     * @param thumbprint the thumbprint of the certificate.
+     * @return the {@link X509Certificate} identified by {@code thumbprint} as well as any certificates in its chain.
+     */
+    default Optional<X509Certificate[]> getCertificateChain(ByteString thumbprint) {
+        return getCertificate(thumbprint).map(c -> new X509Certificate[]{c});
+    }
+
+    /**
      * @return the Set of all managed {@link KeyPair}s.
      */
     Set<KeyPair> getKeyPairs();

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/channel/ChunkEncoder.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/channel/ChunkEncoder.java
@@ -270,7 +270,7 @@ public class ChunkEncoder {
         public void encodeSecurityHeader(SecureChannel channel, ByteBuf buffer) throws UaException {
             AsymmetricSecurityHeader header = new AsymmetricSecurityHeader(
                 channel.getSecurityPolicy().getSecurityPolicyUri(),
-                channel.getLocalCertificateBytes(),
+                channel.getLocalCertificateChainBytes(),
                 channel.getRemoteCertificateThumbprint()
             );
 
@@ -280,11 +280,11 @@ public class ChunkEncoder {
         @Override
         public int getSecurityHeaderSize(SecureChannel channel) throws UaException {
             String securityPolicyUri = channel.getSecurityPolicy().getSecurityPolicyUri();
-            byte[] localCertificateBytes = channel.getLocalCertificateBytes().bytes();
+            byte[] localCertificateChainBytes = channel.getLocalCertificateChainBytes().bytes();
             byte[] remoteCertificateThumbprint = channel.getRemoteCertificateThumbprint().bytes();
 
             return 12 + securityPolicyUri.length() +
-                (localCertificateBytes != null ? localCertificateBytes.length : 0) +
+                (localCertificateChainBytes != null ? localCertificateChainBytes.length : 0) +
                 (remoteCertificateThumbprint != null ? remoteCertificateThumbprint.length : 0);
         }
 

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/channel/ClientSecureChannel.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/channel/ClientSecureChannel.java
@@ -39,17 +39,19 @@ public class ClientSecureChannel extends DefaultAttributeMap implements SecureCh
 
     private final KeyPair keyPair;
     private final X509Certificate localCertificate;
+    private final List<X509Certificate> localCertificateChain;
     private final X509Certificate remoteCertificate;
     private final List<X509Certificate> remoteCertificateChain;
     private final SecurityPolicy securityPolicy;
     private final MessageSecurityMode messageSecurityMode;
 
     public ClientSecureChannel(SecurityPolicy securityPolicy, MessageSecurityMode messageSecurityMode) {
-        this(null, null, null, null, securityPolicy, messageSecurityMode);
+        this(null, null, null, null, null, securityPolicy, messageSecurityMode);
     }
 
     public ClientSecureChannel(KeyPair keyPair,
                                X509Certificate localCertificate,
+                               List<X509Certificate> localCertificateChain,
                                X509Certificate remoteCertificate,
                                List<X509Certificate> remoteCertificateChain,
                                SecurityPolicy securityPolicy,
@@ -57,6 +59,7 @@ public class ClientSecureChannel extends DefaultAttributeMap implements SecureCh
 
         this.keyPair = keyPair;
         this.localCertificate = localCertificate;
+        this.localCertificateChain = localCertificateChain;
         this.remoteCertificate = remoteCertificate;
         this.remoteCertificateChain = remoteCertificateChain;
         this.securityPolicy = securityPolicy;
@@ -120,6 +123,11 @@ public class ClientSecureChannel extends DefaultAttributeMap implements SecureCh
     @Override
     public X509Certificate getLocalCertificate() {
         return localCertificate;
+    }
+
+    @Override
+    public List<X509Certificate> getLocalCertificateChain() {
+        return localCertificateChain;
     }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/channel/SecureChannel.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/channel/SecureChannel.java
@@ -109,6 +109,26 @@ public interface SecureChannel {
         }
     }
 
+    default ByteString getRemoteCertificateChainBytes() throws UaException {
+        List<X509Certificate> remoteCertificateChain = getRemoteCertificateChain();
+
+        if (remoteCertificateChain != null) {
+            byte[] encoded = remoteCertificateChain.stream()
+                .map(c -> {
+                    try {
+                        return c.getEncoded();
+                    } catch (CertificateEncodingException e) {
+                        return new byte[0];
+                    }
+                })
+                .reduce(new byte[0], Bytes::concat);
+
+            return ByteString.of(encoded);
+        } else {
+            return ByteString.NULL_VALUE;
+        }
+    }
+
     default ByteString getRemoteCertificateThumbprint() throws UaException {
         try {
             return getRemoteCertificate() != null ?

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/channel/SecureChannel.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/channel/SecureChannel.java
@@ -21,6 +21,7 @@ import java.security.cert.X509Certificate;
 import java.security.interfaces.RSAPublicKey;
 import java.util.List;
 
+import com.google.common.primitives.Bytes;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.security.SecurityAlgorithm;
@@ -34,6 +35,8 @@ public interface SecureChannel {
     KeyPair getKeyPair();
 
     X509Certificate getLocalCertificate();
+
+    List<X509Certificate> getLocalCertificateChain();
 
     X509Certificate getRemoteCertificate();
 
@@ -62,6 +65,26 @@ public interface SecureChannel {
                 ByteString.NULL_VALUE;
         } catch (CertificateEncodingException e) {
             throw new UaException(StatusCodes.Bad_CertificateInvalid, e);
+        }
+    }
+
+    default ByteString getLocalCertificateChainBytes() throws UaException {
+        List<X509Certificate> localCertificateChain = getLocalCertificateChain();
+
+        if (localCertificateChain != null) {
+            byte[] encoded = localCertificateChain.stream()
+                .map(c -> {
+                    try {
+                        return c.getEncoded();
+                    } catch (CertificateEncodingException e) {
+                        return new byte[0];
+                    }
+                })
+                .reduce(new byte[0], Bytes::concat);
+
+            return ByteString.of(encoded);
+        } else {
+            return ByteString.NULL_VALUE;
         }
     }
 

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/channel/ServerSecureChannel.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/channel/ServerSecureChannel.java
@@ -15,6 +15,7 @@ package org.eclipse.milo.opcua.stack.core.channel;
 
 import java.security.KeyPair;
 import java.security.cert.X509Certificate;
+import java.util.Arrays;
 import java.util.List;
 
 import com.google.common.base.MoreObjects;
@@ -35,6 +36,7 @@ public class ServerSecureChannel extends DefaultAttributeMap implements SecureCh
 
     private volatile KeyPair keyPair;
     private volatile X509Certificate localCertificate;
+    private volatile List<X509Certificate> localCertificateChain;
 
     private volatile X509Certificate remoteCertificate;
     private volatile List<X509Certificate> remoteCertificateChain;
@@ -67,6 +69,10 @@ public class ServerSecureChannel extends DefaultAttributeMap implements SecureCh
         this.localCertificate = localCertificate;
     }
 
+    public void setLocalCertificateChain(X509Certificate[] localCertificateChain) {
+        this.localCertificateChain = Arrays.asList(localCertificateChain);
+    }
+
     public void setRemoteCertificate(byte[] certificateBytes) throws UaException {
         remoteCertificate = CertificateUtil.decodeCertificate(certificateBytes);
         remoteCertificateChain = CertificateUtil.decodeCertificates(certificateBytes);
@@ -96,6 +102,11 @@ public class ServerSecureChannel extends DefaultAttributeMap implements SecureCh
     @Override
     public X509Certificate getLocalCertificate() {
         return localCertificate;
+    }
+
+    @Override
+    public List<X509Certificate> getLocalCertificateChain() {
+        return localCertificateChain;
     }
 
     @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/util/CertificateUtil.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/util/CertificateUtil.java
@@ -57,6 +57,28 @@ public class CertificateUtil {
      * @throws UaException if decoding the certificate fails.
      */
     public static X509Certificate decodeCertificate(InputStream inputStream) throws UaException {
+        return decodeCertificates(inputStream).get(0);
+    }
+
+    /**
+     * Decode either a sequence of DER-encoded X.509 certificates or a PKCS#7 certificate chain.
+     *
+     * @param certificateBytes the byte[] to decode from.
+     * @return a {@link List} of certificates deocded from {@code certificateBytes}.
+     * @throws UaException if decoding fails.
+     */
+    public static List<X509Certificate> decodeCertificates(byte[] certificateBytes) throws UaException {
+        return decodeCertificates(new ByteArrayInputStream(certificateBytes));
+    }
+
+    /**
+     * Decode either a sequence of DER-encoded X.509 certificates or a PKCS#7 certificate chain.
+     *
+     * @param inputStream the {@link InputStream} to decode from.
+     * @return a {@link List} of certificates decoded from {@code inputStream}.
+     * @throws UaException if decoding fails.
+     */
+    public static List<X509Certificate> decodeCertificates(InputStream inputStream) throws UaException {
         Preconditions.checkNotNull(inputStream, "inputStream cannot be null");
 
         CertificateFactory factory;
@@ -68,33 +90,8 @@ public class CertificateUtil {
         }
 
         try {
-            return (X509Certificate) factory.generateCertificate(inputStream);
-        } catch (CertificateException | ClassCastException e) {
-            throw new UaException(StatusCodes.Bad_CertificateInvalid, e);
-        }
-    }
-
-    /**
-     * Decode either a sequence of DER-encoded X.509 certificates or a PKCS#7 certificate chain.
-     *
-     * @param certificateBytes the byte[] to decode from.
-     * @return a {@link List} of certificates deocded from {@code certificateBytes}.
-     * @throws UaException if decoding fails.
-     */
-    public static List<X509Certificate> decodeCertificates(byte[] certificateBytes) throws UaException {
-        Preconditions.checkNotNull(certificateBytes, "certificateBytes cannot be null");
-
-        CertificateFactory factory;
-
-        try {
-            factory = CertificateFactory.getInstance("X.509");
-        } catch (CertificateException e) {
-            throw new UaException(StatusCodes.Bad_InternalError, e);
-        }
-
-        try {
             Collection<? extends Certificate> certificates =
-                factory.generateCertificates(new ByteArrayInputStream(certificateBytes));
+                factory.generateCertificates(inputStream);
 
             return certificates.stream()
                 .map(X509Certificate.class::cast)

--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/application/DefaultCertificateManagerTest.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/application/DefaultCertificateManagerTest.java
@@ -1,6 +1,8 @@
 package org.eclipse.milo.opcua.stack.core.application;
 
 import java.security.KeyPair;
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
 
 import org.testng.annotations.Test;
 
@@ -12,7 +14,12 @@ public class DefaultCertificateManagerTest {
     public void testNullPrivateKeyOrCertificateFails() {
         expectThrows(
             Exception.class,
-            () -> new DefaultCertificateManager((KeyPair) null, null)
+            () -> new DefaultCertificateManager((KeyPair) null, (X509Certificate) null)
+        );
+
+        expectThrows(
+            Exception.class,
+            () -> new DefaultCertificateManager().add(null, (X509Certificate) null)
         );
     }
 

--- a/opc-ua-stack/stack-server/src/main/java/org/eclipse/milo/opcua/stack/server/handlers/UaTcpServerAsymmetricHandler.java
+++ b/opc-ua-stack/stack-server/src/main/java/org/eclipse/milo/opcua/stack/server/handlers/UaTcpServerAsymmetricHandler.java
@@ -216,14 +216,17 @@ public class UaTcpServerAsymmetricHandler extends ByteToMessageDecoder implement
             if (!securityHeader.getReceiverThumbprint().isNull()) {
                 CertificateManager certificateManager = server.getCertificateManager();
 
-                Optional<X509Certificate> localCertificate = certificateManager
-                    .getCertificate(securityHeader.getReceiverThumbprint());
+                Optional<X509Certificate[]> localCertificateChain = certificateManager
+                    .getCertificateChain(securityHeader.getReceiverThumbprint());
 
                 Optional<KeyPair> keyPair = certificateManager
                     .getKeyPair(securityHeader.getReceiverThumbprint());
 
-                if (localCertificate.isPresent() && keyPair.isPresent()) {
-                    secureChannel.setLocalCertificate(localCertificate.get());
+                if (localCertificateChain.isPresent() && keyPair.isPresent()) {
+                    X509Certificate[] chain = localCertificateChain.get();
+
+                    secureChannel.setLocalCertificate(chain[0]);
+                    secureChannel.setLocalCertificateChain(chain);
                     secureChannel.setKeyPair(keyPair.get());
                 } else {
                     throw new UaException(StatusCodes.Bad_SecurityChecksFailed,

--- a/opc-ua-stack/stack-server/src/main/java/org/eclipse/milo/opcua/stack/server/handlers/UaTcpServerAsymmetricHandler.java
+++ b/opc-ua-stack/stack-server/src/main/java/org/eclipse/milo/opcua/stack/server/handlers/UaTcpServerAsymmetricHandler.java
@@ -167,7 +167,7 @@ public class UaTcpServerAsymmetricHandler extends ByteToMessageDecoder implement
                         "unknown secure channel id: " + secureChannelId);
                 }
 
-                if (!secureChannel.getRemoteCertificateBytes().equals(securityHeader.getSenderCertificate())) {
+                if (!secureChannel.getRemoteCertificateChainBytes().equals(securityHeader.getSenderCertificate())) {
                     throw new UaException(StatusCodes.Bad_SecurityChecksFailed,
                         "certificate requesting renewal did not match existing certificate.");
                 }

--- a/opc-ua-stack/stack-tests/src/test/java/org/eclipse/milo/opcua/stack/SecureChannelFixture.java
+++ b/opc-ua-stack/stack-tests/src/test/java/org/eclipse/milo/opcua/stack/SecureChannelFixture.java
@@ -13,7 +13,8 @@
 
 package org.eclipse.milo.opcua.stack;
 
-import com.google.common.collect.Lists;
+import java.security.cert.X509Certificate;
+
 import org.eclipse.milo.opcua.stack.core.channel.ChannelSecurity;
 import org.eclipse.milo.opcua.stack.core.channel.ClientSecureChannel;
 import org.eclipse.milo.opcua.stack.core.channel.SecureChannel;
@@ -24,6 +25,7 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.MessageSecurityMode;
 import org.eclipse.milo.opcua.stack.core.types.structured.ChannelSecurityToken;
 
+import static com.google.common.collect.Lists.newArrayList;
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
 import static org.eclipse.milo.opcua.stack.core.util.NonceUtil.generateNonce;
 import static org.eclipse.milo.opcua.stack.core.util.NonceUtil.getNonceLength;
@@ -39,8 +41,9 @@ public abstract class SecureChannelFixture extends SecurityFixture {
         ClientSecureChannel clientChannel = new ClientSecureChannel(
             securityPolicy == SecurityPolicy.None ? null : clientKeyPair,
             securityPolicy == SecurityPolicy.None ? null : clientCertificate,
+            securityPolicy == SecurityPolicy.None ? null : newArrayList(clientCertificate),
             securityPolicy == SecurityPolicy.None ? null : serverCertificate,
-            securityPolicy == SecurityPolicy.None ? null : Lists.newArrayList(serverCertificate),
+            securityPolicy == SecurityPolicy.None ? null : newArrayList(serverCertificate),
             securityPolicy,
             messageSecurity
         );
@@ -78,6 +81,7 @@ public abstract class SecureChannelFixture extends SecurityFixture {
 
                 serverChannel.setKeyPair(serverKeyPair);
                 serverChannel.setLocalCertificate(serverCertificate);
+                serverChannel.setLocalCertificateChain(new X509Certificate[]{serverCertificate});
                 serverChannel.setRemoteCertificate(clientCertificateBytes);
 
                 if (messageSecurity != MessageSecurityMode.None) {

--- a/opc-ua-stack/stack-tests/src/test/java/org/eclipse/milo/opcua/stack/client/config/UaTcpStackClientConfigTest.java
+++ b/opc-ua-stack/stack-tests/src/test/java/org/eclipse/milo/opcua/stack/client/config/UaTcpStackClientConfigTest.java
@@ -13,6 +13,7 @@
 
 package org.eclipse.milo.opcua.stack.client.config;
 
+import java.security.cert.X509Certificate;
 import java.util.Optional;
 
 import org.eclipse.milo.opcua.stack.SecurityFixture;
@@ -32,6 +33,7 @@ public class UaTcpStackClientConfigTest extends SecurityFixture {
             .setEndpointUrl("test")
             .setKeyPair(clientKeyPair)
             .setCertificate(clientCertificate)
+            .setCertificateChain(new X509Certificate[]{clientCertificate})
             .setApplicationName(LocalizedText.english("testName"))
             .setApplicationUri("testApplicationUri")
             .setProductUri("testProductUri")
@@ -48,6 +50,7 @@ public class UaTcpStackClientConfigTest extends SecurityFixture {
         assertEquals(copy.getEndpointUrl(), original.getEndpointUrl());
         assertEquals(copy.getKeyPair(), original.getKeyPair());
         assertEquals(copy.getCertificate(), original.getCertificate());
+        assertEquals(copy.getCertificateChain(), original.getCertificateChain());
         assertEquals(copy.getApplicationName(), original.getApplicationName());
         assertEquals(copy.getApplicationUri(), original.getApplicationUri());
         assertEquals(copy.getProductUri(), original.getProductUri());
@@ -82,6 +85,7 @@ public class UaTcpStackClientConfigTest extends SecurityFixture {
             builder -> builder.setEndpointUrl("foo")
                 .setKeyPair(null)
                 .setCertificate(null)
+                .setCertificateChain(null)
                 .setApplicationName(LocalizedText.english("fooName"))
                 .setApplicationUri("fooApplicationUri")
                 .setProductUri("fooProductUri")
@@ -92,6 +96,7 @@ public class UaTcpStackClientConfigTest extends SecurityFixture {
         assertEquals(copy.getEndpointUrl(), Optional.of("foo"));
         assertEquals(copy.getKeyPair(), Optional.empty());
         assertEquals(copy.getCertificate(), Optional.empty());
+        assertEquals(copy.getCertificateChain(), Optional.empty());
         assertEquals(copy.getApplicationName(), LocalizedText.english("fooName"));
         assertEquals(copy.getApplicationUri(), "fooApplicationUri");
         assertEquals(copy.getProductUri(), "fooProductUri");


### PR DESCRIPTION
Client certificate chains are configured in the UaTcpStackClientConfig.

Server certificate chains are configured in the CertificateManager that
UaTcpStackServerConfig provides.