### PR TITLE
Fix eclipse checkstyle errors

### DIFF
--- a/milo-examples/client-examples/src/main/java/org/eclipse/milo/examples/client/ProsysEventSubscriptionExample.java
+++ b/milo-examples/client-examples/src/main/java/org/eclipse/milo/examples/client/ProsysEventSubscriptionExample.java
@@ -13,7 +13,6 @@
 
 package org.eclipse.milo.examples.client;
 
-
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/session/states/SessionState.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/session/states/SessionState.java
@@ -13,7 +13,6 @@
 
 package org.eclipse.milo.opcua.sdk.client.session.states;
 
-
 import java.util.concurrent.CompletableFuture;
 
 import org.eclipse.milo.opcua.sdk.client.OpcUaSession;

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/application/CertificateValidator.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/application/CertificateValidator.java
@@ -13,7 +13,6 @@
 
 package org.eclipse.milo.opcua.stack.core.application;
 
-
 import java.security.cert.X509Certificate;
 import java.util.List;
 

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/application/DefaultCertificateValidator.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/application/DefaultCertificateValidator.java
@@ -13,7 +13,6 @@
 
 package org.eclipse.milo.opcua.stack.core.application;
 
-
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/util/PShaUtil.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/util/PShaUtil.java
@@ -13,7 +13,6 @@
 
 package org.eclipse.milo.opcua.stack.core.util;
 
-
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 


### PR DESCRIPTION
I believe there is "maven" checking of checkstyle, but by default eclipse import of the projects, the below cause errors. I believe they are not harmful, and we can add checkstyle checks in Eclipse to match maven, at a later point.

Signed-off-by: Ahmed Ashour <asashour@yahoo.com>