### PR TITLE
Ignore duplicate namespace URIs

### DIFF
--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/OpcUaClient.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/OpcUaClient.java
@@ -208,6 +208,11 @@ public class OpcUaClient implements UaClient {
                         uriTable.clear();
 
                         for (int i = 0; i < uris.length; i++) {
+                            if (uriTable.containsValue(uris[i])) {
+                                logger.warn("Skipping duplicate namespace URI: {}");
+                                continue;
+                            }
+
                             uriTable.put(ushort(i), uris[i]);
                         }
                     });


### PR DESCRIPTION
Hey and thanks for this wonderful library!

We are using Milo 0.2.1 to connect to a commercial OPC UA product, and ran into an issue where said product returns several namespaces with the URI "null". This then leads to an IllegalArgumentException in Milo because the same value ("null") is inserted into the namespace BiMap twice. And this exception then prevents Milo from learning about all namespaces in the array after the second "null" value.

I am not sure what the best way to handle this (presumably buggy?) server behavior would be. Attached is the simple fix we are currently evaluating internally.