### PR TITLE
DoS Mitigations

### DIFF
--- a/opc-ua-stack/stack-client/src/main/java/org/eclipse/milo/opcua/stack/client/handlers/UaTcpClientAcknowledgeHandler.java
+++ b/opc-ua-stack/stack-client/src/main/java/org/eclipse/milo/opcua/stack/client/handlers/UaTcpClientAcknowledgeHandler.java
@@ -114,12 +114,7 @@ public class UaTcpClientAcknowledgeHandler extends ByteToMessageCodec<UaRequestF
         int maxChunkSize = config.getMaxChunkSize();
 
         while (buffer.readableBytes() >= HEADER_LENGTH) {
-            int messageLength = getMessageLength(buffer);
-
-            if (messageLength > maxChunkSize) {
-                throw new UaException(StatusCodes.Bad_TcpMessageTooLarge,
-                    String.format("max chunk size exceeded (%s)", maxChunkSize));
-            }
+            int messageLength = getMessageLength(buffer, maxChunkSize);
 
             if (buffer.readableBytes() < messageLength) {
                 break;

--- a/opc-ua-stack/stack-client/src/main/java/org/eclipse/milo/opcua/stack/client/handlers/UaTcpClientMessageHandler.java
+++ b/opc-ua-stack/stack-client/src/main/java/org/eclipse/milo/opcua/stack/client/handlers/UaTcpClientMessageHandler.java
@@ -390,12 +390,7 @@ public class UaTcpClientMessageHandler extends ByteToMessageCodec<UaRequestFutur
     @Override
     protected void decode(ChannelHandlerContext ctx, ByteBuf buffer, List<Object> out) throws Exception {
         if (buffer.readableBytes() >= HEADER_LENGTH) {
-            int messageLength = getMessageLength(buffer);
-
-            if (messageLength > maxChunkSize) {
-                throw new UaException(StatusCodes.Bad_TcpMessageTooLarge,
-                    String.format("max chunk size exceeded (%s)", maxChunkSize));
-            }
+            int messageLength = getMessageLength(buffer, maxChunkSize);
 
             if (buffer.readableBytes() >= messageLength) {
                 decodeMessage(ctx, buffer);
@@ -404,7 +399,7 @@ public class UaTcpClientMessageHandler extends ByteToMessageCodec<UaRequestFutur
     }
 
     private void decodeMessage(ChannelHandlerContext ctx, ByteBuf buffer) throws UaException {
-        int messageLength = getMessageLength(buffer);
+        int messageLength = getMessageLength(buffer, maxChunkSize);
         MessageType messageType = MessageType.fromMediumInt(buffer.getMediumLE(buffer.readerIndex()));
 
         switch (messageType) {

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/Stack.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/Stack.java
@@ -38,7 +38,6 @@ public final class Stack {
 
     public static final int DEFAULT_PORT = 12685;
 
-
     private static NioEventLoopGroup EVENT_LOOP;
     private static ExecutorService EXECUTOR_SERVICE;
     private static ScheduledExecutorService SCHEDULED_EXECUTOR_SERVICE;
@@ -201,6 +200,42 @@ public final class Stack {
             WHEEL_TIMER.stop().forEach(Timeout::cancel);
             WHEEL_TIMER = null;
         }
+    }
+
+    public static final class ConnectionLimits {
+
+        private ConnectionLimits() {}
+
+        /**
+         * Deadline, in milliseconds, that UA Hello message must be received within before the channel is closed.
+         */
+        public static volatile int HELLO_DEADLINE_MS = 10_000;
+
+        /**
+         * Allows rate limiting to be disabled stack-wide.
+         */
+        public static boolean RATE_LIMIT_ENABLED = true;
+
+        /**
+         * Maximum number of connect attempts per {@link #RATE_LIMIT_WINDOW_MS}.
+         */
+        public static int RATE_LIMIT_MAX_ATTEMPTS = 3;
+
+        /**
+         * The window of time over which connect attempts will be counted for rate limiting.
+         */
+        public static int RATE_LIMIT_WINDOW_MS = 1000;
+
+        /**
+         * The maximum number of connections allowed in total (any remote address, not including localhost).
+         */
+        public static int RATE_LIMIT_MAX_CONNECTIONS = 10_000;
+
+        /**
+         * The maximum number of connections allowed from any 1 remote address.
+         */
+        public static int RATE_LIMIT_MAX_CONNECTIONS_PER_ADDRESS = 100;
+
     }
 
 }

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/channel/headers/HeaderDecoder.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/channel/headers/HeaderDecoder.java
@@ -13,8 +13,9 @@
 
 package org.eclipse.milo.opcua.stack.core.channel.headers;
 
-import com.google.common.primitives.Ints;
 import io.netty.buffer.ByteBuf;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
+import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.channel.messages.TcpMessageEncoder;
 
 public interface HeaderDecoder {
@@ -31,8 +32,15 @@ public interface HeaderDecoder {
      * @param buffer {@link ByteBuf} to extract from.
      * @return The message length, which includes the size of the header.
      */
-    default int getMessageLength(ByteBuf buffer) {
-        return Ints.checkedCast(buffer.getUnsignedIntLE(buffer.readerIndex() + HEADER_LENGTH_INDEX));
+    default int getMessageLength(ByteBuf buffer, int maxMessageLength) throws UaException {
+        long messageLength = buffer.getUnsignedIntLE(buffer.readerIndex() + HEADER_LENGTH_INDEX);
+
+        if (messageLength <= maxMessageLength) {
+            return (int) messageLength;
+        } else {
+            throw new UaException(StatusCodes.Bad_TcpMessageTooLarge,
+                String.format("max message length exceeded (%s > %s)", messageLength, maxMessageLength));
+        }
     }
 
 }

--- a/opc-ua-stack/stack-server/src/main/java/org/eclipse/milo/opcua/stack/server/handlers/RateLimitingHandler.java
+++ b/opc-ua-stack/stack-server/src/main/java/org/eclipse/milo/opcua/stack/server/handlers/RateLimitingHandler.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2017 Kevin Herron
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *   http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *   http://www.eclipse.org/org/documents/edl-v10.html.
+ */
+
+package org.eclipse.milo.opcua.stack.server.handlers;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.util.Date;
+import java.util.LinkedList;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.TimeUnit;
+
+import com.google.common.collect.ConcurrentHashMultiset;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Multiset;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.ipfilter.AbstractRemoteAddressFilter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@ChannelHandler.Sharable
+public class RateLimitingHandler extends AbstractRemoteAddressFilter<InetSocketAddress> {
+
+    /**
+     * Allows rate limiting to be disabled stack-wide.
+     */
+    @SuppressWarnings("WeakerAccess")
+    public static boolean ENABLED = true;
+
+    /**
+     * Maximum number of connect attempts per {@link #RATE_LIMIT_WINDOW_MS}.
+     */
+    @SuppressWarnings("WeakerAccess")
+    public static int MAX_ATTEMPTS = 3;
+
+    /**
+     * The window of time over which connect attempts will be counted for rate limiting.
+     */
+    @SuppressWarnings("WeakerAccess")
+    public static int RATE_LIMIT_WINDOW_MS = 1000;
+
+    /**
+     * Get the shared {@link RateLimitingHandler} instance.
+     * <p>
+     * The values of {@link #ENABLED}, {@link #MAX_ATTEMPTS}, and {@link #RATE_LIMIT_WINDOW_MS} will be locked in
+     * whenever the first invocation of this method occurs.
+     *
+     * @return the shared {@link RateLimitingHandler} instance.
+     */
+    public static RateLimitingHandler getInstance() {
+        return InstanceHolder.INSTANCE;
+    }
+
+    private static class InstanceHolder {
+
+        private static final RateLimitingHandler INSTANCE =
+            new RateLimitingHandler(ENABLED, MAX_ATTEMPTS, RATE_LIMIT_WINDOW_MS);
+
+    }
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    private final Multiset<InetAddress> connections = ConcurrentHashMultiset.create();
+    private final ConcurrentMap<InetAddress, LinkedList<Date>> timestamps = Maps.newConcurrentMap();
+
+    private final boolean enabled;
+    private final int maxAttempts;
+    private final int rateLimitWindowMs;
+
+    private RateLimitingHandler(boolean enabled, int maxAttempts, int rateLimitWindowMs) {
+        this.enabled = enabled;
+        this.maxAttempts = maxAttempts;
+        this.rateLimitWindowMs = rateLimitWindowMs;
+
+        logger.debug("enabled=" + enabled + " maxAttempts=" + maxAttempts + " rateLimitWindowMs=" + rateLimitWindowMs);
+    }
+
+    @Override
+    protected boolean accept(ChannelHandlerContext ctx, InetSocketAddress isa) {
+        final InetAddress address = isa.getAddress();
+
+        if (!enabled || address.isLoopbackAddress()) {
+            return true;
+        }
+
+        LinkedList<Date> dates = timestamps.computeIfAbsent(address, ia -> new LinkedList<>());
+
+        if (dates.size() >= maxAttempts) {
+            long now = System.currentTimeMillis();
+
+            // count the number of previous connections from this address
+            // that have occurred within the rate limit window.
+            int count = 0;
+            for (Date d : dates) {
+                if (now - d.getTime() < rateLimitWindowMs) {
+                    count++;
+                }
+            }
+
+            boolean accept = count < maxAttempts;
+
+            dates.addLast(new Date());
+            while (dates.size() > maxAttempts) {
+                dates.removeFirst();
+            }
+
+            if (accept) {
+                logger.debug(String.format(
+                    "Accepting connection from %s. Number of attempts in last %sms: %s",
+                    isa, rateLimitWindowMs, count));
+            } else {
+                logger.warn(String.format(
+                    "Rejecting connection from %s. Number of attempts exceeds %s per %sms",
+                    isa, maxAttempts, rateLimitWindowMs));
+            }
+
+            return accept;
+        } else {
+            dates.addLast(new Date());
+
+            return true;
+        }
+    }
+
+    @Override
+    protected void channelAccepted(ChannelHandlerContext ctx, InetSocketAddress remoteAddress) {
+        final InetAddress address = remoteAddress.getAddress();
+
+        if (!enabled || address.isLoopbackAddress()) {
+            return;
+        }
+
+        connections.add(address);
+
+        ctx.channel().closeFuture().addListener((ChannelFutureListener) future -> {
+            connections.remove(address);
+
+            if (connections.count(address) == 0) {
+                logger.debug("Scheduling timestamp removal for " + address);
+
+                ctx.executor().schedule(
+                    () -> {
+                        // If there's still no connections from the remote address after the rate limit window remove
+                        // the timestamps.
+                        // Removing them before the window elapses would allow a remote address to connect/disconnect
+                        // at an effectively unlimited rate.
+                        if (connections.count(address) == 0) {
+                            timestamps.remove(address);
+                            logger.debug("Removed timestamps for " + address);
+                        }
+                    },
+                    rateLimitWindowMs,
+                    TimeUnit.MILLISECONDS
+                );
+            }
+        });
+    }
+
+}

--- a/opc-ua-stack/stack-server/src/main/java/org/eclipse/milo/opcua/stack/server/handlers/RateLimitingHandler.java
+++ b/opc-ua-stack/stack-server/src/main/java/org/eclipse/milo/opcua/stack/server/handlers/RateLimitingHandler.java
@@ -42,6 +42,9 @@ import org.slf4j.LoggerFactory;
 @ChannelHandler.Sharable
 public class RateLimitingHandler extends AbstractRemoteAddressFilter<InetSocketAddress> {
 
+    /**
+     * Cumulative count of all connection rejections for the lifetime of the server.
+     */
     public static final AtomicLong CUMULATIVE_REJECTION_COUNT = new AtomicLong(0L);
 
     /**

--- a/opc-ua-stack/stack-server/src/main/java/org/eclipse/milo/opcua/stack/server/handlers/UaTcpServerAsymmetricHandler.java
+++ b/opc-ua-stack/stack-server/src/main/java/org/eclipse/milo/opcua/stack/server/handlers/UaTcpServerAsymmetricHandler.java
@@ -95,12 +95,7 @@ public class UaTcpServerAsymmetricHandler extends ByteToMessageDecoder implement
     @Override
     protected void decode(ChannelHandlerContext ctx, ByteBuf buffer, List<Object> out) throws Exception {
         while (buffer.readableBytes() >= HEADER_LENGTH) {
-            int messageLength = getMessageLength(buffer);
-
-            if (messageLength > maxChunkSize) {
-                throw new UaException(StatusCodes.Bad_TcpMessageTooLarge,
-                    String.format("max chunk size exceeded (%s)", maxChunkSize));
-            }
+            int messageLength = getMessageLength(buffer, maxChunkSize);
 
             if (buffer.readableBytes() < messageLength) {
                 break;

--- a/opc-ua-stack/stack-server/src/main/java/org/eclipse/milo/opcua/stack/server/handlers/UaTcpServerAsymmetricHandler.java
+++ b/opc-ua-stack/stack-server/src/main/java/org/eclipse/milo/opcua/stack/server/handlers/UaTcpServerAsymmetricHandler.java
@@ -404,7 +404,8 @@ public class UaTcpServerAsymmetricHandler extends ByteToMessageDecoder implement
                                     new UaTcpServerSymmetricHandler(
                                         server, serializationQueue, secureChannel);
 
-                                ctx.pipeline().addFirst(symmetricHandler);
+                                ctx.pipeline().addBefore(ctx.name(), null, symmetricHandler);
+
                                 symmetricHandlerAdded = true;
                             }
 

--- a/opc-ua-stack/stack-server/src/main/java/org/eclipse/milo/opcua/stack/server/handlers/UaTcpServerAsymmetricHandler.java
+++ b/opc-ua-stack/stack-server/src/main/java/org/eclipse/milo/opcua/stack/server/handlers/UaTcpServerAsymmetricHandler.java
@@ -94,10 +94,18 @@ public class UaTcpServerAsymmetricHandler extends ByteToMessageDecoder implement
 
     @Override
     protected void decode(ChannelHandlerContext ctx, ByteBuf buffer, List<Object> out) throws Exception {
-        while (buffer.readableBytes() >= HEADER_LENGTH &&
-            buffer.readableBytes() >= getMessageLength(buffer)) {
-
+        while (buffer.readableBytes() >= HEADER_LENGTH) {
             int messageLength = getMessageLength(buffer);
+
+            if (messageLength > maxChunkSize) {
+                throw new UaException(StatusCodes.Bad_TcpMessageTooLarge,
+                    String.format("max chunk size exceeded (%s)", maxChunkSize));
+            }
+
+            if (buffer.readableBytes() < messageLength) {
+                break;
+            }
+
             MessageType messageType = MessageType.fromMediumInt(buffer.getMediumLE(buffer.readerIndex()));
 
             switch (messageType) {

--- a/opc-ua-stack/stack-server/src/main/java/org/eclipse/milo/opcua/stack/server/handlers/UaTcpServerHelloHandler.java
+++ b/opc-ua-stack/stack-server/src/main/java/org/eclipse/milo/opcua/stack/server/handlers/UaTcpServerHelloHandler.java
@@ -54,10 +54,19 @@ public class UaTcpServerHelloHandler extends ByteToMessageDecoder implements Hea
 
     @Override
     protected void decode(ChannelHandlerContext ctx, ByteBuf buffer, List<Object> out) throws Exception {
-        while (buffer.readableBytes() >= HEADER_LENGTH &&
-            buffer.readableBytes() >= getMessageLength(buffer)) {
-
+        while (buffer.readableBytes() >= HEADER_LENGTH) {
             int messageLength = getMessageLength(buffer);
+
+            // We don't actually know the configured max chunk size here, but a Hello message can only be so big...
+            if (messageLength > ChannelConfig.DEFAULT_MAX_CHUNK_SIZE) {
+                throw new UaException(StatusCodes.Bad_TcpMessageTooLarge,
+                    String.format("max chunk size exceeded (%s)", ChannelConfig.DEFAULT_MAX_CHUNK_SIZE));
+            }
+
+            if (buffer.readableBytes() < messageLength) {
+                break;
+            }
+
             MessageType messageType = MessageType.fromMediumInt(buffer.getMediumLE(buffer.readerIndex()));
 
             switch (messageType) {

--- a/opc-ua-stack/stack-server/src/main/java/org/eclipse/milo/opcua/stack/server/handlers/UaTcpServerSymmetricHandler.java
+++ b/opc-ua-stack/stack-server/src/main/java/org/eclipse/milo/opcua/stack/server/handlers/UaTcpServerSymmetricHandler.java
@@ -188,10 +188,18 @@ public class UaTcpServerSymmetricHandler extends ByteToMessageCodec<ServiceRespo
 
     @Override
     protected void decode(ChannelHandlerContext ctx, ByteBuf buffer, List<Object> out) throws Exception {
-        while (buffer.readableBytes() >= HEADER_LENGTH &&
-            buffer.readableBytes() >= getMessageLength(buffer)) {
-
+        while (buffer.readableBytes() >= HEADER_LENGTH) {
             int messageLength = getMessageLength(buffer);
+
+            if (messageLength > maxChunkSize) {
+                throw new UaException(StatusCodes.Bad_TcpMessageTooLarge,
+                    String.format("max chunk size exceeded (%s)", maxChunkSize));
+            }
+
+            if (buffer.readableBytes() < messageLength) {
+                break;
+            }
+
             MessageType messageType = MessageType.fromMediumInt(buffer.getMediumLE(buffer.readerIndex()));
 
             switch (messageType) {

--- a/opc-ua-stack/stack-server/src/main/java/org/eclipse/milo/opcua/stack/server/handlers/UaTcpServerSymmetricHandler.java
+++ b/opc-ua-stack/stack-server/src/main/java/org/eclipse/milo/opcua/stack/server/handlers/UaTcpServerSymmetricHandler.java
@@ -189,12 +189,7 @@ public class UaTcpServerSymmetricHandler extends ByteToMessageCodec<ServiceRespo
     @Override
     protected void decode(ChannelHandlerContext ctx, ByteBuf buffer, List<Object> out) throws Exception {
         while (buffer.readableBytes() >= HEADER_LENGTH) {
-            int messageLength = getMessageLength(buffer);
-
-            if (messageLength > maxChunkSize) {
-                throw new UaException(StatusCodes.Bad_TcpMessageTooLarge,
-                    String.format("max chunk size exceeded (%s)", maxChunkSize));
-            }
+            int messageLength = getMessageLength(buffer, maxChunkSize);
 
             if (buffer.readableBytes() < messageLength) {
                 break;

--- a/opc-ua-stack/stack-server/src/main/java/org/eclipse/milo/opcua/stack/server/tcp/SocketServers.java
+++ b/opc-ua-stack/stack-server/src/main/java/org/eclipse/milo/opcua/stack/server/tcp/SocketServers.java
@@ -39,6 +39,7 @@ import org.eclipse.milo.opcua.stack.core.util.AsyncSemaphore;
 import org.eclipse.milo.opcua.stack.core.util.EndpointUtil;
 import org.eclipse.milo.opcua.stack.core.util.FutureUtils;
 import org.eclipse.milo.opcua.stack.core.util.Unit;
+import org.eclipse.milo.opcua.stack.server.handlers.RateLimitingHandler;
 import org.eclipse.milo.opcua.stack.server.handlers.UaTcpServerHelloHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -189,7 +190,6 @@ public class SocketServers {
         }
 
         static CompletableFuture<SocketServer> bootstrap(InetSocketAddress address) {
-
             final CompletableFuture<SocketServer> serverFuture = new CompletableFuture<>();
 
             final ServerBootstrap bootstrap = new ServerBootstrap();
@@ -205,6 +205,7 @@ public class SocketServers {
                         Function<String, Optional<UaTcpStackServer>> serverLookup =
                             endpointUrl -> getServerByEndpointUrl(address, endpointUrl);
 
+                        channel.pipeline().addLast(RateLimitingHandler.getInstance());
                         channel.pipeline().addLast(new UaTcpServerHelloHandler(serverLookup));
                     }
                 });


### PR DESCRIPTION
Implements some basic DoS mitigations:

1) Rate limit inbound connection attempts on a per-remote-address basis. This does not include connections from localhost.

2) Check the message length indicated in the header against max chunk size ASAP. This prevents a maliciously crafted length and buffer from growing beyond max chunk size, as opposed to letting it grow and catching it when the chunk is handled.

3) Limit the number of total connections and connections per remote address.

4) Implement a deadline for receiving the UA TCP Hello message after a connection is established.