### PR TITLE
 Recalculate keep-alive count when publishing interval is revised

### DIFF
--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/api/subscriptions/UaSubscriptionManager.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/api/subscriptions/UaSubscriptionManager.java
@@ -14,6 +14,8 @@
 package org.eclipse.milo.opcua.sdk.client.api.subscriptions;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.function.BiFunction;
+import java.util.function.Function;
 
 import com.google.common.collect.ImmutableList;
 import org.eclipse.milo.opcua.sdk.client.api.UaSession;
@@ -27,6 +29,8 @@ public interface UaSubscriptionManager {
 
     /**
      * Create a {@link UaSubscription} using default parameters.
+     * <p>
+     * The requested max keep-alive count and lifetime count will be derived from the requested publishing interval.
      *
      * @param requestedPublishingInterval the requested publishing interval of the subscription.
      * @return a {@link CompletableFuture} containing the {@link UaSubscription}.
@@ -40,12 +44,36 @@ public interface UaSubscriptionManager {
      * @param requestedLifetimeCount      the requested lifetime count.
      * @param requestedMaxKeepAliveCount  the requested max keep-alive count.
      * @param maxNotificationsPerPublish  the maximum number of notifications allowed in a publish response.
+     * @param publishingEnabled           {@code true} if publishing is enabled for the subscription.
      * @param priority                    the relative priority to assign to the subscription.
      * @return a {@link CompletableFuture} containing the {@link UaSubscription}.
      */
     CompletableFuture<UaSubscription> createSubscription(double requestedPublishingInterval,
                                                          UInteger requestedLifetimeCount,
                                                          UInteger requestedMaxKeepAliveCount,
+                                                         UInteger maxNotificationsPerPublish,
+                                                         boolean publishingEnabled,
+                                                         UByte priority);
+
+    /**
+     * Create a {@link UaSubscription}.
+     * <p>
+     * This overload uses provided functions to calculate keep-alive and lifetime counts. They may be called more than
+     * once, with revised values, in order to modify the subscription if the server revises the requested publishing
+     * interval.
+     *
+     * @param requestedPublishingInterval the requested publishing interval.
+     * @param getLifetimeCount            function returning lifetime count given publishing interval and
+     *                                    keep-alive count.
+     * @param getKeepAliveCount           function returning keep-alive count given publishing interval.
+     * @param maxNotificationsPerPublish  the maximum number of notifications allowed in a publish response.
+     * @param publishingEnabled           {@code true} if publishing is enabled for the subscription.
+     * @param priority                    the relative priority to assign to the subscription.
+     * @return a {@link CompletableFuture} containing the {@link UaSubscription}.
+     */
+    CompletableFuture<UaSubscription> createSubscription(double requestedPublishingInterval,
+                                                         BiFunction<Double, UInteger, UInteger> getLifetimeCount,
+                                                         Function<Double, UInteger> getKeepAliveCount,
                                                          UInteger maxNotificationsPerPublish,
                                                          boolean publishingEnabled,
                                                          UByte priority);
@@ -77,6 +105,29 @@ public interface UaSubscriptionManager {
                                                          double requestedPublishingInterval,
                                                          UInteger requestedLifetimeCount,
                                                          UInteger requestedMaxKeepAliveCount,
+                                                         UInteger maxNotificationsPerPublish,
+                                                         UByte priority);
+
+    /**
+     * Modify a {@link UaSubscription}.
+     * <p>
+     * This overload uses provided functions to calculate keep-alive and lifetime counts. They may be called more than
+     * once, with revised values, in order to modify the subscription if the server revises the requested publishing
+     * interval.
+     *
+     * @param subscriptionId              the server-assigned id of the {@link UaSubscription} to modify.
+     * @param requestedPublishingInterval the requested publishing interval.
+     * @param getLifetimeCount            function returning lifetime count given publishing interval and
+     *                                    keep-alive count.
+     * @param getKeepAliveCount           function returning keep-alive count given publishing interval.
+     * @param maxNotificationsPerPublish  the maximum number of notifications allowed in a publish response.
+     * @param priority                    the relative priority to assign to the subscription.
+     * @return a {@link CompletableFuture} containing the {@link UaSubscription}.
+     */
+    CompletableFuture<UaSubscription> modifySubscription(UInteger subscriptionId,
+                                                         double requestedPublishingInterval,
+                                                         BiFunction<Double, UInteger, UInteger> getLifetimeCount,
+                                                         Function<Double, UInteger> getKeepAliveCount,
                                                          UInteger maxNotificationsPerPublish,
                                                          UByte priority);
 

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/api/subscriptions/UaSubscriptionManager.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/api/subscriptions/UaSubscriptionManager.java
@@ -65,7 +65,7 @@ public interface UaSubscriptionManager {
      * @param requestedPublishingInterval the requested publishing interval.
      * @param getLifetimeCount            function returning lifetime count given publishing interval and
      *                                    keep-alive count.
-     * @param getKeepAliveCount           function returning keep-alive count given publishing interval.
+     * @param getMaxKeepAliveCount        function returning max keep-alive count given publishing interval.
      * @param maxNotificationsPerPublish  the maximum number of notifications allowed in a publish response.
      * @param publishingEnabled           {@code true} if publishing is enabled for the subscription.
      * @param priority                    the relative priority to assign to the subscription.
@@ -73,7 +73,7 @@ public interface UaSubscriptionManager {
      */
     CompletableFuture<UaSubscription> createSubscription(double requestedPublishingInterval,
                                                          BiFunction<Double, UInteger, UInteger> getLifetimeCount,
-                                                         Function<Double, UInteger> getKeepAliveCount,
+                                                         Function<Double, UInteger> getMaxKeepAliveCount,
                                                          UInteger maxNotificationsPerPublish,
                                                          boolean publishingEnabled,
                                                          UByte priority);
@@ -119,7 +119,7 @@ public interface UaSubscriptionManager {
      * @param requestedPublishingInterval the requested publishing interval.
      * @param getLifetimeCount            function returning lifetime count given publishing interval and
      *                                    keep-alive count.
-     * @param getKeepAliveCount           function returning keep-alive count given publishing interval.
+     * @param getMaxKeepAliveCount        function returning max keep-alive count given publishing interval.
      * @param maxNotificationsPerPublish  the maximum number of notifications allowed in a publish response.
      * @param priority                    the relative priority to assign to the subscription.
      * @return a {@link CompletableFuture} containing the {@link UaSubscription}.
@@ -127,7 +127,7 @@ public interface UaSubscriptionManager {
     CompletableFuture<UaSubscription> modifySubscription(UInteger subscriptionId,
                                                          double requestedPublishingInterval,
                                                          BiFunction<Double, UInteger, UInteger> getLifetimeCount,
-                                                         Function<Double, UInteger> getKeepAliveCount,
+                                                         Function<Double, UInteger> getMaxKeepAliveCount,
                                                          UInteger maxNotificationsPerPublish,
                                                          UByte priority);
 

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/subscriptions/OpcUaSubscriptionManager.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/subscriptions/OpcUaSubscriptionManager.java
@@ -108,8 +108,8 @@ public class OpcUaSubscriptionManager implements UaSubscriptionManager {
     public CompletableFuture<UaSubscription> createSubscription(double requestedPublishingInterval) {
         return createSubscription(
             requestedPublishingInterval,
-            this::getKeepAliveCount,
             this::getLifetimeCount,
+            this::getKeepAliveCount,
             DEFAULT_MAX_NOTIFICATIONS_PER_PUBLISH,
             true,
             UByte.MIN
@@ -127,8 +127,8 @@ public class OpcUaSubscriptionManager implements UaSubscriptionManager {
 
         return createSubscription(
             requestedPublishingInterval,
-            p -> requestedMaxKeepAliveCount,
             (p, c) -> requestedLifetimeCount,
+            p -> requestedMaxKeepAliveCount,
             maxNotificationsPerPublish,
             publishingEnabled,
             priority
@@ -137,8 +137,8 @@ public class OpcUaSubscriptionManager implements UaSubscriptionManager {
 
     private CompletableFuture<UaSubscription> createSubscription(
         double requestedPublishingInterval,
-        Function<Double, UInteger> getKeepAliveCount,
         BiFunction<Double, UInteger, UInteger> getLifetimeCount,
+        Function<Double, UInteger> getKeepAliveCount,
         UInteger maxNotificationsPerPublish,
         boolean publishingEnabled,
         UByte priority) {
@@ -242,8 +242,8 @@ public class OpcUaSubscriptionManager implements UaSubscriptionManager {
         return modifySubscription(
             subscriptionId,
             requestedPublishingInterval,
-            this::getKeepAliveCount,
             this::getLifetimeCount,
+            this::getKeepAliveCount,
             subscription.getMaxNotificationsPerPublish(),
             subscription.getPriority()
         );
@@ -261,8 +261,8 @@ public class OpcUaSubscriptionManager implements UaSubscriptionManager {
         return modifySubscription(
             subscriptionId,
             requestedPublishingInterval,
-            p -> requestedMaxKeepAliveCount,
             (p, c) -> requestedLifetimeCount,
+            p -> requestedMaxKeepAliveCount,
             maxNotificationsPerPublish,
             priority
         );
@@ -271,8 +271,8 @@ public class OpcUaSubscriptionManager implements UaSubscriptionManager {
     private CompletableFuture<UaSubscription> modifySubscription(
         UInteger subscriptionId,
         double requestedPublishingInterval,
-        Function<Double, UInteger> getKeepAliveCount,
         BiFunction<Double, UInteger, UInteger> getLifetimeCount,
+        Function<Double, UInteger> getKeepAliveCount,
         UInteger maxNotificationsPerPublish,
         UByte priority) {
 

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/subscriptions/OpcUaSubscriptionManager.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/subscriptions/OpcUaSubscriptionManager.java
@@ -135,7 +135,8 @@ public class OpcUaSubscriptionManager implements UaSubscriptionManager {
         );
     }
 
-    private CompletableFuture<UaSubscription> createSubscription(
+    @Override
+    public CompletableFuture<UaSubscription> createSubscription(
         double requestedPublishingInterval,
         BiFunction<Double, UInteger, UInteger> getLifetimeCount,
         Function<Double, UInteger> getKeepAliveCount,
@@ -268,7 +269,8 @@ public class OpcUaSubscriptionManager implements UaSubscriptionManager {
         );
     }
 
-    private CompletableFuture<UaSubscription> modifySubscription(
+    @Override
+    public CompletableFuture<UaSubscription> modifySubscription(
         UInteger subscriptionId,
         double requestedPublishingInterval,
         BiFunction<Double, UInteger, UInteger> getLifetimeCount,

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/subscriptions/OpcUaSubscriptionManager.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/subscriptions/OpcUaSubscriptionManager.java
@@ -286,7 +286,8 @@ public class OpcUaSubscriptionManager implements UaSubscriptionManager {
         }
 
         UInteger requestedMaxKeepAliveCount = getMaxKeepAliveCount.apply(requestedPublishingInterval);
-        UInteger requestedLifetimeCount = getLifetimeCount.apply(requestedPublishingInterval, requestedMaxKeepAliveCount);
+        UInteger requestedLifetimeCount = getLifetimeCount.apply(
+            requestedPublishingInterval, requestedMaxKeepAliveCount);
 
         CompletableFuture<ModifySubscriptionResponse> future = client.modifySubscription(
             subscriptionId,


### PR DESCRIPTION
When not explicitly specified by the user, recalculate the max keep-alive count and lifetime count values when a subscription is created or modified and the publishing interval is revised.

This primarily allows for reasonable values to be established when the original requested publishing interval was 0, since reasonable values can't be calculated until the revised publishing interval is known.