### PR TITLE
Use a fixed namespace for root BrowsePath when building type hierarchy

### DIFF
--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/factories/BrowsePath.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/factories/BrowsePath.java
@@ -19,6 +19,11 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
 
 public class BrowsePath {
 
+    static final BrowsePath ROOT = new BrowsePath(
+        null,
+        new QualifiedName(0, "/")
+    );
+
     BrowsePath parent;
     QualifiedName browseName;
 
@@ -50,7 +55,7 @@ public class BrowsePath {
             if (!s.endsWith(separator)) {
                 s += separator;
             }
-            return s + browseName.getName();
+            return s + browseName.getNamespaceIndex() + ":" + browseName.getName();
         }
     }
 

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/factories/InstanceDeclarationHierarchy.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/factories/InstanceDeclarationHierarchy.java
@@ -103,10 +103,7 @@ public class InstanceDeclarationHierarchy {
         }
 
         private InstanceDeclarationHierarchy buildHierarchyForType(NodeId typeDefinitionId) {
-            BrowsePath browsePath = new BrowsePath(
-                null,
-                new QualifiedName(typeDefinitionId.getNamespaceIndex(), "/")
-            );
+            BrowsePath browsePath = BrowsePath.ROOT;
 
             nodeTable.addNode(browsePath, typeDefinitionId);
             referenceTable.addReference(browsePath, Identifiers.HasTypeDefinition, typeDefinitionId.expanded());

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/factories/ReferenceTable.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/factories/ReferenceTable.java
@@ -61,11 +61,13 @@ class ReferenceTable {
                 // This logic may need to be extended to include other Reference types for
                 // which there should only be one.
 
-                boolean noTypeDefinition = mergedTable.references.stream()
-                    .noneMatch(r ->
-                        r.browsePath.equals(browsePath) && r.nodeId.equals(Identifiers.HasTypeDefinition));
+                boolean hasTypeDefinitionReference = mergedTable.references.stream().anyMatch(
+                    r ->
+                        r.browsePath.equals(browsePath) &&
+                            r.nodeId.equals(Identifiers.HasTypeDefinition)
+                );
 
-                if (noTypeDefinition) {
+                if (!hasTypeDefinitionReference) {
                     mergedTable.references.add(row);
                 }
             } else if (!mergedTable.references.contains(row)) {


### PR DESCRIPTION
Always use namespace 0 for BrowsePath that represents the root of a
hierarchy so equality check works even when the type hierarchy spans
multiple namespaces.

fixes #350