### PR TITLE
Guard against BrowseResult#getReferences() returning null

### DIFF
--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/AddressSpace.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/AddressSpace.java
@@ -11,7 +11,6 @@
 package org.eclipse.milo.opcua.sdk.client;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -766,7 +765,8 @@ public class AddressSpace {
 
         return browseFuture.thenCompose(result -> {
             if (result.getStatusCode().isGood()) {
-                Optional<ExpandedNodeId> typeDefinitionId = Arrays.stream(result.getReferences())
+                Optional<ExpandedNodeId> typeDefinitionId = l(result.getReferences())
+                    .stream()
                     .filter(r -> Objects.equals(Identifiers.HasTypeDefinition, r.getReferenceTypeId()))
                     .map(ReferenceDescription::getNodeId)
                     .findFirst();

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/BrowseHelper.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/BrowseHelper.java
@@ -29,6 +29,7 @@ import org.eclipse.milo.opcua.stack.core.types.structured.ReferenceDescription;
 import org.eclipse.milo.opcua.stack.core.types.structured.ViewDescription;
 
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.eclipse.milo.opcua.stack.core.util.ConversionUtil.l;
 
 /**
  * "Helper" functions for doing a Browse followed by as many BrowseNext calls as are necessary
@@ -87,7 +88,7 @@ public class BrowseHelper {
     ) {
 
         if (result.getStatusCode().isGood()) {
-            Collections.addAll(references, result.getReferences());
+            references.addAll(l(result.getReferences()));
 
             ByteString nextContinuationPoint = result.getContinuationPoint();
 

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/nodes/UaObjectNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/nodes/UaObjectNode.java
@@ -10,7 +10,6 @@
 
 package org.eclipse.milo.opcua.sdk.client.nodes;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -272,7 +271,8 @@ public class UaObjectNode extends UaNode implements ObjectNode {
             StatusCode statusCode = result.getStatusCode();
 
             if (statusCode != null && statusCode.isGood()) {
-                Optional<ExpandedNodeId> methodNodeId = Arrays.stream(result.getReferences())
+                Optional<ExpandedNodeId> methodNodeId = l(result.getReferences())
+                    .stream()
                     .filter(rd -> Objects.equals(methodName, rd.getBrowseName()))
                     .findFirst()
                     .map(ReferenceDescription::getNodeId);


### PR DESCRIPTION
The spec says this should be an empty array when there are no references
but it has been observed that some out-of-spec servers will send a null
value instead.

fixes #692
