### PR TITLE
Validate certificates and verify trust chain during session creation

### DIFF
--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/SessionManager.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/SessionManager.java
@@ -37,6 +37,7 @@ import org.eclipse.milo.opcua.sdk.server.services.ServiceAttributes;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.UaRuntimeException;
+import org.eclipse.milo.opcua.stack.core.application.CertificateValidator;
 import org.eclipse.milo.opcua.stack.core.application.services.AttributeHistoryServiceSet;
 import org.eclipse.milo.opcua.stack.core.application.services.AttributeServiceSet;
 import org.eclipse.milo.opcua.stack.core.application.services.MethodServiceSet;
@@ -264,14 +265,21 @@ public class SessionManager implements
         ByteString clientCertificateBytes = request.getClientCertificate();
 
         if (secureChannel.getSecurityPolicy() != SecurityPolicy.None) {
-            X509Certificate clientCertificate = CertificateUtil
-                .decodeCertificate(clientCertificateBytes.bytes());
+            List<X509Certificate> clientCertificateChain = CertificateUtil
+                .decodeCertificates(clientCertificateBytes.bytes());
+
+            X509Certificate clientCertificate = clientCertificateChain.get(0);
 
             if (!secureChannel.getRemoteCertificate().equals(clientCertificate)) {
                 throw new UaException(StatusCodes.Bad_SecurityChecksFailed,
                     "certificate used to open secure channel " +
                         "differs from certificate used to create session");
             }
+
+            CertificateValidator certificateValidator = server.getConfig().getCertificateValidator();
+
+            certificateValidator.validate(clientCertificate);
+            certificateValidator.verifyTrustChain(clientCertificateChain);
 
             validateApplicationUri(request.getClientDescription().getApplicationUri(), clientCertificate);
         }

--- a/opc-ua-stack/stack-server/src/main/java/org/eclipse/milo/opcua/stack/server/handlers/UaTcpServerAsymmetricHandler.java
+++ b/opc-ua-stack/stack-server/src/main/java/org/eclipse/milo/opcua/stack/server/handlers/UaTcpServerAsymmetricHandler.java
@@ -202,7 +202,6 @@ public class UaTcpServerAsymmetricHandler extends ByteToMessageDecoder implement
                 CertificateValidator certificateValidator = server.getCertificateValidator();
 
                 certificateValidator.validate(secureChannel.getRemoteCertificate());
-
                 certificateValidator.verifyTrustChain(secureChannel.getRemoteCertificateChain());
 
                 CertificateManager certificateManager = server.getCertificateManager();


### PR DESCRIPTION
This already happens when secure channels are created, but if/when Milo
adds support for other transports, such as HTTPS, then it's necessary
that the validation happens during session creation because there may
be no earlier opportunity.