### PR TITLE
ignore test-output folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@
 # Maven #
 target/
 dependency-reduced-pom.xml
+
+# TestNG #
+test-output

--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,4 @@ target/
 dependency-reduced-pom.xml
 
 # TestNG #
-test-output
+test-output/


### PR DESCRIPTION
Running TestNG tests in Eclipse produces files in `test-output`, and these are considered for commits, it should be ignored.

Signed-off-by: Ahmed Ashour <asashour@yahoo.com>