### PR TITLE
Add type parameter to IdentityValidator API

### DIFF
--- a/build-tools/src/main/resources/milo/checkstyle.xml
+++ b/build-tools/src/main/resources/milo/checkstyle.xml
@@ -18,7 +18,7 @@
 
     <module name="RegexpHeader">
         <property name="header"
-                  value="/*\n * Copyright \(c\) \d\d\d\d the Eclipse Milo Authors\n *\n * This program and the accompanying materials are made\n * available under the terms of the Eclipse Public License 2.0\n * which is available at https://www.eclipse.org/legal/epl-2.0/\n *\n * SPDX-License-Identifier: EPL-2.0\n */\n" />
+                  value="/*\n * Copyright \(c\) \d\d\d\d the Eclipse Milo Authors\n *\n * This program and the accompanying materials are made\n * available under the terms of the Eclipse Public License 2.0\n * which is available at https://www.eclipse.org/legal/epl-2.0/\n *\n * SPDX-License-Identifier: EPL-2.0\n */\n"/>
         <property name="fileExtensions" value="java"/>
     </module>
 
@@ -215,5 +215,9 @@
             <property name="exceptionVariableName" value="expected"/>
         </module>
         <module name="CommentsIndentation"/>
+        <module name="SuppressionCommentFilter">
+            <property name="offCommentFormat" value="@formatter\:off"/>
+            <property name="onCommentFormat" value="@formatter\:on"/>
+        </module>
     </module>
 </module>

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/AbstractIdentityValidator.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/AbstractIdentityValidator.java
@@ -43,21 +43,40 @@ public abstract class AbstractIdentityValidator implements IdentityValidator {
         UserTokenPolicy tokenPolicy,
         SignatureData tokenSignature) throws UaException {
 
-        if (token instanceof AnonymousIdentityToken) {
-            return validateAnonymousToken(
-                session, (AnonymousIdentityToken) token, tokenPolicy, tokenSignature);
-        } else if (token instanceof UserNameIdentityToken) {
-            return validateUsernameToken(
-                session, (UserNameIdentityToken) token, tokenPolicy, tokenSignature);
-        } else if (token instanceof X509IdentityToken) {
-            return validateX509Token(
-                session, (X509IdentityToken) token, tokenPolicy, tokenSignature);
-        } else if (token instanceof IssuedIdentityToken) {
-            return validateIssuedIdentityToken(
-                session, (IssuedIdentityToken) token, tokenPolicy, tokenSignature);
-        } else {
-            throw new UaException(StatusCodes.Bad_IdentityTokenInvalid);
+        switch (tokenPolicy.getTokenType()) {
+            case Anonymous: {
+                if (token instanceof AnonymousIdentityToken) {
+                    return validateAnonymousToken(
+                        session, (AnonymousIdentityToken) token, tokenPolicy, tokenSignature);
+                }
+                break;
+            }
+            case UserName: {
+                if (token instanceof UserNameIdentityToken) {
+                    return validateUsernameToken(
+                        session, (UserNameIdentityToken) token, tokenPolicy, tokenSignature);
+                }
+                break;
+            }
+            case Certificate: {
+                if (token instanceof X509IdentityToken) {
+                    return validateX509Token(
+                        session, (X509IdentityToken) token, tokenPolicy, tokenSignature);
+                }
+                break;
+            }
+            case IssuedToken: {
+                if (token instanceof IssuedIdentityToken) {
+                    return validateIssuedIdentityToken(
+                        session, (IssuedIdentityToken) token, tokenPolicy, tokenSignature);
+                }
+                break;
+            }
+            default:
+                throw new UaException(StatusCodes.Bad_IdentityTokenInvalid);
         }
+
+        throw new UaException(StatusCodes.Bad_IdentityTokenInvalid);
     }
 
     /**

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/AbstractIdentityValidator.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/AbstractIdentityValidator.java
@@ -34,10 +34,10 @@ import org.eclipse.milo.opcua.stack.core.types.structured.X509IdentityToken;
 import org.eclipse.milo.opcua.stack.core.util.CertificateUtil;
 import org.eclipse.milo.opcua.stack.core.util.DigestUtil;
 
-public abstract class AbstractIdentityValidator implements IdentityValidator {
+public abstract class AbstractIdentityValidator<T> implements IdentityValidator<T> {
 
     @Override
-    public Object validateIdentityToken(
+    public T validateIdentityToken(
         Session session,
         UserIdentityToken token,
         UserTokenPolicy tokenPolicy,
@@ -92,7 +92,7 @@ public abstract class AbstractIdentityValidator implements IdentityValidator {
      * @return an identity Object that represents the user.
      * @throws UaException if the token is invalid, rejected, or user access is denied.
      */
-    protected Object validateAnonymousToken(
+    protected T validateAnonymousToken(
         Session session,
         AnonymousIdentityToken token,
         UserTokenPolicy tokenPolicy,
@@ -114,7 +114,7 @@ public abstract class AbstractIdentityValidator implements IdentityValidator {
      * @return an identity Object that represents the user.
      * @throws UaException if the token is invalid, rejected, or user access is denied.
      */
-    protected Object validateUsernameToken(
+    protected T validateUsernameToken(
         Session session,
         UserNameIdentityToken token,
         UserTokenPolicy tokenPolicy,
@@ -136,7 +136,7 @@ public abstract class AbstractIdentityValidator implements IdentityValidator {
      * @return an identity Object that represents the user.
      * @throws UaException if the token is invalid, rejected, or user access is denied.
      */
-    protected Object validateX509Token(
+    protected T validateX509Token(
         Session session,
         X509IdentityToken token,
         UserTokenPolicy tokenPolicy,
@@ -158,7 +158,7 @@ public abstract class AbstractIdentityValidator implements IdentityValidator {
      * @return an identity Object that represents the user.
      * @throws UaException if the token is invalid, rejected, or user access is denied.
      */
-    protected Object validateIssuedIdentityToken(
+    protected T validateIssuedIdentityToken(
         Session session,
         IssuedIdentityToken token,
         UserTokenPolicy tokenPolicy,

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/AbstractUsernameIdentityValidator.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/AbstractUsernameIdentityValidator.java
@@ -148,7 +148,7 @@ public abstract class AbstractUsernameIdentityValidator<T> extends AbstractIdent
      * @param session  the {@link Session} being activated.
      * @param username the username to authenticate.
      * @param password the password to authenticate the user with.
-     * @return an identity object of type {@code T} if the authentication succeeded, {@code null} if it failed.
+     * @return an identity object of type {@code T} if the authentication succeeded, or {@code null} if it failed.
      */
     @Nullable
     protected abstract T authenticateUsernamePassword(Session session, String username, String password);

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/AbstractUsernameIdentityValidator.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/AbstractUsernameIdentityValidator.java
@@ -25,10 +25,10 @@ import org.eclipse.milo.opcua.stack.core.types.structured.SignatureData;
 import org.eclipse.milo.opcua.stack.core.types.structured.UserNameIdentityToken;
 import org.eclipse.milo.opcua.stack.core.types.structured.UserTokenPolicy;
 
-public abstract class AbstractUsernameIdentityValidator<T> extends AbstractIdentityValidator {
+public abstract class AbstractUsernameIdentityValidator<T> extends AbstractIdentityValidator<T> {
 
     @Override
-    protected Object validateAnonymousToken(
+    protected T validateAnonymousToken(
         Session session,
         AnonymousIdentityToken token,
         UserTokenPolicy tokenPolicy,
@@ -39,7 +39,7 @@ public abstract class AbstractUsernameIdentityValidator<T> extends AbstractIdent
     }
 
     @Override
-    protected Object validateUsernameToken(
+    protected T validateUsernameToken(
         Session session,
         UserNameIdentityToken token,
         UserTokenPolicy tokenPolicy,

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/AbstractUsernameIdentityValidator.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/AbstractUsernameIdentityValidator.java
@@ -11,7 +11,7 @@
 package org.eclipse.milo.opcua.sdk.server.identity;
 
 import java.nio.charset.Charset;
-import java.util.Arrays;
+import java.security.MessageDigest;
 import javax.annotation.Nullable;
 
 import org.eclipse.milo.opcua.sdk.server.Session;
@@ -97,7 +97,7 @@ public abstract class AbstractUsernameIdentityValidator<T> extends AbstractIdent
             System.arraycopy(plainTextBytes, 4, passwordBytes, 0, passwordBytes.length);
             System.arraycopy(plainTextBytes, 4 + passwordBytes.length, nonceBytes, 0, lastNonceLength);
 
-            if (Arrays.equals(lastNonce.bytes(), nonceBytes)) {
+            if (MessageDigest.isEqual(lastNonce.bytes(), nonceBytes)) {
                 String password = new String(passwordBytes, Charset.forName("UTF-8"));
 
                 return authenticateUsernameOrThrow(session, username, password);

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/AbstractUsernameIdentityValidator.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/AbstractUsernameIdentityValidator.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2019 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.identity;
+
+import java.nio.charset.Charset;
+import java.util.Arrays;
+import javax.annotation.Nullable;
+
+import org.eclipse.milo.opcua.sdk.server.Session;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
+import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.security.SecurityAlgorithm;
+import org.eclipse.milo.opcua.stack.core.security.SecurityPolicy;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
+import org.eclipse.milo.opcua.stack.core.types.structured.AnonymousIdentityToken;
+import org.eclipse.milo.opcua.stack.core.types.structured.SignatureData;
+import org.eclipse.milo.opcua.stack.core.types.structured.UserNameIdentityToken;
+import org.eclipse.milo.opcua.stack.core.types.structured.UserTokenPolicy;
+
+public abstract class AbstractUsernameIdentityValidator<T> extends AbstractIdentityValidator {
+
+    @Override
+    protected Object validateAnonymousToken(
+        Session session,
+        AnonymousIdentityToken token,
+        UserTokenPolicy tokenPolicy,
+        SignatureData tokenSignature
+    ) throws UaException {
+
+        if (isAnonymousAccessAllowed()) {
+            return createAnonymousIdentityObject(session);
+        } else {
+            throw new UaException(StatusCodes.Bad_IdentityTokenInvalid);
+        }
+    }
+
+    @Override
+    protected Object validateUsernameToken(
+        Session session,
+        UserNameIdentityToken token,
+        UserTokenPolicy tokenPolicy,
+        SignatureData tokenSignature
+    ) throws UaException {
+
+        try {
+            return validateUserNameIdentityToken(session, token);
+        } catch (UaException e) {
+            throw e;
+        } catch (Throwable t) {
+            throw new UaException(StatusCodes.Bad_InternalError, t);
+        }
+    }
+
+    private T validateUserNameIdentityToken(
+        Session session,
+        UserNameIdentityToken token
+    ) throws UaException {
+
+        SecurityPolicy securityPolicy = session
+            .getSecurityConfiguration().getSecurityPolicy();
+
+        String username = token.getUserName();
+        ByteString lastNonce = session.getLastNonce();
+        int lastNonceLength = lastNonce.length();
+
+        if (username == null || username.isEmpty()) {
+            throw new UaException(StatusCodes.Bad_IdentityTokenInvalid);
+        }
+
+        SecurityAlgorithm algorithm;
+
+        String algorithmUri = token.getEncryptionAlgorithm();
+
+        if (algorithmUri == null || algorithmUri.isEmpty()) {
+            algorithm = securityPolicy.getAsymmetricEncryptionAlgorithm();
+        } else {
+            try {
+                algorithm = SecurityAlgorithm.fromUri(algorithmUri);
+            } catch (UaException e) {
+                throw new UaException(StatusCodes.Bad_IdentityTokenInvalid);
+            }
+
+            if (algorithm != SecurityAlgorithm.Rsa15 &&
+                algorithm != SecurityAlgorithm.RsaOaepSha1 &&
+                algorithm != SecurityAlgorithm.RsaOaepSha256) {
+
+                throw new UaException(StatusCodes.Bad_IdentityTokenInvalid);
+            }
+        }
+
+        byte[] tokenBytes = token.getPassword().bytes();
+        if (tokenBytes == null) tokenBytes = new byte[0];
+
+        if (algorithm != SecurityAlgorithm.None) {
+            byte[] plainTextBytes = decryptTokenData(session, algorithm, tokenBytes);
+
+            int length = ((plainTextBytes[3] & 0xFF) << 24) |
+                ((plainTextBytes[2] & 0xFF) << 16) |
+                ((plainTextBytes[1] & 0xFF) << 8) |
+                (plainTextBytes[0] & 0xFF);
+
+            byte[] passwordBytes = new byte[length - lastNonceLength];
+            byte[] nonceBytes = new byte[lastNonceLength];
+
+            System.arraycopy(plainTextBytes, 4, passwordBytes, 0, passwordBytes.length);
+            System.arraycopy(plainTextBytes, 4 + passwordBytes.length, nonceBytes, 0, lastNonceLength);
+
+            if (Arrays.equals(lastNonce.bytes(), nonceBytes)) {
+                String password = new String(passwordBytes, Charset.forName("UTF-8"));
+
+                return authenticateOrThrow(session, username, password);
+            } else {
+                throw new UaException(StatusCodes.Bad_UserAccessDenied);
+            }
+        } else {
+            String password = new String(tokenBytes, Charset.forName("UTF-8"));
+
+            return authenticateOrThrow(session, username, password);
+        }
+    }
+
+    private T authenticateOrThrow(Session session, String username, String password) throws UaException {
+        T identityObject = authenticate(session, username, password);
+
+        if (identityObject != null) {
+            return identityObject;
+        } else {
+            throw new UaException(StatusCodes.Bad_UserAccessDenied);
+        }
+    }
+
+    /**
+     * Authenticate {@code username} with {@code password}, returning an identity object of type {@code T} if the
+     * authentication succeeded, or {@code null} if the authentication failed.
+     *
+     * @param session  the {@link Session} being activated.
+     * @param username the username to authenticate.
+     * @param password the password to authenticate the user with.
+     * @return an identity object of type {@code T} if the authentication succeeded, or {@code null} if the
+     * authentication failed.
+     */
+    @Nullable
+    protected abstract T authenticate(Session session, String username, String password) throws UaException;
+
+    /**
+     * @return {@code true} if anonymous access is allowed.
+     */
+    protected abstract boolean isAnonymousAccessAllowed();
+
+    /**
+     * Create and return an identity object for an anonymous user.
+     *
+     * @param session the {@link Session} being activated.
+     * @return an identity object for an anonymous user.
+     */
+    protected abstract T createAnonymousIdentityObject(Session session) throws UaException;
+
+}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/AbstractX509IdentityValidator.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/AbstractX509IdentityValidator.java
@@ -84,6 +84,15 @@ public abstract class AbstractX509IdentityValidator<T> extends AbstractIdentityV
         }
     }
 
+    /**
+     * Create and return an identity object for the user identified by {@code identityCertificate}.
+     * <p>
+     * Possession of the private key associated with this certificate has been verified prior to this call.
+     *
+     * @param session             the {@link Session} being activated.
+     * @param identityCertificate the {@link X509Certificate} identifying the user.
+     * @return an identity object of type {@code T} if the authentication succeeded, or {@code null} if it failed.
+     */
     @Nullable
     protected abstract T authenticateIdentityCertificate(Session session, X509Certificate identityCertificate);
 

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/AbstractX509IdentityValidator.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/AbstractX509IdentityValidator.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2019 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.identity;
+
+import java.security.cert.X509Certificate;
+import javax.annotation.Nullable;
+
+import com.google.common.primitives.Bytes;
+import org.eclipse.milo.opcua.sdk.server.Session;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
+import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.security.SecurityAlgorithm;
+import org.eclipse.milo.opcua.stack.core.security.SecurityPolicy;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
+import org.eclipse.milo.opcua.stack.core.types.structured.SignatureData;
+import org.eclipse.milo.opcua.stack.core.types.structured.UserTokenPolicy;
+import org.eclipse.milo.opcua.stack.core.types.structured.X509IdentityToken;
+import org.eclipse.milo.opcua.stack.core.util.CertificateUtil;
+import org.eclipse.milo.opcua.stack.core.util.SignatureUtil;
+
+public abstract class AbstractX509IdentityValidator<T> extends AbstractIdentityValidator<T> {
+
+    @Override
+    protected T validateX509Token(
+        Session session,
+        X509IdentityToken token,
+        UserTokenPolicy tokenPolicy,
+        SignatureData tokenSignature
+    ) throws UaException {
+
+        ByteString clientCertificateBs = token.getCertificateData();
+        X509Certificate identityCertificate = CertificateUtil.decodeCertificate(clientCertificateBs.bytesOrEmpty());
+
+        // verify the algorithm matches the one specified by the tokenPolicy or else the channel itself
+        if (tokenPolicy.getSecurityPolicyUri() != null) {
+            SecurityPolicy securityPolicy = SecurityPolicy.fromUri(tokenPolicy.getSecurityPolicyUri());
+
+            if (!securityPolicy.getAsymmetricSignatureAlgorithm().getUri().equals(tokenSignature.getAlgorithm())) {
+                throw new UaException(StatusCodes.Bad_SecurityChecksFailed,
+                    "algorithm in token signature did not match algorithm specified by token policy");
+            }
+        } else {
+            SecurityPolicy securityPolicy = session.getSecurityConfiguration().getSecurityPolicy();
+
+            if (!securityPolicy.getAsymmetricSignatureAlgorithm().getUri().equals(tokenSignature.getAlgorithm())) {
+                throw new UaException(StatusCodes.Bad_SecurityChecksFailed,
+                    "algorithm in token signature did not match algorithm specified by secure channel");
+            }
+        }
+
+        SecurityAlgorithm algorithm = SecurityAlgorithm.fromUri(tokenSignature.getAlgorithm());
+
+        if (algorithm != SecurityAlgorithm.None) {
+            verifySignature(
+                session,
+                tokenSignature,
+                identityCertificate,
+                algorithm
+            );
+        }
+
+        return authenticateIdentityCertificateOrThrow(session, identityCertificate);
+    }
+
+    private T authenticateIdentityCertificateOrThrow(
+        Session session,
+        X509Certificate identityCertificate
+    ) throws UaException {
+
+        T identityObject = authenticateIdentityCertificate(session, identityCertificate);
+
+        if (identityObject != null) {
+            return identityObject;
+        } else {
+            throw new UaException(StatusCodes.Bad_UserAccessDenied);
+        }
+    }
+
+    @Nullable
+    protected abstract T authenticateIdentityCertificate(Session session, X509Certificate identityCertificate);
+
+    private static void verifySignature(
+        Session session,
+        SignatureData tokenSignature,
+        X509Certificate identityCertificate,
+        SecurityAlgorithm algorithm
+    ) throws UaException {
+
+        ByteString serverCertificateBs = session
+            .getSecurityConfiguration()
+            .getServerCertificateBytes();
+
+        ByteString lastNonceBs = session.getLastNonce();
+
+        byte[] dataBytes = Bytes.concat(serverCertificateBs.bytesOrEmpty(), lastNonceBs.bytesOrEmpty());
+        byte[] signatureBytes = tokenSignature.getSignature().bytesOrEmpty();
+
+        SignatureUtil.verify(
+            algorithm,
+            identityCertificate,
+            dataBytes,
+            signatureBytes
+        );
+    }
+
+}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/AnonymousIdentityValidator.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/AnonymousIdentityValidator.java
@@ -15,7 +15,7 @@ import org.eclipse.milo.opcua.stack.core.types.structured.AnonymousIdentityToken
 import org.eclipse.milo.opcua.stack.core.types.structured.SignatureData;
 import org.eclipse.milo.opcua.stack.core.types.structured.UserTokenPolicy;
 
-public final class AnonymousIdentityValidator extends AbstractIdentityValidator {
+public final class AnonymousIdentityValidator extends AbstractIdentityValidator<String> {
 
     /**
      * A static instance implementing AnonymousIdentityValidator
@@ -26,18 +26,20 @@ public final class AnonymousIdentityValidator extends AbstractIdentityValidator 
      * @deprecated Use {@link #INSTANCE} instead
      */
     @Deprecated
-    public AnonymousIdentityValidator() {
-    }
+    public AnonymousIdentityValidator() {}
 
     @Override
-    public Object validateAnonymousToken(
+    public String validateAnonymousToken(
         Session session,
         AnonymousIdentityToken token,
         UserTokenPolicy tokenPolicy,
-        SignatureData tokenSignature) {
+        SignatureData tokenSignature
+    ) {
 
         return String.format("anonymous_%s_%s",
-            session.getSessionName(), session.getSessionId().toParseableString());
+            session.getSessionName(),
+            session.getSessionId().toParseableString()
+        );
     }
 
 }

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/CompositeValidator.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/CompositeValidator.java
@@ -26,31 +26,31 @@ import org.slf4j.LoggerFactory;
 /**
  * A composite {@link IdentityValidator} that tries its component {@link IdentityValidator}s in the order provided.
  */
-public class CompositeValidator implements IdentityValidator {
+public class CompositeValidator<T> implements IdentityValidator<T> {
 
     private final Logger logger = LoggerFactory.getLogger(getClass());
 
-    private final ImmutableList<IdentityValidator> validators;
+    private final ImmutableList<IdentityValidator<T>> validators;
 
-    public CompositeValidator(IdentityValidator... validators) {
+    public CompositeValidator(IdentityValidator<T>... validators) {
         this.validators = ImmutableList.copyOf(validators);
     }
 
-    public CompositeValidator(List<IdentityValidator> validators) {
+    public CompositeValidator(List<IdentityValidator<T>> validators) {
         this.validators = ImmutableList.copyOf(validators);
     }
 
     @Override
-    public Object validateIdentityToken(
+    public T validateIdentityToken(
         Session session,
         UserIdentityToken token,
         UserTokenPolicy tokenPolicy,
         SignatureData tokenSignature) throws UaException {
 
-        Iterator<IdentityValidator> iterator = validators.iterator();
+        Iterator<IdentityValidator<T>> iterator = validators.iterator();
 
         while (iterator.hasNext()) {
-            IdentityValidator validator = iterator.next();
+            IdentityValidator<T> validator = iterator.next();
 
             try {
                 return validator.validateIdentityToken(session, token, tokenPolicy, tokenSignature);

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/IdentityValidator.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/IdentityValidator.java
@@ -17,7 +17,7 @@ import org.eclipse.milo.opcua.stack.core.types.structured.SignatureData;
 import org.eclipse.milo.opcua.stack.core.types.structured.UserIdentityToken;
 import org.eclipse.milo.opcua.stack.core.types.structured.UserTokenPolicy;
 
-public interface IdentityValidator {
+public interface IdentityValidator<T> {
 
     /**
      * Validate the provided {@link UserIdentityToken} and return an identity Object that represents the user.
@@ -29,13 +29,14 @@ public interface IdentityValidator {
      * @param token          the {@link UserIdentityToken}.
      * @param tokenPolicy    the {@link UserTokenPolicy} specified by the policyId in {@code token}.
      * @param tokenSignature the {@link SignatureData} sent in the {@link ActivateSessionRequest}
-     * @return an identity Object that represents the user.
+     * @return an identity object of type {@code T} that represents the authenticated user.
      * @throws UaException if the token is invalid, rejected, or user access is denied.
      */
-    Object validateIdentityToken(
+    T validateIdentityToken(
         Session session,
         UserIdentityToken token,
         UserTokenPolicy tokenPolicy,
-        SignatureData tokenSignature) throws UaException;
+        SignatureData tokenSignature
+    ) throws UaException;
 
 }

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/UsernameIdentityValidator.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/UsernameIdentityValidator.java
@@ -10,30 +10,27 @@
 
 package org.eclipse.milo.opcua.sdk.server.identity;
 
-import java.nio.charset.Charset;
-import java.util.Arrays;
 import java.util.function.Predicate;
+import javax.annotation.Nullable;
 
 import org.eclipse.milo.opcua.sdk.server.Session;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.UaException;
-import org.eclipse.milo.opcua.stack.core.security.SecurityAlgorithm;
-import org.eclipse.milo.opcua.stack.core.security.SecurityPolicy;
-import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
 import org.eclipse.milo.opcua.stack.core.types.structured.AnonymousIdentityToken;
 import org.eclipse.milo.opcua.stack.core.types.structured.SignatureData;
-import org.eclipse.milo.opcua.stack.core.types.structured.UserNameIdentityToken;
 import org.eclipse.milo.opcua.stack.core.types.structured.UserTokenPolicy;
 
-public class UsernameIdentityValidator extends AbstractIdentityValidator {
+public class UsernameIdentityValidator extends AbstractUsernameIdentityValidator<String> {
 
-    private final boolean allowAnonymous;
+    private final boolean anonymousAccessAllowed;
     private final Predicate<AuthenticationChallenge> predicate;
 
-    public UsernameIdentityValidator(boolean allowAnonymous,
-                                     Predicate<AuthenticationChallenge> predicate) {
+    public UsernameIdentityValidator(
+        boolean anonymousAccessAllowed,
+        Predicate<AuthenticationChallenge> predicate
+    ) {
 
-        this.allowAnonymous = allowAnonymous;
+        this.anonymousAccessAllowed = anonymousAccessAllowed;
         this.predicate = predicate;
     }
 
@@ -44,7 +41,7 @@ public class UsernameIdentityValidator extends AbstractIdentityValidator {
         UserTokenPolicy tokenPolicy,
         SignatureData tokenSignature) throws UaException {
 
-        if (allowAnonymous) {
+        if (anonymousAccessAllowed) {
             return String.format("anonymous_%s_%s",
                 session.getSessionName(), session.getSessionId().toParseableString());
         } else {
@@ -53,85 +50,26 @@ public class UsernameIdentityValidator extends AbstractIdentityValidator {
     }
 
     @Override
-    public Object validateUsernameToken(
-        Session session,
-        UserNameIdentityToken token,
-        UserTokenPolicy tokenPolicy,
-        SignatureData tokenSignature) throws UaException {
-
-        return validateUserNameIdentityToken(session, token);
+    protected boolean isAnonymousAccessAllowed() {
+        return anonymousAccessAllowed;
     }
 
-    private String validateUserNameIdentityToken(
-        Session session,
-        UserNameIdentityToken token) throws UaException {
+    @Override
+    protected String createAnonymousIdentityObject(Session session) {
+        return String.format(
+            "anonymous_%s_%s",
+            session.getSessionName(),
+            session.getSessionId().toParseableString()
+        );
+    }
 
-        SecurityPolicy securityPolicy = session
-            .getSecurityConfiguration().getSecurityPolicy();
+    @Nullable
+    @Override
+    protected String authenticate(Session session, String username, String password) {
+        AuthenticationChallenge challenge =
+            new AuthenticationChallenge(username, password);
 
-        String username = token.getUserName();
-        ByteString lastNonce = session.getLastNonce();
-        int lastNonceLength = lastNonce.length();
-
-        if (username == null || username.isEmpty()) {
-            throw new UaException(StatusCodes.Bad_IdentityTokenInvalid);
-        }
-
-        SecurityAlgorithm algorithm;
-
-        String algorithmUri = token.getEncryptionAlgorithm();
-        if (algorithmUri == null || algorithmUri.isEmpty()) {
-            algorithm = securityPolicy.getAsymmetricEncryptionAlgorithm();
-        } else {
-            try {
-                algorithm = SecurityAlgorithm.fromUri(algorithmUri);
-            } catch (UaException e) {
-                throw new UaException(StatusCodes.Bad_IdentityTokenInvalid);
-            }
-
-            if (algorithm != SecurityAlgorithm.Rsa15 &&
-                algorithm != SecurityAlgorithm.RsaOaepSha1 &&
-                algorithm != SecurityAlgorithm.RsaOaepSha256) {
-
-                throw new UaException(StatusCodes.Bad_IdentityTokenInvalid);
-            }
-        }
-
-        byte[] tokenBytes = token.getPassword().bytes();
-        if (tokenBytes == null) tokenBytes = new byte[0];
-
-        if (algorithm != SecurityAlgorithm.None) {
-            byte[] plainTextBytes = decryptTokenData(session, algorithm, tokenBytes);
-
-            int length = ((plainTextBytes[3] & 0xFF) << 24) |
-                ((plainTextBytes[2] & 0xFF) << 16) |
-                ((plainTextBytes[1] & 0xFF) << 8) |
-                (plainTextBytes[0] & 0xFF);
-
-            byte[] passwordBytes = new byte[length - lastNonceLength];
-            byte[] nonceBytes = new byte[lastNonceLength];
-
-            System.arraycopy(plainTextBytes, 4, passwordBytes, 0, passwordBytes.length);
-            System.arraycopy(plainTextBytes, 4 + passwordBytes.length, nonceBytes, 0, lastNonceLength);
-
-            String password = new String(passwordBytes, Charset.forName("UTF-8"));
-            AuthenticationChallenge challenge = new AuthenticationChallenge(username, password);
-
-            if (Arrays.equals(lastNonce.bytes(), nonceBytes) && predicate.test(challenge)) {
-                return username;
-            } else {
-                throw new UaException(StatusCodes.Bad_UserAccessDenied);
-            }
-        } else {
-            String password = new String(tokenBytes, Charset.forName("UTF-8"));
-            AuthenticationChallenge challenge = new AuthenticationChallenge(username, password);
-
-            if (predicate.test(challenge)) {
-                return username;
-            } else {
-                throw new UaException(StatusCodes.Bad_UserAccessDenied);
-            }
-        }
+        return predicate.test(challenge) ? username : null;
     }
 
     public static final class AuthenticationChallenge {
@@ -139,7 +77,7 @@ public class UsernameIdentityValidator extends AbstractIdentityValidator {
         private final String username;
         private final String password;
 
-        public AuthenticationChallenge(String username, String password) {
+        AuthenticationChallenge(String username, String password) {
             this.username = username;
             this.password = password;
         }

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/UsernameIdentityValidator.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/UsernameIdentityValidator.java
@@ -14,11 +14,6 @@ import java.util.function.Predicate;
 import javax.annotation.Nullable;
 
 import org.eclipse.milo.opcua.sdk.server.Session;
-import org.eclipse.milo.opcua.stack.core.StatusCodes;
-import org.eclipse.milo.opcua.stack.core.UaException;
-import org.eclipse.milo.opcua.stack.core.types.structured.AnonymousIdentityToken;
-import org.eclipse.milo.opcua.stack.core.types.structured.SignatureData;
-import org.eclipse.milo.opcua.stack.core.types.structured.UserTokenPolicy;
 
 public class UsernameIdentityValidator extends AbstractUsernameIdentityValidator<String> {
 
@@ -34,28 +29,18 @@ public class UsernameIdentityValidator extends AbstractUsernameIdentityValidator
         this.predicate = predicate;
     }
 
-    @Override
-    public Object validateAnonymousToken(
-        Session session,
-        AnonymousIdentityToken token,
-        UserTokenPolicy tokenPolicy,
-        SignatureData tokenSignature) throws UaException {
-
-        if (anonymousAccessAllowed) {
-            return String.format("anonymous_%s_%s",
-                session.getSessionName(), session.getSessionId().toParseableString());
-        } else {
-            throw new UaException(StatusCodes.Bad_UserAccessDenied);
-        }
-    }
-
+    @Nullable
     @Override
     protected String authenticateAnonymous(Session session) {
-        return String.format(
-            "anonymous_%s_%s",
-            session.getSessionName(),
-            session.getSessionId().toParseableString()
-        );
+        if (anonymousAccessAllowed) {
+            return String.format(
+                "anonymous_%s_%s",
+                session.getSessionName(),
+                session.getSessionId().toParseableString()
+            );
+        } else {
+            return null;
+        }
     }
 
     @Nullable

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/UsernameIdentityValidator.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/UsernameIdentityValidator.java
@@ -50,12 +50,7 @@ public class UsernameIdentityValidator extends AbstractUsernameIdentityValidator
     }
 
     @Override
-    protected boolean isAnonymousAccessAllowed() {
-        return anonymousAccessAllowed;
-    }
-
-    @Override
-    protected String createAnonymousIdentityObject(Session session) {
+    protected String authenticateAnonymous(Session session) {
         return String.format(
             "anonymous_%s_%s",
             session.getSessionName(),
@@ -65,7 +60,7 @@ public class UsernameIdentityValidator extends AbstractUsernameIdentityValidator
 
     @Nullable
     @Override
-    protected String authenticate(Session session, String username, String password) {
+    protected String authenticateUsernamePassword(Session session, String username, String password) {
         AuthenticationChallenge challenge =
             new AuthenticationChallenge(username, password);
 

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/X509IdentityValidator.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/X509IdentityValidator.java
@@ -12,21 +12,11 @@ package org.eclipse.milo.opcua.sdk.server.identity;
 
 import java.security.cert.X509Certificate;
 import java.util.function.Predicate;
+import javax.annotation.Nullable;
 
-import com.google.common.primitives.Bytes;
 import org.eclipse.milo.opcua.sdk.server.Session;
-import org.eclipse.milo.opcua.stack.core.StatusCodes;
-import org.eclipse.milo.opcua.stack.core.UaException;
-import org.eclipse.milo.opcua.stack.core.security.SecurityAlgorithm;
-import org.eclipse.milo.opcua.stack.core.security.SecurityPolicy;
-import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
-import org.eclipse.milo.opcua.stack.core.types.structured.SignatureData;
-import org.eclipse.milo.opcua.stack.core.types.structured.UserTokenPolicy;
-import org.eclipse.milo.opcua.stack.core.types.structured.X509IdentityToken;
-import org.eclipse.milo.opcua.stack.core.util.CertificateUtil;
-import org.eclipse.milo.opcua.stack.core.util.SignatureUtil;
 
-public class X509IdentityValidator extends AbstractIdentityValidator {
+public class X509IdentityValidator extends AbstractX509IdentityValidator {
 
     private final Predicate<X509Certificate> predicate;
 
@@ -34,72 +24,14 @@ public class X509IdentityValidator extends AbstractIdentityValidator {
         this.predicate = predicate;
     }
 
+    @Nullable
     @Override
-    public Object validateX509Token(
-        Session session,
-        X509IdentityToken token,
-        UserTokenPolicy tokenPolicy,
-        SignatureData tokenSignature) throws UaException {
-
-        ByteString clientCertificateBs = token.getCertificateData();
-        X509Certificate identityCertificate = CertificateUtil.decodeCertificate(clientCertificateBs.bytesOrEmpty());
-
-        // verify the algorithm matches the one specified by the tokenPolicy or else the channel itself
-        if (tokenPolicy.getSecurityPolicyUri() != null) {
-            SecurityPolicy securityPolicy = SecurityPolicy.fromUri(tokenPolicy.getSecurityPolicyUri());
-
-            if (!securityPolicy.getAsymmetricSignatureAlgorithm().getUri().equals(tokenSignature.getAlgorithm())) {
-                throw new UaException(StatusCodes.Bad_SecurityChecksFailed,
-                    "algorithm in token signature did not match algorithm specified by token policy");
-            }
-        } else {
-            SecurityPolicy securityPolicy = session.getSecurityConfiguration().getSecurityPolicy();
-
-            if (!securityPolicy.getAsymmetricSignatureAlgorithm().getUri().equals(tokenSignature.getAlgorithm())) {
-                throw new UaException(StatusCodes.Bad_SecurityChecksFailed,
-                    "algorithm in token signature did not match algorithm specified by secure channel");
-            }
-        }
-
-        SecurityAlgorithm algorithm = SecurityAlgorithm.fromUri(tokenSignature.getAlgorithm());
-
-        if (algorithm != SecurityAlgorithm.None) {
-            verifySignature(
-                session,
-                tokenSignature,
-                identityCertificate,
-                algorithm
-            );
-        }
-
+    protected Object authenticateIdentityCertificate(Session session, X509Certificate identityCertificate) {
         if (predicate.test(identityCertificate)) {
             return identityCertificate;
         } else {
-            throw new UaException(StatusCodes.Bad_UserAccessDenied);
+            return null;
         }
-    }
-
-    private void verifySignature(
-        Session session,
-        SignatureData tokenSignature,
-        X509Certificate identityCertificate,
-        SecurityAlgorithm algorithm) throws UaException {
-
-        ByteString serverCertificateBs = session
-            .getSecurityConfiguration()
-            .getServerCertificateBytes();
-        
-        ByteString lastNonceBs = session.getLastNonce();
-
-        byte[] dataBytes = Bytes.concat(serverCertificateBs.bytesOrEmpty(), lastNonceBs.bytesOrEmpty());
-        byte[] signatureBytes = tokenSignature.getSignature().bytesOrEmpty();
-
-        SignatureUtil.verify(
-            algorithm,
-            identityCertificate,
-            dataBytes,
-            signatureBytes
-        );
     }
 
 }


### PR DESCRIPTION
Add type parameter to IdentityValidator API and implement reusable abstract base classes for anonymous, username, and X509 validators.