### PR TITLE
Relax nonce validation when not used to protect credentials

### DIFF
--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/api/identity/UsernameProvider.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/api/identity/UsernameProvider.java
@@ -22,7 +22,6 @@ import javax.crypto.Cipher;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
-import org.bouncycastle.util.Arrays;
 import org.eclipse.milo.opcua.stack.core.Stack;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.UaException;
@@ -119,26 +118,16 @@ public class UsernameProvider implements IdentityProvider {
 
         UserTokenPolicy tokenPolicy = policyChooser.apply(tokenPolicies);
 
-        String policyId = tokenPolicy.getPolicyId();
-
-        SecurityPolicy securityPolicy = SecurityPolicy.None;
+        SecurityPolicy securityPolicy;
 
         String securityPolicyUri = tokenPolicy.getSecurityPolicyUri();
         try {
-            if (securityPolicyUri != null && !securityPolicyUri.isEmpty()) {
-                securityPolicy = SecurityPolicy.fromUri(securityPolicyUri);
-            } else {
+            if (securityPolicyUri == null || securityPolicyUri.isEmpty()) {
                 securityPolicyUri = endpoint.getSecurityPolicyUri();
-                securityPolicy = SecurityPolicy.fromUri(securityPolicyUri);
             }
+            securityPolicy = SecurityPolicy.fromUri(securityPolicyUri);
         } catch (Throwable t) {
-            logger.warn("Error parsing SecurityPolicy for uri={}, falling back to no security.", securityPolicyUri);
-        }
-
-        NonceUtil.validateNonce(serverNonce);
-
-        if (serverNonce.length() > 0 && Arrays.areAllZeroes(serverNonce.bytesOrEmpty(), 0, serverNonce.length())) {
-            throw new UaException(StatusCodes.Bad_NonceInvalid, "nonce must be non-zero");
+            throw new UaException(StatusCodes.Bad_SecurityPolicyRejected, t);
         }
 
         byte[] passwordBytes = password.getBytes(StandardCharsets.UTF_8);
@@ -149,6 +138,8 @@ public class UsernameProvider implements IdentityProvider {
         if (securityPolicy == SecurityPolicy.None) {
             buffer.writeBytes(passwordBytes);
         } else {
+            NonceUtil.validateNonce(serverNonce);
+
             buffer.writeIntLE(passwordBytes.length + nonceBytes.length);
             buffer.writeBytes(passwordBytes);
             buffer.writeBytes(nonceBytes);
@@ -159,7 +150,8 @@ public class UsernameProvider implements IdentityProvider {
                 throw new UaException(
                     StatusCodes.Bad_ConfigurationError,
                     "UserTokenPolicy requires encryption but " +
-                        "server did not provide a certificate in endpoint");
+                        "server did not provide a certificate in endpoint"
+                );
             }
 
             List<X509Certificate> certificateChain = CertificateUtil.decodeCertificates(bs.bytes());
@@ -212,7 +204,7 @@ public class UsernameProvider implements IdentityProvider {
         String encryptionAlgorithm = securityAlgorithmUri.isEmpty() ? null : securityAlgorithmUri;
 
         UserNameIdentityToken token = new UserNameIdentityToken(
-            policyId,
+            tokenPolicy.getPolicyId(),
             username,
             ByteString.of(bs),
             encryptionAlgorithm

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/api/identity/X509IdentityProvider.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/api/identity/X509IdentityProvider.java
@@ -15,7 +15,6 @@ import java.security.PrivateKey;
 import java.security.cert.X509Certificate;
 import java.util.List;
 
-import org.bouncycastle.util.Arrays;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.security.SecurityPolicy;
@@ -54,54 +53,52 @@ public class X509IdentityProvider implements IdentityProvider {
             .filter(t -> t.getTokenType() == UserTokenType.Certificate)
             .findFirst().orElseThrow(() -> new Exception("no x509 certificate token policy found"));
 
-        String policyId = tokenPolicy.getPolicyId();
-
-        SecurityPolicy securityPolicy = SecurityPolicy.None;
+        SecurityPolicy securityPolicy;
 
         String securityPolicyUri = tokenPolicy.getSecurityPolicyUri();
 
         try {
-            if (securityPolicyUri != null && !securityPolicyUri.isEmpty()) {
-                securityPolicy = SecurityPolicy.fromUri(securityPolicyUri);
-            } else {
+            if (securityPolicyUri == null || securityPolicyUri.isEmpty()) {
                 securityPolicyUri = endpoint.getSecurityPolicyUri();
-                securityPolicy = SecurityPolicy.fromUri(securityPolicyUri);
             }
+            securityPolicy = SecurityPolicy.fromUri(securityPolicyUri);
         } catch (Throwable t) {
-            logger.warn("Error parsing SecurityPolicy for uri={}", securityPolicyUri);
-        }
-
-        NonceUtil.validateNonce(serverNonce);
-
-        if (serverNonce.length() > 0 && Arrays.areAllZeroes(serverNonce.bytesOrEmpty(), 0, serverNonce.length())) {
-            throw new UaException(StatusCodes.Bad_NonceInvalid, "nonce must be non-zero");
+            throw new UaException(StatusCodes.Bad_SecurityPolicyRejected, t);
         }
 
         X509IdentityToken token = new X509IdentityToken(
-            policyId,
+            tokenPolicy.getPolicyId(),
             ByteString.of(certificate.getEncoded())
         );
 
-        byte[] serverCertificateBytes = new byte[0];
-        if (!endpoint.getSecurityPolicyUri().equals(SecurityPolicy.None.getUri())) {
-            ByteString serverCertificate = endpoint.getServerCertificate();
-            serverCertificateBytes = serverCertificate.bytesOrEmpty();
+        SignatureData signatureData;
+
+        if (securityPolicy == SecurityPolicy.None) {
+            signatureData = new SignatureData(null, null);
+        } else {
+            NonceUtil.validateNonce(serverNonce);
+
+            byte[] serverCertificateBytes = new byte[0];
+            if (!endpoint.getSecurityPolicyUri().equals(SecurityPolicy.None.getUri())) {
+                ByteString serverCertificate = endpoint.getServerCertificate();
+                serverCertificateBytes = serverCertificate.bytesOrEmpty();
+            }
+
+            byte[] serverNonceBytes = serverNonce.bytes();
+            if (serverNonceBytes == null) serverNonceBytes = new byte[0];
+
+            byte[] signature = SignatureUtil.sign(
+                securityPolicy.getAsymmetricSignatureAlgorithm(),
+                privateKey,
+                ByteBuffer.wrap(serverCertificateBytes),
+                ByteBuffer.wrap(serverNonceBytes)
+            );
+
+            signatureData = new SignatureData(
+                securityPolicy.getAsymmetricSignatureAlgorithm().getUri(),
+                ByteString.of(signature)
+            );
         }
-
-        byte[] serverNonceBytes = serverNonce.bytes();
-        if (serverNonceBytes == null) serverNonceBytes = new byte[0];
-
-        byte[] signature = SignatureUtil.sign(
-            securityPolicy.getAsymmetricSignatureAlgorithm(),
-            privateKey,
-            ByteBuffer.wrap(serverCertificateBytes),
-            ByteBuffer.wrap(serverNonceBytes)
-        );
-
-        SignatureData signatureData = new SignatureData(
-            securityPolicy.getAsymmetricSignatureAlgorithm().getUri(),
-            ByteString.of(signature)
-        );
 
         return new SignedIdentityToken(token, signatureData);
     }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/session/SessionFsmFactory.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/session/SessionFsmFactory.java
@@ -875,8 +875,6 @@ public class SessionFsmFactory {
 
             ByteString csrNonce = csr.getServerNonce();
 
-            NonceUtil.validateNonce(csrNonce);
-
             SignedIdentityToken signedIdentityToken =
                 client.getConfig().getIdentityProvider()
                     .getIdentityToken(endpoint, csrNonce);
@@ -898,27 +896,23 @@ public class SessionFsmFactory {
             return stackClient.sendRequest(request)
                 .thenApply(ActivateSessionResponse.class::cast)
                 .thenCompose(asr -> {
-                    try {
-                        ByteString asrNonce = asr.getServerNonce();
+                    ByteString asrNonce = asr.getServerNonce();
 
-                        NonceUtil.validateNonce(asrNonce);
+                    // TODO check for repeated nonce?
 
-                        OpcUaSession session = new OpcUaSession(
-                            csr.getAuthenticationToken(),
-                            csr.getSessionId(),
-                            client.getConfig().getSessionName().get(),
-                            csr.getRevisedSessionTimeout(),
-                            csr.getMaxRequestMessageSize(),
-                            csr.getServerCertificate(),
-                            csr.getServerSoftwareCertificates()
-                        );
+                    OpcUaSession session = new OpcUaSession(
+                        csr.getAuthenticationToken(),
+                        csr.getSessionId(),
+                        client.getConfig().getSessionName().get(),
+                        csr.getRevisedSessionTimeout(),
+                        csr.getMaxRequestMessageSize(),
+                        csr.getServerCertificate(),
+                        csr.getServerSoftwareCertificates()
+                    );
 
-                        session.setServerNonce(asrNonce);
+                    session.setServerNonce(asrNonce);
 
-                        return completedFuture(session);
-                    } catch (UaException e) {
-                        return failedFuture(e);
-                    }
+                    return completedFuture(session);
                 });
         } catch (Exception ex) {
             return failedFuture(ex);

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/SessionManager.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/SessionManager.java
@@ -187,10 +187,12 @@ public class SessionManager implements
 
         ByteString clientNonce = request.getClientNonce();
 
-        NonceUtil.validateNonce(clientNonce);
+        if (securityPolicy != SecurityPolicy.None) {
+            NonceUtil.validateNonce(clientNonce);
 
-        if (securityPolicy != SecurityPolicy.None && clientNonces.contains(clientNonce)) {
-            throw new UaException(StatusCodes.Bad_NonceInvalid);
+            if (clientNonces.contains(clientNonce)) {
+                throw new UaException(StatusCodes.Bad_NonceInvalid);
+            }
         }
 
         if (securityPolicy != SecurityPolicy.None && clientNonce.isNotNull()) {

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/util/NonceUtil.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/util/NonceUtil.java
@@ -16,6 +16,7 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.bouncycastle.util.Arrays;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.security.SecurityPolicy;
@@ -177,6 +178,10 @@ public class NonceUtil {
                 StatusCodes.Bad_NonceInvalid,
                 "nonce must be at least " + minimumLength + " bytes"
             );
+        }
+
+        if (bs.length > 0 && Arrays.areAllZeroes(bs, 0, bs.length)) {
+            throw new UaException(StatusCodes.Bad_NonceInvalid, "nonce must be non-zero");
         }
     }
 


### PR DESCRIPTION
Nonce validation can be relaxed when:

- using an AnonymousIdentityToken
- using a UserNameIdentityToken with SecurityPolicy None in both the channel
and UserTokenPolicy
- using an X509IdentityToken with SecurityPolicy None in both the channel and
UserTokenPolicy

This allows unsecured credentials to be used regardless of the nonce validity,
since the nonce isn't used in that case, while still ensuring that if the nonce
is supposed to protect the credentials it must be valid.

fixes #579 