### PR TITLE
Implement new Sha2-based security profiles

### DIFF
--- a/milo-examples/client-examples/pom.xml
+++ b/milo-examples/client-examples/pom.xml
@@ -41,5 +41,10 @@
             <artifactId>logback-classic</artifactId>
             <version>1.1.7</version>
         </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk15on</artifactId>
+            <version>1.56</version>
+        </dependency>
     </dependencies>
 </project>

--- a/milo-examples/client-examples/src/main/java/org/eclipse/milo/examples/client/ClientExampleRunner.java
+++ b/milo-examples/client-examples/src/main/java/org/eclipse/milo/examples/client/ClientExampleRunner.java
@@ -14,11 +14,13 @@
 package org.eclipse.milo.examples.client;
 
 import java.io.File;
+import java.security.Security;
 import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.eclipse.milo.examples.server.ExampleServer;
 import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
 import org.eclipse.milo.opcua.sdk.client.api.config.OpcUaClientConfig;
@@ -27,12 +29,20 @@ import org.eclipse.milo.opcua.stack.core.Stack;
 import org.eclipse.milo.opcua.stack.core.security.SecurityPolicy;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.structured.EndpointDescription;
+import org.eclipse.milo.opcua.stack.core.util.CryptoRestrictions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
 
 public class ClientExampleRunner {
+
+    static {
+        CryptoRestrictions.remove();
+
+        // Required for SecurityPolicy.Aes256_Sha256_RsaPss
+        Security.addProvider(new BouncyCastleProvider());
+    }
 
     private final Logger logger = LoggerFactory.getLogger(getClass());
 

--- a/milo-examples/server-examples/pom.xml
+++ b/milo-examples/server-examples/pom.xml
@@ -36,6 +36,11 @@
             <artifactId>logback-classic</artifactId>
             <version>1.1.7</version>
         </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk15on</artifactId>
+            <version>1.56</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -44,6 +49,18 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <version>2.3</version>
+                <configuration>
+                    <filters>
+                        <filter>
+                            <artifact>*:*</artifact>
+                            <excludes>
+                                <exclude>META-INF/*.SF</exclude>
+                                <exclude>META-INF/*.DSA</exclude>
+                                <exclude>META-INF/*.RSA</exclude>
+                            </excludes>
+                        </filter>
+                    </filters>
+                </configuration>
                 <executions>
                     <execution>
                         <phase>package</phase>

--- a/milo-examples/server-examples/src/main/java/org/eclipse/milo/examples/server/ExampleServer.java
+++ b/milo-examples/server-examples/src/main/java/org/eclipse/milo/examples/server/ExampleServer.java
@@ -14,11 +14,13 @@
 package org.eclipse.milo.examples.server;
 
 import java.io.File;
+import java.security.Security;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 import com.google.common.collect.ImmutableList;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.eclipse.milo.opcua.sdk.server.OpcUaServer;
 import org.eclipse.milo.opcua.sdk.server.api.config.OpcUaServerConfig;
 import org.eclipse.milo.opcua.sdk.server.identity.CompositeValidator;
@@ -41,6 +43,13 @@ import static org.eclipse.milo.opcua.sdk.server.api.config.OpcUaServerConfig.USE
 
 public class ExampleServer {
 
+    static {
+        CryptoRestrictions.remove();
+
+        // Required for SecurityPolicy.Aes256_Sha256_RsaPss
+        Security.addProvider(new BouncyCastleProvider());
+    }
+
     public static void main(String[] args) throws Exception {
         ExampleServer server = new ExampleServer();
 
@@ -56,8 +65,6 @@ public class ExampleServer {
     private final OpcUaServer server;
 
     public ExampleServer() throws Exception {
-        CryptoRestrictions.remove();
-
         File securityTempDir = new File(System.getProperty("java.io.tmpdir"), "security");
         LoggerFactory.getLogger(getClass()).info("security temp dir: {}", securityTempDir.getAbsolutePath());
 
@@ -117,7 +124,9 @@ public class ExampleServer {
                     SecurityPolicy.None,
                     SecurityPolicy.Basic128Rsa15,
                     SecurityPolicy.Basic256,
-                    SecurityPolicy.Basic256Sha256))
+                    SecurityPolicy.Basic256Sha256,
+                    SecurityPolicy.Aes128_Sha256_RsaOaep,
+                    SecurityPolicy.Aes256_Sha256_RsaPss))
             .setUserTokenPolicies(
                 ImmutableList.of(
                     USER_TOKEN_POLICY_ANONYMOUS,

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/api/identity/UsernameProvider.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/api/identity/UsernameProvider.java
@@ -160,8 +160,10 @@ public class UsernameProvider implements IdentityProvider {
         switch (algorithm) {
             case Rsa15:
                 return (getAsymmetricKeyLength(certificate) + 1) / 8 - 11;
-            case RsaOaep:
+            case RsaOaepSha1:
                 return (getAsymmetricKeyLength(certificate) + 1) / 8 - 42;
+            case RsaOaepSha256:
+                return (getAsymmetricKeyLength(certificate) + 1) / 8 - 66;
             default:
                 return 1;
         }
@@ -172,7 +174,8 @@ public class UsernameProvider implements IdentityProvider {
 
         switch (algorithm) {
             case Rsa15:
-            case RsaOaep:
+            case RsaOaepSha1:
+            case RsaOaepSha256:
                 return (getAsymmetricKeyLength(certificate) + 1) / 8;
             default:
                 return 1;

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/api/identity/X509IdentityProvider.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/api/identity/X509IdentityProvider.java
@@ -77,10 +77,11 @@ public class X509IdentityProvider implements IdentityProvider {
             ByteString.of(certificate.getEncoded())
         );
 
-        ByteString serverCertificate = endpoint.getServerCertificate();
-
-        byte[] serverCertificateBytes = serverCertificate.bytes();
-        if (serverCertificateBytes == null) serverCertificateBytes = new byte[0];
+        byte[] serverCertificateBytes = new byte[0];
+        if (!endpoint.getSecurityPolicyUri().equals(SecurityPolicy.None.getSecurityPolicyUri())) {
+            ByteString serverCertificate = endpoint.getServerCertificate();
+            serverCertificateBytes = serverCertificate.bytesOrEmpty();
+        }
 
         byte[] serverNonceBytes = serverNonce.bytes();
         if (serverNonceBytes == null) serverNonceBytes = new byte[0];

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/UsernameIdentityValidator.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/UsernameIdentityValidator.java
@@ -94,7 +94,10 @@ public class UsernameIdentityValidator extends AbstractIdentityValidator {
                 throw new UaException(StatusCodes.Bad_IdentityTokenInvalid);
             }
 
-            if (algorithm != SecurityAlgorithm.Rsa15 && algorithm != SecurityAlgorithm.RsaOaep) {
+            if (algorithm != SecurityAlgorithm.Rsa15 &&
+                algorithm != SecurityAlgorithm.RsaOaepSha1 &&
+                algorithm != SecurityAlgorithm.RsaOaepSha256) {
+
                 throw new UaException(StatusCodes.Bad_IdentityTokenInvalid);
             }
         }

--- a/opc-ua-sdk/sdk-tests/pom.xml
+++ b/opc-ua-sdk/sdk-tests/pom.xml
@@ -36,6 +36,12 @@
             <version>6.9.10</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk15on</artifactId>
+            <version>1.56</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/opc-ua-sdk/sdk-tests/pom.xml
+++ b/opc-ua-sdk/sdk-tests/pom.xml
@@ -39,7 +39,7 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk15on</artifactId>
-            <version>1.56</version>
+            <version>1.58</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/opc-ua-sdk/sdk-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/OpcUaClientIT.java
+++ b/opc-ua-sdk/sdk-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/OpcUaClientIT.java
@@ -15,6 +15,7 @@ package org.eclipse.milo.opcua.sdk.client;
 
 import java.security.KeyStore;
 import java.security.PrivateKey;
+import java.security.Security;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -29,6 +30,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
 
 import com.google.common.collect.ImmutableList;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.eclipse.milo.opcua.sdk.client.api.UaSession;
 import org.eclipse.milo.opcua.sdk.client.api.config.OpcUaClientConfig;
 import org.eclipse.milo.opcua.sdk.client.api.identity.UsernameProvider;
@@ -64,6 +66,7 @@ import org.eclipse.milo.opcua.stack.core.types.structured.MonitoredItemCreateReq
 import org.eclipse.milo.opcua.stack.core.types.structured.MonitoringParameters;
 import org.eclipse.milo.opcua.stack.core.types.structured.ReadValueId;
 import org.eclipse.milo.opcua.stack.core.types.structured.UserTokenPolicy;
+import org.eclipse.milo.opcua.stack.core.util.CryptoRestrictions;
 import org.eclipse.milo.opcua.stack.core.util.FutureUtils;
 import org.eclipse.milo.opcua.stack.server.tcp.SocketServers;
 import org.jooq.lambda.tuple.Tuple2;
@@ -82,6 +85,13 @@ import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
 public class OpcUaClientIT {
+
+    static {
+        CryptoRestrictions.remove();
+
+        // Required for SecurityPolicy.Aes256_Sha256_RsaPss
+        Security.addProvider(new BouncyCastleProvider());
+    }
 
     private final Logger logger = LoggerFactory.getLogger(getClass());
 
@@ -105,15 +115,20 @@ public class OpcUaClientIT {
     }
 
     private void startClient() throws Exception {
-        EndpointDescription[] endpoints = UaTcpStackClient.getEndpoints("opc.tcp://localhost:12686/test-server").get();
+        EndpointDescription[] endpoints = UaTcpStackClient
+            .getEndpoints("opc.tcp://localhost:12686/test-server").get();
 
         EndpointDescription endpoint = Arrays.stream(endpoints)
             .filter(e -> e.getSecurityPolicyUri().equals(SecurityPolicy.None.getSecurityPolicyUri()))
             .findFirst().orElseThrow(() -> new Exception("no desired endpoints returned"));
 
+        KeyStoreLoader loader = new KeyStoreLoader().load();
+
         OpcUaClientConfig clientConfig = OpcUaClientConfig.builder()
-            .setApplicationName(LocalizedText.english("digitalpetri opc-ua client"))
-            .setApplicationUri("urn:digitalpetri:opcua:client")
+            .setApplicationName(LocalizedText.english("Eclipse Milo Test Client"))
+            .setApplicationUri("urn:eclipse:milo:test:client")
+            .setCertificate(loader.getClientCertificate())
+            .setKeyPair(loader.getClientKeyPair())
             .setEndpoint(endpoint)
             .setRequestTimeout(uint(60000))
             .build();
@@ -164,14 +179,21 @@ public class OpcUaClientIT {
         );
 
         OpcUaServerConfig serverConfig = OpcUaServerConfig.builder()
-            .setApplicationName(LocalizedText.english("digitalpetri opc-ua server"))
-            .setApplicationUri("urn:digitalpetri:opcua:server")
+            .setApplicationName(LocalizedText.english("Eclipse Milo Test Server"))
+            .setApplicationUri("urn:eclipse:milo:examples:server")
             .setBindAddresses(newArrayList("localhost"))
             .setEndpointAddresses(newArrayList("localhost"))
             .setBindPort(12686)
             .setCertificateManager(certificateManager)
             .setCertificateValidator(certificateValidator)
-            .setSecurityPolicies(EnumSet.of(SecurityPolicy.None, SecurityPolicy.Basic128Rsa15))
+            .setSecurityPolicies(
+                EnumSet.of(
+                    SecurityPolicy.None,
+                    SecurityPolicy.Basic128Rsa15,
+                    SecurityPolicy.Basic256,
+                    SecurityPolicy.Basic256Sha256,
+                    SecurityPolicy.Aes128_Sha256_RsaOaep,
+                    SecurityPolicy.Aes256_Sha256_RsaPss))
             .setProductUri("urn:digitalpetri:opcua:sdk")
             .setServerName("test-server")
             .setUserTokenPolicies(userTokenPolicies)
@@ -417,8 +439,8 @@ public class OpcUaClientIT {
         KeyStoreLoader loader = new KeyStoreLoader().load();
 
         OpcUaClientConfig clientConfig = OpcUaClientConfig.builder()
-            .setApplicationName(LocalizedText.english("digitalpetri opc-ua client"))
-            .setApplicationUri("urn:digitalpetri:opcua:client")
+            .setApplicationName(LocalizedText.english("Eclipse Milo Test Client"))
+            .setApplicationUri("urn:eclipse:milo:test:client")
             .setCertificate(loader.getClientCertificate())
             .setKeyPair(loader.getClientKeyPair())
             .setEndpoint(endpoint)
@@ -449,12 +471,44 @@ public class OpcUaClientIT {
         String user = new String(cs);
         String pass = new String(cs);
 
+
+        KeyStoreLoader loader = new KeyStoreLoader().load();
+
         OpcUaClientConfig clientConfig = OpcUaClientConfig.builder()
-            .setApplicationName(LocalizedText.english("digitalpetri opc-ua client"))
-            .setApplicationUri("urn:digitalpetri:opcua:client")
+            .setApplicationName(LocalizedText.english("Eclipse Milo Test Client"))
+            .setApplicationUri("urn:eclipse:milo:test:client")
+            .setCertificate(loader.getClientCertificate())
+            .setKeyPair(loader.getClientKeyPair())
             .setEndpoint(endpoint)
             .setRequestTimeout(uint(60000))
             .setIdentityProvider(new UsernameProvider(user, pass))
+            .build();
+
+        OpcUaClient client = new OpcUaClient(clientConfig);
+
+        client.connect().get();
+    }
+
+    @Test
+    public void testUsernamePassword_WithSecurity() throws Exception {
+        logger.info("testUsernamePassword_WithSecurity()");
+
+        EndpointDescription[] endpoints = UaTcpStackClient.getEndpoints("opc.tcp://localhost:12686/test-server").get();
+
+        EndpointDescription endpoint = Arrays.stream(endpoints)
+            .filter(e -> e.getSecurityPolicyUri().equals(SecurityPolicy.Aes256_Sha256_RsaPss.getSecurityPolicyUri()))
+            .findFirst().orElseThrow(() -> new Exception("no desired endpoints returned"));
+
+        KeyStoreLoader loader = new KeyStoreLoader().load();
+
+        OpcUaClientConfig clientConfig = OpcUaClientConfig.builder()
+            .setApplicationName(LocalizedText.english("Eclipse Milo Test Client"))
+            .setApplicationUri("urn:eclipse:milo:test:client")
+            .setCertificate(loader.getClientCertificate())
+            .setKeyPair(loader.getClientKeyPair())
+            .setEndpoint(endpoint)
+            .setRequestTimeout(uint(60000))
+            .setIdentityProvider(new UsernameProvider("user", "password"))
             .build();
 
         OpcUaClient client = new OpcUaClient(clientConfig);
@@ -490,13 +544,17 @@ public class OpcUaClientIT {
         X509Certificate identityCertificate = (X509Certificate) keyStore.getCertificate("identity");
         PrivateKey identityPrivateKey = (PrivateKey) keyStore.getKey("identity", "password".toCharArray());
 
+        KeyStoreLoader loader = new KeyStoreLoader().load();
+
         OpcUaClientConfig clientConfig = OpcUaClientConfig.builder()
-            .setApplicationName(LocalizedText.english("eclipse milo opc-ua client"))
-            .setApplicationUri("urn:eclipse:milo:examples:client")
+            .setApplicationName(LocalizedText.english("Eclipse Milo Test Client"))
+            .setApplicationUri("urn:eclipse:milo:test:client")
             .setEndpoint(endpoint)
             .setKeyPair(loader.getClientKeyPair())
             .setCertificate(loader.getClientCertificate())
             .setRequestTimeout(uint(60000))
+            .setCertificate(loader.getClientCertificate())
+            .setKeyPair(loader.getClientKeyPair())
             .setIdentityProvider(new X509IdentityProvider(identityCertificate, identityPrivateKey))
             .build();
 
@@ -523,8 +581,8 @@ public class OpcUaClientIT {
             }
 
             private OpcUaClientConfig clientConfig = OpcUaClientConfig.builder()
-                .setApplicationName(LocalizedText.english("digitalpetri opc-ua client"))
-                .setApplicationUri("urn:digitalpetri:opcua:client")
+                .setApplicationName(LocalizedText.english("Eclipse Milo Test Client"))
+                .setApplicationUri("urn:eclipse:milo:test:client")
                 .setEndpoint(endpoint)
                 .setRequestTimeout(uint(10000))
                 .build();
@@ -579,8 +637,8 @@ public class OpcUaClientIT {
             .findFirst().orElseThrow(() -> new Exception("no desired endpoints returned"));
 
         OpcUaClientConfig clientConfig = OpcUaClientConfig.builder()
-            .setApplicationName(LocalizedText.english("digitalpetri opc-ua client"))
-            .setApplicationUri("urn:digitalpetri:opcua:client")
+            .setApplicationName(LocalizedText.english("Eclipse Milo Test Client"))
+            .setApplicationUri("urn:eclipse:milo:test:client")
             .setEndpoint(endpoint)
             .setRequestTimeout(uint(10000))
             .build();

--- a/opc-ua-sdk/sdk-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/OpcUaClientIT.java
+++ b/opc-ua-sdk/sdk-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/OpcUaClientIT.java
@@ -126,7 +126,7 @@ public class OpcUaClientIT {
 
         OpcUaClientConfig clientConfig = OpcUaClientConfig.builder()
             .setApplicationName(LocalizedText.english("Eclipse Milo Test Client"))
-            .setApplicationUri("urn:eclipse:milo:test:client")
+            .setApplicationUri("urn:eclipse:milo:examples:client")
             .setCertificate(loader.getClientCertificate())
             .setKeyPair(loader.getClientKeyPair())
             .setEndpoint(endpoint)
@@ -503,7 +503,7 @@ public class OpcUaClientIT {
 
         OpcUaClientConfig clientConfig = OpcUaClientConfig.builder()
             .setApplicationName(LocalizedText.english("Eclipse Milo Test Client"))
-            .setApplicationUri("urn:eclipse:milo:test:client")
+            .setApplicationUri("urn:eclipse:milo:examples:client")
             .setCertificate(loader.getClientCertificate())
             .setKeyPair(loader.getClientKeyPair())
             .setEndpoint(endpoint)
@@ -544,11 +544,9 @@ public class OpcUaClientIT {
         X509Certificate identityCertificate = (X509Certificate) keyStore.getCertificate("identity");
         PrivateKey identityPrivateKey = (PrivateKey) keyStore.getKey("identity", "password".toCharArray());
 
-        KeyStoreLoader loader = new KeyStoreLoader().load();
-
         OpcUaClientConfig clientConfig = OpcUaClientConfig.builder()
             .setApplicationName(LocalizedText.english("Eclipse Milo Test Client"))
-            .setApplicationUri("urn:eclipse:milo:test:client")
+            .setApplicationUri("urn:eclipse:milo:examples:client")
             .setEndpoint(endpoint)
             .setKeyPair(loader.getClientKeyPair())
             .setCertificate(loader.getClientCertificate())

--- a/opc-ua-stack/stack-client/src/main/java/org/eclipse/milo/opcua/stack/client/handlers/UaTcpClientMessageHandler.java
+++ b/opc-ua-stack/stack-client/src/main/java/org/eclipse/milo/opcua/stack/client/handlers/UaTcpClientMessageHandler.java
@@ -50,7 +50,6 @@ import org.eclipse.milo.opcua.stack.core.channel.headers.HeaderDecoder;
 import org.eclipse.milo.opcua.stack.core.channel.messages.ErrorMessage;
 import org.eclipse.milo.opcua.stack.core.channel.messages.MessageType;
 import org.eclipse.milo.opcua.stack.core.channel.messages.TcpMessageDecoder;
-import org.eclipse.milo.opcua.stack.core.security.SecurityAlgorithm;
 import org.eclipse.milo.opcua.stack.core.security.SecurityPolicy;
 import org.eclipse.milo.opcua.stack.core.serialization.UaResponseMessage;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
@@ -193,11 +192,8 @@ public class UaTcpClientMessageHandler extends ByteToMessageCodec<UaRequestFutur
     private void sendOpenSecureChannelRequest(ChannelHandlerContext ctx, SecurityTokenRequestType requestType) {
         openSecureChannelRequestPending = true;
 
-        SecurityAlgorithm algorithm = secureChannel.getSecurityPolicy().getSymmetricEncryptionAlgorithm();
-        int nonceLength = NonceUtil.getNonceLength(algorithm);
-
         ByteString clientNonce = secureChannel.isSymmetricSigningEnabled() ?
-            NonceUtil.generateNonce(nonceLength) :
+            NonceUtil.generateNonce(secureChannel.getSecurityPolicy()) :
             ByteString.NULL_VALUE;
 
         secureChannel.setLocalNonce(clientNonce);

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/channel/SecureChannel.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/channel/SecureChannel.java
@@ -145,7 +145,8 @@ public interface SecureChannel {
 
             switch (algorithm) {
                 case Rsa15:
-                case RsaOaep:
+                case RsaOaepSha1:
+                case RsaOaepSha256:
                     return (getAsymmetricKeyLength(getLocalCertificate()) + 1) / 8;
                 default:
                     return 1;
@@ -161,7 +162,8 @@ public interface SecureChannel {
 
             switch (algorithm) {
                 case Rsa15:
-                case RsaOaep:
+                case RsaOaepSha1:
+                case RsaOaepSha256:
                     return (getAsymmetricKeyLength(getRemoteCertificate()) + 1) / 8;
                 default:
                     return 1;
@@ -178,8 +180,10 @@ public interface SecureChannel {
             switch (algorithm) {
                 case Rsa15:
                     return (getAsymmetricKeyLength(getLocalCertificate()) + 1) / 8 - 11;
-                case RsaOaep:
+                case RsaOaepSha1:
                     return (getAsymmetricKeyLength(getLocalCertificate()) + 1) / 8 - 42;
+                case RsaOaepSha256:
+                    return (getAsymmetricKeyLength(getLocalCertificate()) + 1) / 8 - 66;
                 default:
                     return 1;
             }
@@ -195,8 +199,10 @@ public interface SecureChannel {
             switch (algorithm) {
                 case Rsa15:
                     return (getAsymmetricKeyLength(getRemoteCertificate()) + 1) / 8 - 11;
-                case RsaOaep:
+                case RsaOaepSha1:
                     return (getAsymmetricKeyLength(getRemoteCertificate()) + 1) / 8 - 42;
+                case RsaOaepSha256:
+                    return (getAsymmetricKeyLength(getRemoteCertificate()) + 1) / 8 - 66;
                 default:
                     return 1;
             }
@@ -211,6 +217,7 @@ public interface SecureChannel {
         switch (algorithm) {
             case RsaSha1:
             case RsaSha256:
+            case RsaSha256Pss:
                 return (getAsymmetricKeyLength(getLocalCertificate()) + 1) / 8;
             default:
                 return 0;
@@ -223,6 +230,7 @@ public interface SecureChannel {
         switch (algorithm) {
             case RsaSha1:
             case RsaSha256:
+            case RsaSha256Pss:
                 return (getAsymmetricKeyLength(getRemoteCertificate()) + 1) / 8;
             default:
                 return 0;
@@ -294,6 +302,8 @@ public interface SecureChannel {
             case Basic256:
                 return 24;
             case Basic256Sha256:
+            case Aes128_Sha256_RsaOaep:
+            case Aes256_Sha256_RsaPss:
                 return 32;
             default:
                 return 0;
@@ -305,9 +315,11 @@ public interface SecureChannel {
             case None:
                 return 0;
             case Basic128Rsa15:
+            case Aes128_Sha256_RsaOaep:
                 return 16;
             case Basic256:
             case Basic256Sha256:
+            case Aes256_Sha256_RsaPss:
                 return 32;
             default:
                 return 0;

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/SecurityAlgorithm.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/SecurityAlgorithm.java
@@ -60,7 +60,7 @@ public enum SecurityAlgorithm {
      * <p>
      * Requires Bouncy Castle installed as a Security Provider.
      */
-    RsaSha256Pss("http://www.w3.org/2007/05/xmldsig-more#rsa-pss", "SHA256withRSA/PSS"),
+    RsaSha256Pss("http://opcfoundation.org/UA/security/rsa-sha2-256-pss", "SHA256withRSA/PSS"),
 
     /**
      * Asymmetric Encryption; transformation to be used with {@link Cipher#getInstance(String)}.
@@ -70,7 +70,7 @@ public enum SecurityAlgorithm {
     /**
      * Asymmetric Encryption; transformation to be used with {@link Cipher#getInstance(String)}.
      */
-    RsaOaepSha1("http://www.w3.org/2009/xmlenc11#mgf1sha1", "RSA/ECB/OAEPWithSHA-1AndMGF1Padding"),
+    RsaOaepSha1("http://www.w3.org/2001/04/xmlenc#rsa-oaep", "RSA/ECB/OAEPWithSHA-1AndMGF1Padding"),
 
     /**
      * Asymmetric Encryption; transformation to be used with {@link Cipher#getInstance(String)}.
@@ -82,7 +82,7 @@ public enum SecurityAlgorithm {
      * <p>
      * This is important because the BC version uses SHA256 in the padding while the SunJCE version uses Sha1.
      */
-    RsaOaepSha256("http://www.w3.org/2009/xmlenc11#mgf1sha256", "RSA/ECB/OAEPWithSHA256AndMGF1Padding"),
+    RsaOaepSha256("http://opcfoundation.org/UA/security/rsa-oaep-sha2-256", "RSA/ECB/OAEPWithSHA256AndMGF1Padding"),
 
     /**
      * Asymmetric Key Wrap

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/SecurityAlgorithm.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/SecurityAlgorithm.java
@@ -56,6 +56,13 @@ public enum SecurityAlgorithm {
     RsaSha256("http://www.w3.org/2001/04/xmldsig-more#rsa-sha256", "SHA256withRSA"),
 
     /**
+     * Asymmetric Signature; transformation to be used with {@link Signature#getInstance(String)}.
+     * <p>
+     * Requires Bouncy Castle installed as a Security Provider.
+     */
+    RsaSha256Pss("http://www.w3.org/2007/05/xmldsig-more#rsa-pss", "SHA256withRSA/PSS"),
+
+    /**
      * Asymmetric Encryption; transformation to be used with {@link Cipher#getInstance(String)}.
      */
     Rsa15("http://www.w3.org/2001/04/xmlenc#rsa-1_5", "RSA/ECB/PKCS1Padding"),
@@ -63,7 +70,12 @@ public enum SecurityAlgorithm {
     /**
      * Asymmetric Encryption; transformation to be used with {@link Cipher#getInstance(String)}.
      */
-    RsaOaep("http://www.w3.org/2001/04/xmlenc#rsa-oaep", "RSA/ECB/OAEPWithSHA-1AndMGF1Padding"),
+    RsaOaepSha1("http://www.w3.org/2009/xmlenc11#mgf1sha1", "RSA/ECB/OAEPWithSHA-1AndMGF1Padding"),
+
+    /**
+     * Asymmetric Encryption; transformation to be used with {@link Cipher#getInstance(String)}.
+     */
+    RsaOaepSha256("http://www.w3.org/2009/xmlenc11#mgf1sha256", "RSA/ECB/OAEPWithSHA-256AndMGF1Padding"),
 
     /**
      * Asymmetric Key Wrap

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/SecurityAlgorithm.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/SecurityAlgorithm.java
@@ -74,8 +74,15 @@ public enum SecurityAlgorithm {
 
     /**
      * Asymmetric Encryption; transformation to be used with {@link Cipher#getInstance(String)}.
+     * <p>
+     * Important note: the transformation used is "RSA/ECB/OAEPWithSHA256AndMGF1Padding" as opposed to
+     * "RSA/ECB/OAEPWithSHA-256AndMGF1Padding".
+     * <p>
+     * While similar, the former is provided by Bouncy Castle whereas the latter is provided by SunJCE.
+     * <p>
+     * This is important because the BC version uses SHA256 in the padding while the SunJCE version uses Sha1.
      */
-    RsaOaepSha256("http://www.w3.org/2009/xmlenc11#mgf1sha256", "RSA/ECB/OAEPWithSHA-256AndMGF1Padding"),
+    RsaOaepSha256("http://www.w3.org/2009/xmlenc11#mgf1sha256", "RSA/ECB/OAEPWithSHA256AndMGF1Padding"),
 
     /**
      * Asymmetric Key Wrap

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/SecurityAlgorithm.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/SecurityAlgorithm.java
@@ -60,7 +60,7 @@ public enum SecurityAlgorithm {
      * <p>
      * Requires Bouncy Castle installed as a Security Provider.
      */
-    RsaSha256Pss("http://opcfoundation.org/UA/security/rsa-sha2-256-pss", "SHA256withRSA/PSS"),
+    RsaSha256Pss("http://opcfoundation.org/UA/security/rsa-pss-sha2-256", "SHA256withRSA/PSS"),
 
     /**
      * Asymmetric Encryption; transformation to be used with {@link Cipher#getInstance(String)}.

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/SecurityPolicy.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/SecurityPolicy.java
@@ -71,7 +71,7 @@ public enum SecurityPolicy {
     ),
 
     Aes128_Sha256_RsaOaep(
-        "http://opcfoundation.org/UA/SecurityPolicy#Aes128-Sha256-RsaOaep",
+        "http://opcfoundation.org/UA/SecurityPolicy#Aes128_Sha256_RsaOaep",
         SecurityAlgorithm.HmacSha256,
         SecurityAlgorithm.Aes128,
         SecurityAlgorithm.RsaSha256,
@@ -82,7 +82,7 @@ public enum SecurityPolicy {
     ),
 
     Aes256_Sha256_RsaPss(
-        "http://opcfoundation.org/UA/SecurityPolicy#Aes256-Sha256-RsaPss",
+        "http://opcfoundation.org/UA/SecurityPolicy#Aes256_Sha256_RsaPss",
         SecurityAlgorithm.HmacSha256,
         SecurityAlgorithm.Aes256,
         SecurityAlgorithm.RsaSha256Pss,

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/SecurityPolicy.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/SecurityPolicy.java
@@ -23,44 +23,74 @@ public enum SecurityPolicy {
     /**
      * A suite of algorithms that do not provide any security settings.
      */
-    None("http://opcfoundation.org/UA/SecurityPolicy#None",
+    None(
+        "http://opcfoundation.org/UA/SecurityPolicy#None",
         SecurityAlgorithm.None,
         SecurityAlgorithm.None,
         SecurityAlgorithm.None,
         SecurityAlgorithm.None,
         SecurityAlgorithm.None,
         SecurityAlgorithm.None,
-        SecurityAlgorithm.None),
+        SecurityAlgorithm.None
+    ),
 
     /**
      * A suite of algorithms that use RSA for asymmetric encryption and AES-128 for symmetric encryption.
      */
-    Basic128Rsa15("http://opcfoundation.org/UA/SecurityPolicy#Basic128Rsa15",
+    Basic128Rsa15(
+        "http://opcfoundation.org/UA/SecurityPolicy#Basic128Rsa15",
         SecurityAlgorithm.HmacSha1,
         SecurityAlgorithm.Aes128,
         SecurityAlgorithm.RsaSha1,
         SecurityAlgorithm.Rsa15,
         SecurityAlgorithm.KwRsa15,
         SecurityAlgorithm.PSha1,
-        SecurityAlgorithm.Sha1),
+        SecurityAlgorithm.Sha1
+    ),
 
-    Basic256("http://opcfoundation.org/UA/SecurityPolicy#Basic256",
+    Basic256(
+        "http://opcfoundation.org/UA/SecurityPolicy#Basic256",
         SecurityAlgorithm.HmacSha1,
         SecurityAlgorithm.Aes256,
         SecurityAlgorithm.RsaSha1,
-        SecurityAlgorithm.RsaOaep,
+        SecurityAlgorithm.RsaOaepSha1,
         SecurityAlgorithm.KwRsaOaep,
         SecurityAlgorithm.PSha1,
-        SecurityAlgorithm.Sha1),
+        SecurityAlgorithm.Sha1
+    ),
 
-    Basic256Sha256("http://opcfoundation.org/UA/SecurityPolicy#Basic256Sha256",
+    Basic256Sha256(
+        "http://opcfoundation.org/UA/SecurityPolicy#Basic256Sha256",
         SecurityAlgorithm.HmacSha256,
         SecurityAlgorithm.Aes256,
         SecurityAlgorithm.RsaSha256,
-        SecurityAlgorithm.RsaOaep,
+        SecurityAlgorithm.RsaOaepSha1,
         SecurityAlgorithm.KwRsaOaep,
         SecurityAlgorithm.PSha256,
-        SecurityAlgorithm.Sha256);
+        SecurityAlgorithm.Sha256
+    ),
+
+    Aes128_Sha256_RsaOaep(
+        "http://opcfoundation.org/UA/SecurityPolicy#Aes128-Sha256-RsaOaep",
+        SecurityAlgorithm.HmacSha256,
+        SecurityAlgorithm.Aes128,
+        SecurityAlgorithm.RsaSha256,
+        SecurityAlgorithm.RsaOaepSha1,
+        null, // N/A
+        SecurityAlgorithm.PSha256,
+        SecurityAlgorithm.Sha256
+    ),
+
+    Aes256_Sha256_RsaPss(
+        "http://opcfoundation.org/UA/SecurityPolicy#Aes256-Sha256-RsaPss",
+        SecurityAlgorithm.HmacSha256,
+        SecurityAlgorithm.Aes256,
+        SecurityAlgorithm.RsaSha256Pss,
+        SecurityAlgorithm.RsaOaepSha256,
+        null, // N/A
+        SecurityAlgorithm.PSha256,
+        SecurityAlgorithm.Sha256
+    );
 
     private final String securityPolicyUri;
     private final SecurityAlgorithm symmetricSignatureAlgorithm;

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/util/NonceUtil.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/util/NonceUtil.java
@@ -47,7 +47,7 @@ public class NonceUtil {
             long delta = System.nanoTime() - start;
 
             LoggerFactory.getLogger(NonceUtil.class).info(
-                "SecureRandom from getInstanceStrong() finished seeding in %sms.",
+                "SecureRandom from getInstanceStrong() finished seeding in {}ms.",
                 TimeUnit.NANOSECONDS.convert(delta, TimeUnit.MILLISECONDS));
         }, "SecureRandomGetInstanceStrong").start();
     }

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/util/NonceUtil.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/util/NonceUtil.java
@@ -17,7 +17,7 @@ import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.util.concurrent.ThreadLocalRandom;
 
-import org.eclipse.milo.opcua.stack.core.security.SecurityAlgorithm;
+import org.eclipse.milo.opcua.stack.core.security.SecurityPolicy;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
 
 public class NonceUtil {
@@ -74,27 +74,37 @@ public class NonceUtil {
     }
 
     /**
-     * Generate a nonce for the given {@link SecurityAlgorithm}. The length is determined by the algorithm.
+     * Generate a nonce for the given {@link SecurityPolicy}.
+     * <p>
+     * The length is determined by the policy: see {@link #getNonceLength(SecurityPolicy)}.
      *
-     * @param algorithm the algorithm to use when determined the nonce length.
-     * @return a nonce of the appropriate length for the given algorithm.
+     * @param securityPolicy the {@link SecurityPolicy} to use when determining the nonce length.
+     * @return a nonce of the appropriate length for the given security policy.
      */
-    public static ByteString generateNonce(SecurityAlgorithm algorithm) {
-        return generateNonce(getNonceLength(algorithm));
+    public static ByteString generateNonce(SecurityPolicy securityPolicy) {
+        return generateNonce(getNonceLength(securityPolicy));
     }
 
     /**
-     * Get the nonce length for use with {@code algorithm}.
+     * Get the minimum nonce length for use with {@code securityPolicy}.
+     * <p>
+     * For an RSA-based {@link SecurityPolicy}, the nonce shall be a cryptographic random number with a length equal to
+     * the key length specified by policy's SymmetricEncryptionAlgorithm or the length of hash algorithm used by the
+     * policy's KeyDerivationAlgorithm, whichever is greater.
      *
-     * @param algorithm a symmetric encryption algorithm.
-     * @return the nonce length.
+     * @param securityPolicy the {@link SecurityPolicy} in use.
+     * @return the minimum nonce length for use with {@code securityPolicy}.
      */
-    public static int getNonceLength(SecurityAlgorithm algorithm) {
-        switch (algorithm) {
-            case Aes128:
+    public static int getNonceLength(SecurityPolicy securityPolicy) {
+        switch (securityPolicy) {
+            case Basic128Rsa15:
                 return 16;
-            case Aes256:
+            case Basic256:
+            case Basic256Sha256:
+            case Aes128_Sha256_RsaOaep:
+            case Aes256_Sha256_RsaPss:
                 return 32;
+            case None:
             default:
                 return 0;
         }

--- a/opc-ua-stack/stack-server/src/main/java/org/eclipse/milo/opcua/stack/server/handlers/UaTcpServerAsymmetricHandler.java
+++ b/opc-ua-stack/stack-server/src/main/java/org/eclipse/milo/opcua/stack/server/handlers/UaTcpServerAsymmetricHandler.java
@@ -45,7 +45,6 @@ import org.eclipse.milo.opcua.stack.core.channel.headers.AsymmetricSecurityHeade
 import org.eclipse.milo.opcua.stack.core.channel.headers.HeaderDecoder;
 import org.eclipse.milo.opcua.stack.core.channel.messages.ErrorMessage;
 import org.eclipse.milo.opcua.stack.core.channel.messages.MessageType;
-import org.eclipse.milo.opcua.stack.core.security.SecurityAlgorithm;
 import org.eclipse.milo.opcua.stack.core.security.SecurityPolicy;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
 import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
@@ -343,23 +342,20 @@ public class UaTcpServerAsymmetricHandler extends ByteToMessageDecoder implement
         ChannelSecurity.SecuritySecrets newKeys = null;
 
         if (secureChannel.isSymmetricSigningEnabled()) {
-            SecurityAlgorithm algorithm = secureChannel.getSecurityPolicy().getSymmetricEncryptionAlgorithm();
-
             // Validate the remote nonce; it must be non-null and the correct length for the security algorithm.
             ByteString remoteNonce = request.getClientNonce();
             if (remoteNonce == null || remoteNonce.isNull()) {
                 throw new UaException(StatusCodes.Bad_SecurityChecksFailed, "remote nonce must be non-null");
             }
-            if (remoteNonce.length() < getNonceLength(algorithm)) {
+            if (remoteNonce.length() < getNonceLength(secureChannel.getSecurityPolicy())) {
                 String message = String.format(
                     "remote nonce length must be at least %d bytes",
-                    getNonceLength(algorithm));
+                    getNonceLength(secureChannel.getSecurityPolicy()));
 
                 throw new UaException(StatusCodes.Bad_SecurityChecksFailed, message);
             }
 
-
-            ByteString localNonce = generateNonce(getNonceLength(algorithm));
+            ByteString localNonce = generateNonce(secureChannel.getSecurityPolicy());
 
             secureChannel.setLocalNonce(localNonce);
             secureChannel.setRemoteNonce(remoteNonce);

--- a/opc-ua-stack/stack-tests/pom.xml
+++ b/opc-ua-stack/stack-tests/pom.xml
@@ -35,6 +35,12 @@
             <version>${slf4j.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk15on</artifactId>
+            <version>1.56</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/opc-ua-stack/stack-tests/pom.xml
+++ b/opc-ua-stack/stack-tests/pom.xml
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk15on</artifactId>
-            <version>1.56</version>
+            <version>1.58</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/opc-ua-stack/stack-tests/src/test/java/org/eclipse/milo/opcua/stack/ChunkSerializationTest.java
+++ b/opc-ua-stack/stack-tests/src/test/java/org/eclipse/milo/opcua/stack/ChunkSerializationTest.java
@@ -13,11 +13,13 @@
 
 package org.eclipse.milo.opcua.stack;
 
+import java.security.Security;
 import java.util.ArrayList;
 import java.util.List;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.util.ReferenceCountUtil;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.channel.ChannelConfig;
 import org.eclipse.milo.opcua.stack.core.channel.ChannelParameters;
@@ -39,6 +41,8 @@ import org.slf4j.LoggerFactory;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import static org.eclipse.milo.opcua.stack.core.channel.ChannelConfig.DEFAULT_MAX_CHUNK_SIZE;
+import static org.eclipse.milo.opcua.stack.core.channel.ChannelConfig.DEFAULT_MAX_MESSAGE_SIZE;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.fail;
 
@@ -47,6 +51,9 @@ public class ChunkSerializationTest extends SecureChannelFixture {
     static {
         boolean removed = CryptoRestrictions.remove();
         assert removed;
+
+        // Required for SecurityPolicy.Aes256_Sha256_RsaPss
+        Security.addProvider(new BouncyCastleProvider());
     }
 
     private Logger logger = LoggerFactory.getLogger(getClass());
@@ -63,13 +70,13 @@ public class ChunkSerializationTest extends SecureChannelFixture {
     );
 
     private ChannelParameters defaultParameters = new ChannelParameters(
-        ChannelConfig.DEFAULT_MAX_MESSAGE_SIZE,
-        ChannelConfig.DEFAULT_MAX_CHUNK_SIZE,
-        ChannelConfig.DEFAULT_MAX_CHUNK_SIZE,
+        DEFAULT_MAX_MESSAGE_SIZE,
+        DEFAULT_MAX_CHUNK_SIZE,
+        DEFAULT_MAX_CHUNK_SIZE,
         0,
-        ChannelConfig.DEFAULT_MAX_MESSAGE_SIZE,
-        ChannelConfig.DEFAULT_MAX_CHUNK_SIZE,
-        ChannelConfig.DEFAULT_MAX_CHUNK_SIZE,
+        DEFAULT_MAX_MESSAGE_SIZE,
+        DEFAULT_MAX_CHUNK_SIZE,
+        DEFAULT_MAX_CHUNK_SIZE,
         0
     );
 
@@ -95,14 +102,22 @@ public class ChunkSerializationTest extends SecureChannelFixture {
             {SecurityPolicy.Basic256, MessageSecurityMode.SignAndEncrypt, 128},
             {SecurityPolicy.Basic256Sha256, MessageSecurityMode.Sign, 128},
             {SecurityPolicy.Basic256Sha256, MessageSecurityMode.SignAndEncrypt, 128},
+            {SecurityPolicy.Aes128_Sha256_RsaOaep, MessageSecurityMode.Sign, 128},
+            {SecurityPolicy.Aes128_Sha256_RsaOaep, MessageSecurityMode.SignAndEncrypt, 128},
+            {SecurityPolicy.Aes256_Sha256_RsaPss, MessageSecurityMode.Sign, 128},
+            {SecurityPolicy.Aes256_Sha256_RsaPss, MessageSecurityMode.SignAndEncrypt, 128},
 
-            {SecurityPolicy.None, MessageSecurityMode.None, ChannelConfig.DEFAULT_MAX_CHUNK_SIZE},
-            {SecurityPolicy.Basic128Rsa15, MessageSecurityMode.Sign, ChannelConfig.DEFAULT_MAX_CHUNK_SIZE},
-            {SecurityPolicy.Basic128Rsa15, MessageSecurityMode.SignAndEncrypt, ChannelConfig.DEFAULT_MAX_CHUNK_SIZE},
-            {SecurityPolicy.Basic256, MessageSecurityMode.Sign, ChannelConfig.DEFAULT_MAX_CHUNK_SIZE},
-            {SecurityPolicy.Basic256, MessageSecurityMode.SignAndEncrypt, ChannelConfig.DEFAULT_MAX_CHUNK_SIZE},
-            {SecurityPolicy.Basic256Sha256, MessageSecurityMode.Sign, ChannelConfig.DEFAULT_MAX_CHUNK_SIZE},
-            {SecurityPolicy.Basic256Sha256, MessageSecurityMode.SignAndEncrypt, ChannelConfig.DEFAULT_MAX_CHUNK_SIZE},
+            {SecurityPolicy.None, MessageSecurityMode.None, DEFAULT_MAX_CHUNK_SIZE},
+            {SecurityPolicy.Basic128Rsa15, MessageSecurityMode.Sign, DEFAULT_MAX_CHUNK_SIZE},
+            {SecurityPolicy.Basic128Rsa15, MessageSecurityMode.SignAndEncrypt, DEFAULT_MAX_CHUNK_SIZE},
+            {SecurityPolicy.Basic256, MessageSecurityMode.Sign, DEFAULT_MAX_CHUNK_SIZE},
+            {SecurityPolicy.Basic256, MessageSecurityMode.SignAndEncrypt, DEFAULT_MAX_CHUNK_SIZE},
+            {SecurityPolicy.Basic256Sha256, MessageSecurityMode.Sign, DEFAULT_MAX_CHUNK_SIZE},
+            {SecurityPolicy.Basic256Sha256, MessageSecurityMode.SignAndEncrypt, DEFAULT_MAX_CHUNK_SIZE},
+            {SecurityPolicy.Aes128_Sha256_RsaOaep, MessageSecurityMode.Sign, DEFAULT_MAX_CHUNK_SIZE},
+            {SecurityPolicy.Aes128_Sha256_RsaOaep, MessageSecurityMode.SignAndEncrypt, DEFAULT_MAX_CHUNK_SIZE},
+            {SecurityPolicy.Aes256_Sha256_RsaPss, MessageSecurityMode.Sign, DEFAULT_MAX_CHUNK_SIZE},
+            {SecurityPolicy.Aes256_Sha256_RsaPss, MessageSecurityMode.SignAndEncrypt, DEFAULT_MAX_CHUNK_SIZE},
         };
     }
 
@@ -194,7 +209,11 @@ public class ChunkSerializationTest extends SecureChannelFixture {
             {SecurityPolicy.Basic256, MessageSecurityMode.Sign},
             {SecurityPolicy.Basic256, MessageSecurityMode.SignAndEncrypt},
             {SecurityPolicy.Basic256Sha256, MessageSecurityMode.Sign},
-            {SecurityPolicy.Basic256Sha256, MessageSecurityMode.SignAndEncrypt}
+            {SecurityPolicy.Basic256Sha256, MessageSecurityMode.SignAndEncrypt},
+            {SecurityPolicy.Aes128_Sha256_RsaOaep, MessageSecurityMode.Sign},
+            {SecurityPolicy.Aes128_Sha256_RsaOaep, MessageSecurityMode.SignAndEncrypt},
+            {SecurityPolicy.Aes256_Sha256_RsaPss, MessageSecurityMode.Sign},
+            {SecurityPolicy.Aes256_Sha256_RsaPss, MessageSecurityMode.SignAndEncrypt}
         };
     }
 

--- a/opc-ua-stack/stack-tests/src/test/java/org/eclipse/milo/opcua/stack/ClientServerTest.java
+++ b/opc-ua-stack/stack-tests/src/test/java/org/eclipse/milo/opcua/stack/ClientServerTest.java
@@ -442,7 +442,7 @@ public class ClientServerTest extends SecurityFixture {
             uint(0),
             uint(0),
             null,
-            uint(60000),
+            uint(2000),
             null
         );
 

--- a/opc-ua-stack/stack-tests/src/test/java/org/eclipse/milo/opcua/stack/SecureChannelFixture.java
+++ b/opc-ua-stack/stack-tests/src/test/java/org/eclipse/milo/opcua/stack/SecureChannelFixture.java
@@ -28,15 +28,14 @@ import org.eclipse.milo.opcua.stack.core.types.structured.ChannelSecurityToken;
 import static com.google.common.collect.Lists.newArrayList;
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
 import static org.eclipse.milo.opcua.stack.core.util.NonceUtil.generateNonce;
-import static org.eclipse.milo.opcua.stack.core.util.NonceUtil.getNonceLength;
 
 public abstract class SecureChannelFixture extends SecurityFixture {
 
     protected SecureChannel[] generateChannels(SecurityPolicy securityPolicy, MessageSecurityMode messageSecurity) throws Exception {
         super.setUp();
 
-        ByteString clientNonce = generateNonce(getNonceLength(securityPolicy.getSymmetricEncryptionAlgorithm()));
-        ByteString serverNonce = generateNonce(getNonceLength(securityPolicy.getSymmetricEncryptionAlgorithm()));
+        ByteString clientNonce = generateNonce(securityPolicy);
+        ByteString serverNonce = generateNonce(securityPolicy);
 
         ClientSecureChannel clientChannel = new ClientSecureChannel(
             securityPolicy == SecurityPolicy.None ? null : clientKeyPair,


### PR DESCRIPTION
Implements two new security profiles:
* Aes128_Sha256_RsaOaep
* Aes256_Sha256_RsaPss

These profiles are intended to be replacements for all existing profiles
except Basic256Sha256, which is the only profile that does not currently
rely on SHA1 in a way that endangers security (if only yet theoretical).