### PR TITLE
Pass messages to next the handler using ctx.fireChannelRead()

### DIFF
--- a/opc-ua-stack/stack-client/src/main/java/org/eclipse/milo/opcua/stack/client/transport/uasc/UascClientMessageHandler.java
+++ b/opc-ua-stack/stack-client/src/main/java/org/eclipse/milo/opcua/stack/client/transport/uasc/UascClientMessageHandler.java
@@ -390,14 +390,15 @@ public class UascClientMessageHandler extends ByteToMessageCodec<UaTransportRequ
             int messageLength = getMessageLength(buffer, maxChunkSize);
 
             if (buffer.readableBytes() >= messageLength) {
-                decodeMessage(ctx, buffer);
+                decodeMessage(ctx, buffer, messageLength);
             }
         }
     }
 
-    private void decodeMessage(ChannelHandlerContext ctx, ByteBuf buffer) throws UaException {
-        int messageLength = getMessageLength(buffer, maxChunkSize);
-        MessageType messageType = MessageType.fromMediumInt(buffer.getMediumLE(buffer.readerIndex()));
+    private void decodeMessage(ChannelHandlerContext ctx, ByteBuf buffer, int messageLength) throws UaException {
+        MessageType messageType = MessageType.fromMediumInt(
+            buffer.getMediumLE(buffer.readerIndex())
+        );
 
         switch (messageType) {
             case OpenSecureChannel:
@@ -415,7 +416,8 @@ public class UascClientMessageHandler extends ByteToMessageCodec<UaTransportRequ
             default:
                 throw new UaException(
                     StatusCodes.Bad_TcpMessageTypeInvalid,
-                    "unexpected MessageType: " + messageType);
+                    "unexpected MessageType: " + messageType
+                );
         }
     }
 


### PR DESCRIPTION
This prevents sequence numbers from being processed out of order when 
two or more messages, starting with an OPN for a secure channel renewal,
arrive at the same time and are all ready to be decoded.

Implement `decode` consistently among all the handlers, allowing Netty
to be responsible for looping until no more messages can be read.

fixes #483