### PR TITLE
Fix handling of colons in qualified names

### DIFF
--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/builtin/QualifiedName.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/builtin/QualifiedName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 Kevin Herron
+ * Copyright (c) 2016 Kevin Herron and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -106,7 +106,7 @@ public final class QualifiedName {
     }
 
     public static QualifiedName parse(String s) {
-        String[] ss = s.split(":");
+        String[] ss = s.split(":", 2);
 
         int namespaceIndex = 0;
         String name = s;

--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/types/builtin/QualifiedNameTest.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/types/builtin/QualifiedNameTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2017 Red Hat Inc
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *   http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *   http://www.eclipse.org/org/documents/edl-v10.html.
+ */
+
+package org.eclipse.milo.opcua.stack.core.types.builtin;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class QualifiedNameTest {
+
+    @Test
+    public void testToStringAndBack1() {
+        assertSymmetry("0:foo");
+    }
+
+    @Test
+    public void testToStringAndBack2() {
+        assertSymmetry("0:foo:bar");
+    }
+
+    private void assertSymmetry(String string) {
+        String reString = QualifiedName.parse(string).toParseableString();
+        Assert.assertEquals(reString, string);
+    }
+
+}


### PR DESCRIPTION
I think there is a bug in the qualified name parsing. It looks to me as if only the first colon should be special. However I didn't check that in the spec. @kevinherron you might know this.