### PR TITLE
Short-circuit call to InetAddress.isLoopbackAddress()

### DIFF
--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/util/HostnameUtil.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/util/HostnameUtil.java
@@ -66,9 +66,7 @@ public class HostnameUtil {
                     for (NetworkInterface ni : Collections.list(nis)) {
                         Collections.list(ni.getInetAddresses()).forEach(ia -> {
                             if (ia instanceof Inet4Address) {
-                                boolean loopback = ia.isLoopbackAddress();
-
-                                if (!loopback || includeLoopback) {
+                                if (includeLoopback || !ia.isLoopbackAddress()) {
                                     hostnames.add(ia.getHostName());
                                     hostnames.add(ia.getHostAddress());
                                     hostnames.add(ia.getCanonicalHostName());
@@ -81,9 +79,7 @@ public class HostnameUtil {
                         .warn("Failed to NetworkInterfaces for bind address: {}", address, e);
                 }
             } else {
-                boolean loopback = inetAddress.isLoopbackAddress();
-
-                if (!loopback || includeLoopback) {
+                if (includeLoopback || !inetAddress.isLoopbackAddress()) {
                     hostnames.add(inetAddress.getHostName());
                     hostnames.add(inetAddress.getHostAddress());
                     hostnames.add(inetAddress.getCanonicalHostName());


### PR DESCRIPTION
Prevents unnecessary call to isLoopbackAddress() when includeLoopback
parameter is true because it can be a slow operation on some systems.

fixes #641
