### PR TITLE
Provide a unique-per-UaSubscription sequence of client handles 

### DIFF
--- a/milo-examples/client-examples/src/main/java/org/eclipse/milo/examples/client/SubscriptionExample.java
+++ b/milo-examples/client-examples/src/main/java/org/eclipse/milo/examples/client/SubscriptionExample.java
@@ -12,7 +12,6 @@ package org.eclipse.milo.examples.client;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BiConsumer;
 
 import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
@@ -43,8 +42,6 @@ public class SubscriptionExample implements ClientExample {
     }
 
     private final Logger logger = LoggerFactory.getLogger(getClass());
-
-    private final AtomicLong clientHandles = new AtomicLong(1L);
 
     @Override
     public void run(OpcUaClient client, CompletableFuture<OpcUaClient> future) throws Exception {

--- a/milo-examples/client-examples/src/main/java/org/eclipse/milo/examples/client/SubscriptionExample.java
+++ b/milo-examples/client-examples/src/main/java/org/eclipse/milo/examples/client/SubscriptionExample.java
@@ -57,10 +57,13 @@ public class SubscriptionExample implements ClientExample {
         // subscribe to the Value attribute of the server's CurrentTime node
         ReadValueId readValueId = new ReadValueId(
             Identifiers.Server_ServerStatus_CurrentTime,
-            AttributeId.Value.uid(), null, QualifiedName.NULL_VALUE);
+            AttributeId.Value.uid(), null, QualifiedName.NULL_VALUE
+        );
 
-        // important: client handle must be unique per item
-        UInteger clientHandle = uint(clientHandles.getAndIncrement());
+        // IMPORTANT: client handle must be unique per item within the context of a subscription.
+        // You are not required to use the UaSubscription's client handle sequence; it is provided as a convenience.
+        // Your application is free to assign client handles by whatever means necessary.
+        UInteger clientHandle = subscription.nextClientHandle();
 
         MonitoringParameters parameters = new MonitoringParameters(
             clientHandle,
@@ -71,7 +74,10 @@ public class SubscriptionExample implements ClientExample {
         );
 
         MonitoredItemCreateRequest request = new MonitoredItemCreateRequest(
-            readValueId, MonitoringMode.Reporting, parameters);
+            readValueId,
+            MonitoringMode.Reporting,
+            parameters
+        );
 
         // when creating items in MonitoringMode.Reporting this callback is where each item needs to have its
         // value/event consumer hooked up. The alternative is to create the item in sampling mode, hook up the

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/api/subscriptions/UaSubscription.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/api/subscriptions/UaSubscription.java
@@ -86,6 +86,11 @@ public interface UaSubscription {
     ImmutableList<UaMonitoredItem> getMonitoredItems();
 
     /**
+     * @return the next available client handle, unique within the context of this {@link UaSubscription}.
+     */
+    UInteger nextClientHandle();
+
+    /**
      * Create one or more {@link UaMonitoredItem}s.
      * <p>
      * Callers must check the quality of each of the returned {@link UaMonitoredItem}s; it is not to be assumed that

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/subscriptions/OpcUaSubscription.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/subscriptions/OpcUaSubscription.java
@@ -20,6 +20,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
 import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
@@ -442,6 +443,7 @@ public class OpcUaSubscription implements UaSubscription {
             this(handleInUse, 0L);
         }
 
+        @VisibleForTesting
         ClientHandleSequence(Predicate<UInteger> handleInUse, long initialValue) {
             this.handleInUse = handleInUse;
 
@@ -465,12 +467,13 @@ public class OpcUaSubscription implements UaSubscription {
         }
 
         private UInteger getAndIncrementWithRollover() {
-            long next = clientHandle.getAndIncrement();
-            if (next > UInteger.MAX_VALUE) {
-                next = 0;
-                clientHandle.set(0);
+            long current = clientHandle.get();
+
+            if (current > UInteger.MAX_VALUE) {
+                clientHandle.set(0L);
             }
-            return uint(next);
+
+            return uint(clientHandle.getAndIncrement());
         }
 
     }

--- a/opc-ua-sdk/sdk-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/subscriptions/ClientHandleSequenceTest.java
+++ b/opc-ua-sdk/sdk-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/subscriptions/ClientHandleSequenceTest.java
@@ -22,10 +22,12 @@ public class ClientHandleSequenceTest {
 
     @Test
     public void testRollover() {
-        ClientHandleSequence sequence = new ClientHandleSequence(h -> false, UInteger.MAX_VALUE);
+        ClientHandleSequence sequence = new ClientHandleSequence(h -> false, UInteger.MAX_VALUE - 1);
 
+        assertEquals(uint(UInteger.MAX_VALUE - 1), sequence.nextClientHandle());
         assertEquals(UInteger.MAX, sequence.nextClientHandle());
         assertEquals(uint(0), sequence.nextClientHandle());
+        assertEquals(uint(1), sequence.nextClientHandle());
     }
 
     @Test

--- a/opc-ua-sdk/sdk-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/subscriptions/ClientHandleSequenceTest.java
+++ b/opc-ua-sdk/sdk-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/subscriptions/ClientHandleSequenceTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2019 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.client.subscriptions;
+
+import org.eclipse.milo.opcua.sdk.client.subscriptions.OpcUaSubscription.ClientHandleSequence;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.testng.annotations.Test;
+
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertThrows;
+
+public class ClientHandleSequenceTest {
+
+    @Test
+    public void testRollover() {
+        ClientHandleSequence sequence = new ClientHandleSequence(h -> false, UInteger.MAX_VALUE);
+
+        assertEquals(UInteger.MAX, sequence.nextClientHandle());
+        assertEquals(uint(0), sequence.nextClientHandle());
+    }
+
+    @Test
+    public void testInUsePredicate() {
+        ClientHandleSequence sequence = new ClientHandleSequence(h -> h.longValue() < 10);
+
+        assertEquals(uint(10), sequence.nextClientHandle());
+    }
+
+    // Slow; enable to test manually.
+    @Test(enabled = false)
+    public void testThrowsIfAllUsed() {
+        ClientHandleSequence sequence = new ClientHandleSequence(h -> true);
+
+        assertThrows(IllegalStateException.class, sequence::nextClientHandle);
+    }
+
+}


### PR DESCRIPTION
This sequence handles rollover and ensuring that after rollover only
client handles not currently being used are returned.