### PR TITLE
Allow monitored item modification for Nodes that no longer exist

### DIFF
--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/api/AddressSpaceComposite.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/api/AddressSpaceComposite.java
@@ -901,7 +901,12 @@ public class AddressSpaceComposite implements AddressSpace {
         public AddressSpaceFilter getFilter() {
             return new SimpleAddressSpaceFilter() {
                 @Override
-                protected boolean filter(NodeId nodeId) {
+                protected boolean filterNode(NodeId nodeId) {
+                    return true;
+                }
+
+                @Override
+                protected boolean filterMonitoredItem(NodeId nodeId) {
                     return true;
                 }
             };

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/api/ManagedNamespace.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/api/ManagedNamespace.java
@@ -46,12 +46,10 @@ public abstract class ManagedNamespace extends ManagedAddressSpace implements Na
         this.namespaceUri = namespaceUri;
         this.namespaceIndex = server.getNamespaceTable().addUri(namespaceUri);
 
-        filter = new SimpleAddressSpaceFilter() {
-            @Override
-            protected boolean filter(NodeId nodeId) {
-                return nodeId.getNamespaceIndex().equals(namespaceIndex);
-            }
-        };
+        filter = SimpleAddressSpaceFilter.create(
+            nodeId ->
+                nodeId.getNamespaceIndex().equals(getNamespaceIndex())
+        );
     }
 
     @Override

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/api/SimpleAddressSpaceFilter.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/api/SimpleAddressSpaceFilter.java
@@ -35,45 +35,77 @@ public abstract class SimpleAddressSpaceFilter implements AddressSpaceFilter {
     /**
      * Create a new {@link SimpleAddressSpaceFilter} that uses a {@link Predicate} on {@link NodeId}.
      *
-     * @param filter a {@link Predicate} that tests a {@link NodeId}.
+     * @param nodeIdFilter a {@link Predicate} that tests a {@link NodeId}.
      * @return a new {@link SimpleAddressSpaceFilter} that uses a {@link Predicate} on {@link NodeId}.
      */
-    public static SimpleAddressSpaceFilter create(Predicate<NodeId> filter) {
+    public static SimpleAddressSpaceFilter create(Predicate<NodeId> nodeIdFilter) {
+        return create(nodeIdFilter, nodeIdFilter);
+    }
+
+    /**
+     * Create a new {@link SimpleAddressSpaceFilter} that uses a separate {@link Predicate} for {@link NodeId}s and
+     * {@link MonitoredItem}s.
+     *
+     * @param nodeIdFilter        a {@link Predicate} that tests a {@link NodeId}.
+     * @param monitoredItemFilter a {@link Predicate} that tests a {@link NodeId} targeted by a {@link MonitoredItem}.
+     * @return a new {@link SimpleAddressSpaceFilter} that uses a {@link Predicate} on {@link NodeId}.
+     */
+    public static SimpleAddressSpaceFilter create(
+        Predicate<NodeId> nodeIdFilter,
+        Predicate<NodeId> monitoredItemFilter
+    ) {
+
         return new SimpleAddressSpaceFilter() {
             @Override
-            protected boolean filter(NodeId nodeId) {
-                return filter.test(nodeId);
+            protected boolean filterNode(NodeId nodeId) {
+                return nodeIdFilter.test(nodeId);
+            }
+
+            @Override
+            protected boolean filterMonitoredItem(NodeId nodeId) {
+                return monitoredItemFilter.test(nodeId);
             }
         };
     }
 
     /**
-     * Return {@code true} if the operation {@code nodeId} belongs to should be handled this {@link AddressSpace}.
+     * Return {@code true} if the operation {@code nodeId} belongs to should be handled this filter's
+     * {@link AddressSpace}.
      * <p>
      * This is not an indication that a Node for {@code nodeId} exists, rather, it's an indication that this
      * AddressSpace would be responsible for the Node *if it did* exist.
      *
      * @param nodeId a {@link NodeId}.
-     * @return {@code true} if the operation {@code nodeId} belongs to should be handled this {@link AddressSpace}.
+     * @return {@code true} if the operation {@code nodeId} belongs to should be handled this filter's
+     * {@link AddressSpace}.
      */
-    protected abstract boolean filter(NodeId nodeId);
+    protected abstract boolean filterNode(NodeId nodeId);
 
+    /**
+     * Return {@code true} if the operation on the MonitoredItem for {@code nodeId} should be
+     * handled by this filter's {@link AddressSpace}.
+     *
+     * @param nodeId the {@link NodeId} of {@link MonitoredItem} being operated on.
+     * @return {@code true} if the operation on the MonitoredItem for {@code nodeId} should be
+     * handled by this filter's {@link AddressSpace}.
+     */
+    protected abstract boolean filterMonitoredItem(NodeId nodeId);
 
     //region ViewServices
 
     @Override
     public boolean filterBrowse(OpcUaServer server, NodeId nodeId) {
-        return filter(nodeId);
+        return filterNode(nodeId);
     }
 
     @Override
     public boolean filterRegisterNode(OpcUaServer server, NodeId nodeId) {
-        return filter(nodeId);
+        return filterNode(nodeId);
     }
 
     @Override
     public boolean filterUnregisterNode(OpcUaServer server, NodeId nodeId) {
-        return filter(nodeId);
+        return filterNode(nodeId);
     }
 
     //endregion
@@ -82,22 +114,22 @@ public abstract class SimpleAddressSpaceFilter implements AddressSpaceFilter {
 
     @Override
     public boolean filterRead(OpcUaServer server, ReadValueId readValueId) {
-        return filter(readValueId.getNodeId());
+        return filterNode(readValueId.getNodeId());
     }
 
     @Override
     public boolean filterWrite(OpcUaServer server, WriteValue writeValue) {
-        return filter(writeValue.getNodeId());
+        return filterNode(writeValue.getNodeId());
     }
 
     @Override
     public boolean filterHistoryRead(OpcUaServer server, HistoryReadValueId historyReadValueId) {
-        return filter(historyReadValueId.getNodeId());
+        return filterNode(historyReadValueId.getNodeId());
     }
 
     @Override
     public boolean filterHistoryUpdate(OpcUaServer server, HistoryUpdateDetails historyUpdateDetails) {
-        return filter(historyUpdateDetails.getNodeId());
+        return filterNode(historyUpdateDetails.getNodeId());
     }
 
     //endregion
@@ -106,7 +138,7 @@ public abstract class SimpleAddressSpaceFilter implements AddressSpaceFilter {
 
     @Override
     public boolean filterCall(OpcUaServer server, CallMethodRequest callMethodRequest) {
-        return filter(callMethodRequest.getObjectId());
+        return filterNode(callMethodRequest.getObjectId());
     }
 
     //endregion
@@ -115,57 +147,57 @@ public abstract class SimpleAddressSpaceFilter implements AddressSpaceFilter {
 
     @Override
     public boolean filterOnCreateDataItem(OpcUaServer server, ReadValueId readValueId) {
-        return filter(readValueId.getNodeId());
+        return filterMonitoredItem(readValueId.getNodeId());
     }
 
     @Override
     public boolean filterOnModifyDataItem(OpcUaServer server, ReadValueId readValueId) {
-        return filter(readValueId.getNodeId());
+        return filterMonitoredItem(readValueId.getNodeId());
     }
 
     @Override
     public boolean filterOnCreateEventItem(OpcUaServer server, ReadValueId readValueId) {
-        return filter(readValueId.getNodeId());
+        return filterMonitoredItem(readValueId.getNodeId());
     }
 
     @Override
     public boolean filterOnModifyEventItem(OpcUaServer server, ReadValueId readValueId) {
-        return filter(readValueId.getNodeId());
+        return filterMonitoredItem(readValueId.getNodeId());
     }
 
     @Override
     public boolean filterOnDataItemsCreated(OpcUaServer server, ReadValueId readValueId) {
-        return filter(readValueId.getNodeId());
+        return filterMonitoredItem(readValueId.getNodeId());
     }
 
     @Override
     public boolean filterOnDataItemsModified(OpcUaServer server, ReadValueId readValueId) {
-        return filter(readValueId.getNodeId());
+        return filterMonitoredItem(readValueId.getNodeId());
     }
 
     @Override
     public boolean filterOnDataItemsDeleted(OpcUaServer server, ReadValueId readValueId) {
-        return filter(readValueId.getNodeId());
+        return filterMonitoredItem(readValueId.getNodeId());
     }
 
     @Override
     public boolean filterOnEventItemsCreated(OpcUaServer server, ReadValueId readValueId) {
-        return filter(readValueId.getNodeId());
+        return filterMonitoredItem(readValueId.getNodeId());
     }
 
     @Override
     public boolean filterOnEventItemsModified(OpcUaServer server, ReadValueId readValueId) {
-        return filter(readValueId.getNodeId());
+        return filterMonitoredItem(readValueId.getNodeId());
     }
 
     @Override
     public boolean filterOnEventItemsDeleted(OpcUaServer server, ReadValueId readValueId) {
-        return filter(readValueId.getNodeId());
+        return filterMonitoredItem(readValueId.getNodeId());
     }
 
     @Override
     public boolean filterOnMonitoringModeChanged(OpcUaServer server, ReadValueId readValueId) {
-        return filter(readValueId.getNodeId());
+        return filterMonitoredItem(readValueId.getNodeId());
     }
 
     //endregion
@@ -181,30 +213,30 @@ public abstract class SimpleAddressSpaceFilter implements AddressSpaceFilter {
 
         if (requestedNewNodeId.isNotNull()) {
             return requestedNewNodeId
-                .local(namespaceTable)
-                .map(this::filter)
+                .toNodeId(namespaceTable)
+                .map(this::filterNode)
                 .orElse(false);
         } else {
             return addNodesItem.getParentNodeId()
-                .local(namespaceTable)
-                .map(this::filter)
+                .toNodeId(namespaceTable)
+                .map(this::filterNode)
                 .orElse(false);
         }
     }
 
     @Override
     public boolean filterDeleteNodes(OpcUaServer server, DeleteNodesItem deleteNodesItem) {
-        return filter(deleteNodesItem.getNodeId());
+        return filterNode(deleteNodesItem.getNodeId());
     }
 
     @Override
     public boolean filterAddReferences(OpcUaServer server, AddReferencesItem addReferencesItem) {
-        return filter(addReferencesItem.getSourceNodeId());
+        return filterNode(addReferencesItem.getSourceNodeId());
     }
 
     @Override
     public boolean filterDeleteReferences(OpcUaServer server, DeleteReferencesItem deleteReferencesItem) {
-        return filter(deleteReferencesItem.getSourceNodeId());
+        return filterNode(deleteReferencesItem.getSourceNodeId());
     }
 
     //endregion

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/subscriptions/SubscriptionManager.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/subscriptions/SubscriptionManager.java
@@ -785,7 +785,11 @@ public class SubscriptionManager {
                     minimumSamplingInterval = server.getConfig().getLimits().getMinSupportedSampleRate();
                 }
             } catch (UaException e) {
-                if (e.getStatusCode().getValue() != StatusCodes.Bad_AttributeIdInvalid) {
+                long statusCodeValue = e.getStatusCode().getValue();
+
+                if (statusCodeValue != StatusCodes.Bad_AttributeIdInvalid &&
+                    statusCodeValue != StatusCodes.Bad_NodeIdUnknown) {
+
                     throw e;
                 }
             }


### PR DESCRIPTION
This fix has two parts. First, simply allow Bad_NodeIdUnknown when trying to
read the MinimumSamplingInterval attribute during a ModifyMonitoredItems service
call. Second, Modify SimpleAddressSpaceFilter to filter MonitoredItem service calls
with a different predicate than the other services. This will allow AddressSpace
implementations to test whether the service call should be handled based on some
other criteria than the Node simply existing in its NodeManager.

fixes #547
