### PR TITLE
use getSubjectAltNameField method and URI constant

### DIFF
--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/SessionManager.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/SessionManager.java
@@ -57,6 +57,7 @@ import org.eclipse.milo.opcua.stack.core.types.structured.SignedSoftwareCertific
 import org.eclipse.milo.opcua.stack.core.types.structured.UserIdentityToken;
 import org.eclipse.milo.opcua.stack.core.types.structured.UserTokenPolicy;
 import org.eclipse.milo.opcua.stack.core.util.CertificateUtil;
+import org.eclipse.milo.opcua.stack.core.util.CertificateValidationUtil;
 import org.eclipse.milo.opcua.stack.core.util.EndpointUtil;
 import org.eclipse.milo.opcua.stack.core.util.NonceUtil;
 import org.eclipse.milo.opcua.stack.core.util.SignatureUtil;
@@ -237,7 +238,7 @@ public class SessionManager implements
 
             String applicationUri = request.getClientDescription().getApplicationUri();
 
-            validateApplicationUri(applicationUri, clientCertificate);
+            CertificateValidationUtil.validateApplicationUri(clientCertificate, applicationUri);
 
             CertificateValidator certificateValidator =
                 server.getConfig().getCertificateValidator();
@@ -359,32 +360,6 @@ public class SessionManager implements
             logger.warn("Unable to create URI.", e);
             return false;
         }
-    }
-
-    /**
-     * Validate that the application URI matches the SubjectAltName URI in the given certificate.
-     *
-     * @param applicationUri the URI to match.
-     * @param certificate    the certificate to match against.
-     * @throws UaException if the certificate is invalid, does not contain a uri, or contains a uri that does not match.
-     */
-    private void validateApplicationUri(String applicationUri, X509Certificate certificate) throws UaException {
-		Optional<Object> subjectAltNameField = CertificateUtil.getSubjectAltNameField(certificate,
-				CertificateUtil.SUBJECT_ALT_NAME_URI);
-		if (subjectAltNameField.isPresent()) {
-			String certificateUri = (String) subjectAltNameField.get();
-			if (!applicationUri.equals(certificateUri)) {
-				String message = String.format("Certificate URI does not match. certificateUri=%s, applicationUri=%s",
-						certificateUri, applicationUri);
-
-				logger.warn(message);
-				throw new UaException(StatusCodes.Bad_CertificateUriInvalid, message);
-			}
-			return;
-		} else {
-			String message = "Certificate does not contain a SubjectAlternativeName URI entry.";
-			throw new UaException(StatusCodes.Bad_CertificateUriInvalid, message);
-		}
     }
 
     @Override


### PR DESCRIPTION
The method to extract a SAN of a certain type from
a certificate was already implemented but not used
in SessionManager.validateApplicationUri.

Signed-off-by: André Birke <abirke@campus.uni-paderborn.de>