### PR TITLE
Fix X509IdentityProvider when using SecurityPolicy.None

### DIFF
--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/api/identity/X509IdentityProvider.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/api/identity/X509IdentityProvider.java
@@ -78,11 +78,7 @@ public class X509IdentityProvider implements IdentityProvider {
         } else {
             NonceUtil.validateNonce(serverNonce);
 
-            byte[] serverCertificateBytes = new byte[0];
-            if (!endpoint.getSecurityPolicyUri().equals(SecurityPolicy.None.getUri())) {
-                ByteString serverCertificate = endpoint.getServerCertificate();
-                serverCertificateBytes = serverCertificate.bytesOrEmpty();
-            }
+            byte[] serverCertificateBytes = endpoint.getServerCertificate().bytesOrEmpty();
 
             byte[] serverNonceBytes = serverNonce.bytes();
             if (serverNonceBytes == null) serverNonceBytes = new byte[0];
@@ -95,7 +91,7 @@ public class X509IdentityProvider implements IdentityProvider {
             );
 
             signatureData = new SignatureData(
-                securityPolicy.getAsymmetricSignatureAlgorithm().getUri(),
+                securityPolicyUri,
                 ByteString.of(signature)
             );
         }


### PR DESCRIPTION
Fixes two issues with X509IdentityProvider when using SecurityPolicy.None

1. the server certificate bytes are not used even though there might be one in the endpoint
2. the wrong securityPolicyUri is used when building the SignatureData

fixes #647
