### PR TITLE
Configurable LocaleIds when activateSession

### DIFF
--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/api/config/OpcUaClientConfig.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/api/config/OpcUaClientConfig.java
@@ -60,6 +60,11 @@ public interface OpcUaClientConfig extends UaTcpStackClientConfig {
     BsdParser getBsdParser();
 
     /**
+     * @return the list of locale ids in priority order for localized strings
+     */
+    String[] getSessionLocaleIds();
+
+    /**
      * @return a new {@link OpcUaClientConfigBuilder}.
      */
     static OpcUaClientConfigBuilder builder() {
@@ -100,6 +105,7 @@ public interface OpcUaClientConfig extends UaTcpStackClientConfig {
         builder.setMaxPendingPublishRequests(config.getMaxPendingPublishRequests());
         builder.setIdentityProvider(config.getIdentityProvider());
         builder.setBsdParser(config.getBsdParser());
+        builder.setSessionLocaleIds(config.getSessionLocaleIds());
 
         return builder;
     }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/api/config/OpcUaClientConfigBuilder.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/api/config/OpcUaClientConfigBuilder.java
@@ -45,6 +45,7 @@ public class OpcUaClientConfigBuilder extends UaTcpStackClientConfigBuilder {
     private UInteger maxPendingPublishRequests = uint(UInteger.MAX_VALUE);
     private IdentityProvider identityProvider = new AnonymousProvider();
     private BsdParser bsdParser = new GenericBsdParser();
+    private String[] sessionLocaleIds = new String[0];
 
     public OpcUaClientConfigBuilder setSessionName(Supplier<String> sessionName) {
         this.sessionName = sessionName;
@@ -78,6 +79,11 @@ public class OpcUaClientConfigBuilder extends UaTcpStackClientConfigBuilder {
 
     public OpcUaClientConfigBuilder setBsdParser(BsdParser bsdParser) {
         this.bsdParser = bsdParser;
+        return this;
+    }
+
+    public OpcUaClientConfigBuilder setSessionLocaleIds(String[] sessionLocaleIds) {
+        this.sessionLocaleIds = sessionLocaleIds;
         return this;
     }
 
@@ -188,7 +194,8 @@ public class OpcUaClientConfigBuilder extends UaTcpStackClientConfigBuilder {
             maxPendingPublishRequests,
             requestTimeout,
             identityProvider,
-            bsdParser
+            bsdParser,
+            sessionLocaleIds
         );
     }
 
@@ -202,6 +209,7 @@ public class OpcUaClientConfigBuilder extends UaTcpStackClientConfigBuilder {
         private final UInteger requestTimeout;
         private final IdentityProvider identityProvider;
         private final BsdParser bsdParser;
+        private final String[] sessionLocaleIds;
 
         public OpcUaClientConfigImpl(UaTcpStackClientConfig stackClientConfig,
                                      Supplier<String> sessionName,
@@ -210,7 +218,8 @@ public class OpcUaClientConfigBuilder extends UaTcpStackClientConfigBuilder {
                                      UInteger maxPendingPublishRequests,
                                      UInteger requestTimeout,
                                      IdentityProvider identityProvider,
-                                     BsdParser bsdParser) {
+                                     BsdParser bsdParser,
+                                     String[] sessionLocaleIds) {
 
             this.stackClientConfig = stackClientConfig;
             this.sessionName = sessionName;
@@ -220,6 +229,7 @@ public class OpcUaClientConfigBuilder extends UaTcpStackClientConfigBuilder {
             this.requestTimeout = requestTimeout;
             this.identityProvider = identityProvider;
             this.bsdParser = bsdParser;
+            this.sessionLocaleIds = sessionLocaleIds;
         }
 
         @Override
@@ -255,6 +265,11 @@ public class OpcUaClientConfigBuilder extends UaTcpStackClientConfigBuilder {
         @Override
         public BsdParser getBsdParser() {
             return bsdParser;
+        }
+        
+        @Override
+        public String[] getSessionLocaleIds() {
+            return sessionLocaleIds;
         }
 
         @Override

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/session/states/AbstractSessionState.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/session/states/AbstractSessionState.java
@@ -226,6 +226,8 @@ abstract class AbstractSessionState implements SessionState {
 
                 ByteString serverNonce = csr.getServerNonce();
 
+                String[] localeIds = client.getConfig().getSessionLocaleIds();
+
                 Tuple2<UserIdentityToken, SignatureData> tuple =
                     client.getConfig().getIdentityProvider()
                         .getIdentityToken(endpoint, serverNonce);
@@ -237,7 +239,7 @@ abstract class AbstractSessionState implements SessionState {
                     client.newRequestHeader(csr.getAuthenticationToken(), REQUEST_TIMEOUT),
                     buildClientSignature(secureChannel, serverNonce),
                     new SignedSoftwareCertificate[0],
-                    new String[0],
+                    localeIds,
                     ExtensionObject.encode(userIdentityToken),
                     userTokenSignature
                 );

--- a/opc-ua-sdk/sdk-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/config/OpcUaClientConfigTest.java
+++ b/opc-ua-sdk/sdk-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/config/OpcUaClientConfigTest.java
@@ -35,6 +35,7 @@ public class OpcUaClientConfigTest {
             .setMaxPendingPublishRequests(uint(2))
             .setIdentityProvider(new AnonymousProvider())
             .setBsdParser(new GenericBsdParser())
+            .setSessionLocaleIds(new String[]{"en", "es"})
             .build();
 
         OpcUaClientConfig copy = OpcUaClientConfig.copy(original).build();
@@ -46,6 +47,7 @@ public class OpcUaClientConfigTest {
         assertEquals(copy.getMaxPendingPublishRequests(), original.getMaxPendingPublishRequests());
         assertEquals(copy.getIdentityProvider(), original.getIdentityProvider());
         assertEquals(copy.getBsdParser(), original.getBsdParser());
+        assertEquals(copy.getSessionLocaleIds(), original.getSessionLocaleIds());
     }
 
     @Test
@@ -68,16 +70,19 @@ public class OpcUaClientConfigTest {
                     .setMaxPendingPublishRequests(uint(0))
                     .setIdentityProvider(new AnonymousProvider())
                     .setBsdParser(new GenericBsdParser())
+                    .setSessionLocaleIds(new String[]{"en", "es"})
         );
 
         assertNotEquals(copy.getSessionName(), original.getSessionName());
         assertNotEquals(copy.getIdentityProvider(), original.getIdentityProvider());
         assertNotEquals(copy.getBsdParser(), original.getBsdParser());
+        assertNotEquals(copy.getSessionLocaleIds(), original.getSessionLocaleIds());
 
         assertEquals(copy.getSessionTimeout(), uint(0));
         assertEquals(copy.getRequestTimeout(), uint(0));
         assertEquals(copy.getMaxResponseMessageSize(), uint(0));
         assertEquals(copy.getMaxPendingPublishRequests(), uint(0));
+        assertEquals(copy.getSessionLocaleIds(), new String[]{"en", "es"});
     }
 
 }


### PR DESCRIPTION
Currently, session's preferred localeIds are set to none (empty array). With this modification they default to none, but they can be configured by calling OpcUaClientConfigBuilder.setSessionLocaleIds()

Signed-off-by: igarciasz <ignacio.garcia@tecnalia.com>