### PR TITLE
Refactor EndpointUtil.getPath() to use regex instead of Java's URI

### DIFF
--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/util/EndpointUtil.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/util/EndpointUtil.java
@@ -13,7 +13,6 @@
 
 package org.eclipse.milo.opcua.stack.core.util;
 
-import java.net.URI;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.annotation.Nonnull;
@@ -70,31 +69,31 @@ public class EndpointUtil {
         return 4840;
     }
 
+
     /**
      * Get the path component from an endpoint URL.
      * <p>
      * An empty path becomes "/" and trailing "/" are removed from non-empty paths.
-     * <p>
-     * If the URL is not valid the full URL will be returned.
      *
      * @param endpointUrl the endpoint URL.
      * @return the path component from the endpoint URL.
      */
+    @Nonnull
     public static String getPath(@Nonnull String endpointUrl) {
-        try {
-            URI uri = new URI(endpointUrl).parseServerAuthority();
+        Matcher matcher = ENDPOINT_URL_PATTERN.matcher(endpointUrl);
 
-            String path = uri.getPath();
+        if (matcher.matches()) {
+            String path = matcher.group(4);
 
             if (path == null || path.isEmpty()) {
                 path = "/";
             } else if (path.length() > 1 && path.endsWith("/")) {
                 path = path.substring(0, path.length() - 1);
             }
+
             return path;
-        } catch (Throwable e) {
-            LOGGER.warn("Endpoint URL '{}' is not a valid URI: {}", e.getMessage(), e);
-            return endpointUrl;
+        } else {
+            return "/";
         }
     }
 

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/util/EndpointUtil.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/util/EndpointUtil.java
@@ -19,12 +19,8 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import org.eclipse.milo.opcua.stack.core.types.structured.EndpointDescription;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class EndpointUtil {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(EndpointUtil.class);
 
     private static final Pattern ENDPOINT_URL_PATTERN =
         Pattern.compile("(opc.tcp|http|https|opc.http|opc.https|opc.ws|opc.wss)://([^:/]+)(:\\d+)?(/.*)?");
@@ -68,7 +64,6 @@ public class EndpointUtil {
 
         return 4840;
     }
-
 
     /**
      * Get the path component from an endpoint URL.

--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/util/EndpointUtilTest.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/util/EndpointUtilTest.java
@@ -21,22 +21,26 @@ import static org.testng.Assert.assertEquals;
 public class EndpointUtilTest {
 
     @Test
-    public void testGetPath() throws Exception {
+    public void testGetPath() {
         assertEquals(EndpointUtil.getPath("opc.tcp://localhost:4840/foo"), "/foo");
         assertEquals(EndpointUtil.getPath("opc.tcp://localhost:4840/foo/"), "/foo");
+        assertEquals(EndpointUtil.getPath("opc.tcp://invalid_host:4840/foo"), "/foo");
+        assertEquals(EndpointUtil.getPath("opc.tcp://invalid_host:4840/foo/"), "/foo");
     }
 
     @Test
-    public void testGetPath_EmptyAndSlash() throws Exception {
+    public void testGetPath_EmptyAndSlash() {
         assertEquals(EndpointUtil.getPath("opc.tcp://localhost:4840"), "/");
         assertEquals(EndpointUtil.getPath("opc.tcp://localhost:4840/"), "/");
+        assertEquals(EndpointUtil.getPath("opc.tcp://invalid_host:4840"), "/");
+        assertEquals(EndpointUtil.getPath("opc.tcp://invalid_host:4840/"), "/");
     }
 
 
     @Test
-    public void testGetPath_Invalid() throws Exception {
+    public void testGetPath_Invalid() {
         assertEquals(EndpointUtil.getPath("opc.tcp://localhost:4840/no spaces allowed"),
-            "opc.tcp://localhost:4840/no spaces allowed");
+            "/no spaces allowed");
     }
 
     @Test


### PR DESCRIPTION
This allows it to extract paths from URLs that Java's URI class deems
invalid like other methods do.