### PR TITLE
Add limit to NamespaceTable length when connecting

### DIFF
--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/OpcUaClient.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/OpcUaClient.java
@@ -40,6 +40,7 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UShort;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.MonitoringMode;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.TimestampsToReturn;
 import org.eclipse.milo.opcua.stack.core.types.structured.AddNodesItem;
@@ -209,7 +210,11 @@ public class OpcUaClient implements UaClient {
                 .thenAccept(uris -> getNamespaceTable().update(uriTable -> {
                     uriTable.clear();
 
-                    for (int i = 0; i < uris.length; i++) {
+                    if (uris.length > UShort.MAX_VALUE) {
+                        logger.warn("SessionInitializer: NamespaceTable returned by server contains " + uris.length + " entries");
+                    }
+
+                    for (int i = 0; i < uris.length && i < UShort.MAX_VALUE; i++) {
                         String uri = uris[i];
 
                         if (uri != null && !uriTable.containsValue(uri)) {


### PR DESCRIPTION
If the OPC-UA Server returns a NamespaceTable containing more
than 65535 items, client throws a NumberFormatException
when converting the index to ushort.

Added warning for that scenario and limit on the number of
namespaces added to the local table.