### PR TITLE
Create SignatureData in the client using the server's leaf certificate

### DIFF
--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/api/identity/X509IdentityProvider.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/api/identity/X509IdentityProvider.java
@@ -91,7 +91,10 @@ public class X509IdentityProvider implements IdentityProvider {
         } else {
             NonceUtil.validateNonce(serverNonce);
 
-            byte[] serverCertificateBytes = endpoint.getServerCertificate().bytesOrEmpty();
+            List<X509Certificate> serverCertificates = CertificateUtil.decodeCertificates(
+                endpoint.getServerCertificate().bytesOrEmpty()
+            );
+            byte[] serverCertificateBytes = serverCertificates.get(0).getEncoded();
 
             byte[] serverNonceBytes = serverNonce.bytes();
             if (serverNonceBytes == null) serverNonceBytes = new byte[0];

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/session/SessionFsmFactory.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/session/SessionFsmFactory.java
@@ -1092,11 +1092,13 @@ public class SessionFsmFactory {
         } else {
             SecurityAlgorithm signatureAlgorithm = securityPolicy.getAsymmetricSignatureAlgorithm();
             PrivateKey privateKey = config.getKeyPair().map(KeyPair::getPrivate).orElse(null);
-            ByteString serverCertificate = endpoint.getServerCertificate();
+            List<X509Certificate> serverCertificates = CertificateUtil.decodeCertificates(
+                endpoint.getServerCertificate().bytesOrEmpty()
+            );
 
             // Signature data is serverCert + serverNonce signed with our private key.
             byte[] serverNonceBytes = serverNonce.bytesOrEmpty();
-            byte[] serverCertificateBytes = serverCertificate.bytesOrEmpty();
+            byte[] serverCertificateBytes = serverCertificates.get(0).getEncoded();
             byte[] dataToSign = Bytes.concat(serverCertificateBytes, serverNonceBytes);
 
             byte[] signature = SignatureUtil.sign(


### PR DESCRIPTION
Additionally, when verifying a SignatureData in the server, first verify using
the leaf certificate and then fall back to using the full certificate chain if
that fails.

fixes #658
