### PR TITLE
[#216] allow EncodingLimits to be used with ExtensionObjects

### DIFF
--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/nodes/UaNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/nodes/UaNode.java
@@ -372,7 +372,10 @@ public abstract class UaNode implements Node {
                 return null;
             }
         } else if (UaStructure.class.isAssignableFrom(clazz) && o instanceof ExtensionObject) {
-            Object decoded = ((ExtensionObject) o).decode(client.getDataTypeManager());
+            Object decoded = ((ExtensionObject) o).decode(
+                client.getConfig().getEncodingLimits(),
+                client.getDataTypeManager()
+            );
             return clazz.cast(decoded);
         } else {
             return clazz.cast(o);

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/subscriptions/OpcUaSubscriptionManager.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/subscriptions/OpcUaSubscriptionManager.java
@@ -663,7 +663,7 @@ public class OpcUaSubscriptionManager implements UaSubscriptionManager {
                 List<ExtensionObject> notificationData = l(notificationMessage.getNotificationData());
 
                 for (ExtensionObject xo : notificationData) {
-                    Object o = xo.decode();
+                    Object o = xo.decode(client.getConfig().getEncodingLimits(), client.getDataTypeManager());
 
                     if (o instanceof DataChangeNotification) {
                         DataChangeNotification dcn = (DataChangeNotification) o;

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/SessionManager.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/SessionManager.java
@@ -50,6 +50,7 @@ import org.eclipse.milo.opcua.stack.core.application.services.ViewServiceSet;
 import org.eclipse.milo.opcua.stack.core.channel.ServerSecureChannel;
 import org.eclipse.milo.opcua.stack.core.security.SecurityAlgorithm;
 import org.eclipse.milo.opcua.stack.core.security.SecurityPolicy;
+import org.eclipse.milo.opcua.stack.core.types.OpcUaDataTypeManager;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
 import org.eclipse.milo.opcua.stack.core.types.builtin.DiagnosticInfo;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
@@ -393,7 +394,11 @@ public class SessionManager implements
                     /*
                      * Identity change
                      */
-                    Object tokenObject = request.getUserIdentityToken().decode();
+                    Object tokenObject = request.getUserIdentityToken().decode(
+                        server.getConfig().getEncodingLimits(),
+                        OpcUaDataTypeManager.getInstance()
+                    );
+
                     Object identityObject = validateIdentityToken(
                         secureChannel,
                         session,
@@ -427,7 +432,11 @@ public class SessionManager implements
                         throw new UaException(StatusCodes.Bad_IdentityTokenInvalid, "identity token not provided");
                     }
 
-                    Object tokenObject = request.getUserIdentityToken().decode();
+                    Object tokenObject = request.getUserIdentityToken().decode(
+                        server.getConfig().getEncodingLimits(),
+                        OpcUaDataTypeManager.getInstance()
+                    );
+
                     Object identityObject = validateIdentityToken(
                         secureChannel,
                         session,
@@ -474,7 +483,11 @@ public class SessionManager implements
 
             verifyClientSignature(request, secureChannel, session);
 
-            Object tokenObject = request.getUserIdentityToken().decode();
+            Object tokenObject = request.getUserIdentityToken().decode(
+                server.getConfig().getEncodingLimits(),
+                OpcUaDataTypeManager.getInstance()
+            );
+
             Object identityObject = validateIdentityToken(
                 secureChannel,
                 session,

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/util/AttributeReader.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/util/AttributeReader.java
@@ -191,6 +191,7 @@ public class AttributeReader {
             return xo.transcode(
                 newEncodingId,
                 encoding,
+                context.getServer().getConfig().getEncodingLimits(),
                 OpcUaDataTypeManager.getInstance()
             );
         } else {

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/serialization/OpcUaXmlStreamDecoder.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/serialization/OpcUaXmlStreamDecoder.java
@@ -89,7 +89,15 @@ public class OpcUaXmlStreamDecoder implements UaDecoder {
     private Document document;
     private Node currentNode;
 
+    private final EncodingLimits encodingLimits;
+
     public OpcUaXmlStreamDecoder() {
+        this(EncodingLimits.DEFAULT);
+    }
+
+    public OpcUaXmlStreamDecoder(EncodingLimits encodingLimits) {
+        this.encodingLimits = encodingLimits;
+
         try {
             builder = FACTORY.newDocumentBuilder();
         } catch (ParserConfigurationException e) {

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/serialization/OpcUaXmlStreamEncoder.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/serialization/OpcUaXmlStreamEncoder.java
@@ -62,7 +62,15 @@ public class OpcUaXmlStreamEncoder implements UaEncoder {
     private Document document;
     private Node currentNode;
 
+    private final EncodingLimits encodingLimits;
+
     public OpcUaXmlStreamEncoder() {
+        this(EncodingLimits.DEFAULT);
+    }
+
+    public OpcUaXmlStreamEncoder(EncodingLimits encodingLimits) {
+        this.encodingLimits = encodingLimits;
+
         try {
             builder = FACTORY.newDocumentBuilder();
 

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/DataTypeEncoding.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/DataTypeEncoding.java
@@ -13,6 +13,7 @@
 
 package org.eclipse.milo.opcua.stack.core.types;
 
+import org.eclipse.milo.opcua.stack.core.serialization.EncodingLimits;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExtensionObject;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
@@ -23,8 +24,16 @@ public interface DataTypeEncoding {
 
     ExtensionObject.BodyType getBodyType();
 
-    Object encode(Object struct, NodeId encodingId, DataTypeManager dataTypeManager);
+    Object encode(
+        Object decodedBody,
+        NodeId encodingId,
+        EncodingLimits encodingLimits,
+        DataTypeManager dataTypeManager);
 
-    Object decode(Object body, NodeId encodingId, DataTypeManager dataTypeManager);
+    Object decode(
+        Object encodedBody,
+        NodeId encodingId,
+        EncodingLimits encodingLimits,
+        DataTypeManager dataTypeManager);
 
 }

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/OpcUaDefaultXmlEncoding.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/OpcUaDefaultXmlEncoding.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import com.google.common.base.Charsets;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.UaSerializationException;
+import org.eclipse.milo.opcua.stack.core.serialization.EncodingLimits;
 import org.eclipse.milo.opcua.stack.core.serialization.OpcUaXmlStreamDecoder;
 import org.eclipse.milo.opcua.stack.core.serialization.OpcUaXmlStreamEncoder;
 import org.eclipse.milo.opcua.stack.core.serialization.codecs.OpcUaXmlDataTypeCodec;
@@ -52,7 +53,12 @@ public class OpcUaDefaultXmlEncoding implements DataTypeEncoding {
     }
 
     @Override
-    public Object encode(Object struct, NodeId encodingId, DataTypeManager dataTypeManager) {
+    public Object encode(
+        Object struct,
+        NodeId encodingId,
+        EncodingLimits encodingLimits,
+        DataTypeManager dataTypeManager) {
+
         try {
             @SuppressWarnings("unchecked")
             OpcUaXmlDataTypeCodec<Object> codec =
@@ -64,7 +70,7 @@ public class OpcUaDefaultXmlEncoding implements DataTypeEncoding {
                     "no codec registered for encodingId=" + encodingId);
             }
 
-            OpcUaXmlStreamEncoder writer = new OpcUaXmlStreamEncoder();
+            OpcUaXmlStreamEncoder writer = new OpcUaXmlStreamEncoder(encodingLimits);
 
             codec.encode(() -> dataTypeManager, struct, writer);
 
@@ -75,7 +81,12 @@ public class OpcUaDefaultXmlEncoding implements DataTypeEncoding {
     }
 
     @Override
-    public Object decode(Object body, NodeId encodingId, DataTypeManager dataTypeManager) {
+    public Object decode(
+        Object body,
+        NodeId encodingId,
+        EncodingLimits encodingLimits,
+        DataTypeManager dataTypeManager) {
+
         try {
             @SuppressWarnings("unchecked")
             OpcUaXmlDataTypeCodec<Object> codec =
@@ -90,7 +101,7 @@ public class OpcUaDefaultXmlEncoding implements DataTypeEncoding {
             XmlElement xmlBody = (XmlElement) body;
             String xml = xmlBody.getFragmentOrEmpty();
 
-            OpcUaXmlStreamDecoder reader = new OpcUaXmlStreamDecoder();
+            OpcUaXmlStreamDecoder reader = new OpcUaXmlStreamDecoder(encodingLimits);
             reader.setInput(new ByteArrayInputStream(xml.getBytes(Charsets.UTF_8)));
 
             return reader.readStruct(null, encodingId);

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/builtin/ExtensionObject.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/builtin/ExtensionObject.java
@@ -118,6 +118,20 @@ public final class ExtensionObject {
     }
 
     public Object decode(
+        EncodingLimits encodingLimits,
+        DataTypeManager dataTypeManager) throws UaSerializationException {
+
+        switch (bodyType) {
+            case ByteString:
+                return decode(OpcUaDefaultBinaryEncoding.getInstance(), encodingLimits, dataTypeManager);
+            case XmlElement:
+                return decode(OpcUaDefaultXmlEncoding.getInstance(), encodingLimits, dataTypeManager);
+            default:
+                throw new IllegalStateException("BodyType: " + bodyType);
+        }
+    }
+
+    public Object decode(
         DataTypeEncoding encoding,
         DataTypeManager dataTypeManager) throws UaSerializationException {
 
@@ -151,9 +165,9 @@ public final class ExtensionObject {
     }
 
     @Nullable
-    public Object decodeOrNull(DataTypeEncoding encoding, DataTypeManager dataTypeManager) {
+    public Object decodeOrNull(EncodingLimits encodingLimits, DataTypeManager dataTypeManager) {
         try {
-            return decode(encoding, dataTypeManager);
+            return decode(encodingLimits, dataTypeManager);
         } catch (UaSerializationException e) {
             return null;
         }
@@ -170,7 +184,7 @@ public final class ExtensionObject {
         } else {
             // The "fast" path: body is a encoded in Default Binary or Default XML.
             // No need to look up the DataTypeEncoding.
-            Object struct = decodeOrNull();
+            Object struct = decodeOrNull(encodingLimits, dataTypeManager);
 
             if (struct != null) {
                 Object encoded = newEncoding.encode(struct, newEncodingId, encodingLimits, dataTypeManager);


### PR DESCRIPTION
Encode, decode, and transcode methods now accept an EncodingLimits in
their most verbose overload.