### PR TITLE
Naive support for IPv6 addresses in EndpointUtil

### DIFF
--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/util/EndpointUtil.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/util/EndpointUtil.java
@@ -20,7 +20,7 @@ import org.eclipse.milo.opcua.stack.core.types.structured.EndpointDescription;
 public class EndpointUtil {
 
     private static final Pattern ENDPOINT_URL_PATTERN =
-        Pattern.compile("(opc.tcp|http|https|opc.http|opc.https|opc.ws|opc.wss)://([^:/]+)(:\\d+)?(/.*)?");
+        Pattern.compile("(opc.tcp|http|https|opc.http|opc.https|opc.ws|opc.wss)://([^:/]+|\\[.*])(:\\d+)?(/.*)?");
 
     @Nullable
     public static String getScheme(@Nonnull String endpointUrl) {

--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/util/EndpointUtilTest.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/util/EndpointUtilTest.java
@@ -54,6 +54,25 @@ public class EndpointUtilTest {
         testReplaceUrlPortWithScheme("https");
     }
 
+    @Test
+    public void testIpv6() {
+        String withPath = "opc.tcp://[fe80::9289:e377:bacb:f608%enp0s31f6]:4840/foo";
+        String withoutPath = "opc.tcp://[fe80::9289:e377:bacb:f608%enp0s31f6]:4840";
+
+        assertEquals(EndpointUtil.getScheme(withPath), "opc.tcp");
+        assertEquals(EndpointUtil.getScheme(withoutPath), "opc.tcp");
+
+        assertEquals(EndpointUtil.getHost(withPath), "[fe80::9289:e377:bacb:f608%enp0s31f6]");
+        assertEquals(EndpointUtil.getHost(withoutPath), "[fe80::9289:e377:bacb:f608%enp0s31f6]");
+
+        assertEquals(EndpointUtil.getPort(withPath), 4840);
+        assertEquals(EndpointUtil.getPort(withoutPath), 4840);
+
+        assertEquals(EndpointUtil.getPath(withPath), "/foo");
+        assertEquals(EndpointUtil.getPath(withoutPath), "/");
+
+    }
+
     private void testReplaceUrlHostnameWithScheme(String scheme) {
         assertEquals(
             updateUrl(scheme + "://localhost:4840", "localhost2"),


### PR DESCRIPTION
This isn't recognizing or validating IPv6 addresses so much as just
allowing the possibility of an IPv6 address in the hostname position by
allowing anything inside a pair of square brackets to be treated as a
hostname.

fixes #509