### PR TITLE
Ensure OPC UA namespace URI is always present at index 0

### DIFF
--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/OpcUaClient.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/OpcUaClient.java
@@ -123,6 +123,7 @@ import org.eclipse.milo.opcua.stack.core.types.structured.WriteResponse;
 import org.eclipse.milo.opcua.stack.core.types.structured.WriteValue;
 import org.eclipse.milo.opcua.stack.core.util.ExecutionQueue;
 import org.eclipse.milo.opcua.stack.core.util.ManifestUtil;
+import org.eclipse.milo.opcua.stack.core.util.Namespaces;
 import org.eclipse.milo.opcua.stack.core.util.Unit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -371,13 +372,14 @@ public class OpcUaClient implements UaClient {
     private void updateNamespaceTable(String[] namespaceArray) {
         getNamespaceTable().update(uriTable -> {
             uriTable.clear();
+            uriTable.put(ushort(0), Namespaces.OPC_UA);
 
             if (namespaceArray.length > UShort.MAX_VALUE) {
                 logger.warn("NamespaceTable returned by " +
                     "server contains " + namespaceArray.length + " entries");
             }
 
-            for (int i = 0; i < namespaceArray.length && i < UShort.MAX_VALUE; i++) {
+            for (int i = 1; i < namespaceArray.length && i < UShort.MAX_VALUE; i++) {
                 String uri = namespaceArray[i];
 
                 if (uri != null && !uriTable.containsValue(uri)) {


### PR DESCRIPTION
When OpcUaClient reads and updates the namespace table it clears it before updating with the new one read from the server. If the server returned an empty array then the client namespace table will now be empty.

Even though this is defective behavior on the server's part we can still ensure the client's namespace table at least has the OPC UA namespace URI at index 0.

fixes #681
