### PR TITLE
Allow receiving the OpcUaClient type

### DIFF
--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/OpcUaClient.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/OpcUaClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 Kevin Herron
+ * Copyright (c) 2016 Kevin Herron and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -207,13 +207,13 @@ public class OpcUaClient implements UaClient {
     }
 
     @Override
-    public CompletableFuture<UaClient> connect() {
+    public CompletableFuture<OpcUaClient> connect() {
         return stackClient.connect().thenCompose(
             c -> getSession().thenApply(s -> OpcUaClient.this));
     }
 
     @Override
-    public CompletableFuture<UaClient> disconnect() {
+    public CompletableFuture<OpcUaClient> disconnect() {
         // Subscriptions must be cleared first, effectively stopping new
         // PublishRequests from being sent, otherwise continued PublishRequests
         // will initiate reconnection and re-activation.
@@ -222,7 +222,7 @@ public class OpcUaClient implements UaClient {
         return sessionManager
             .closeSession()
             .thenCompose(v -> stackClient.disconnect())
-            .thenApply(c -> (UaClient) OpcUaClient.this)
+            .thenApply(c -> OpcUaClient.this)
             .exceptionally(ex -> OpcUaClient.this);
     }
 

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/api/UaClient.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/api/UaClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 Kevin Herron
+ * Copyright (c) 2016 Kevin Herron and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -40,14 +40,14 @@ public interface UaClient extends AttributeServices,
      *
      * @return a {@link CompletableFuture} holding this client instance.
      */
-    CompletableFuture<UaClient> connect();
+    CompletableFuture<? extends UaClient> connect();
 
     /**
      * Disconnect from the configured endpoint.
      *
      * @return a {@link CompletableFuture} holding this client instance.
      */
-    CompletableFuture<UaClient> disconnect();
+    CompletableFuture<? extends UaClient> disconnect();
 
     /**
      * @return a {@link CompletableFuture} holding the {@link UaSession}.


### PR DESCRIPTION
This change allows to actually receive the OpcUaClient type when the client supports that:

```java
public CompletableFuture<OpcUaClient> createClient() { … }

// before

public static CompletableFuture<UaClient> connect() {
  return createClient().thenCompose(client -> client.connect());
}

// after

public static CompletableFuture<OpcUaClient> connect() {
  return createClient().thenCompose(client -> client.connect());
}
```