### PR TITLE
Generate new client object and variable nodes

### DIFF
--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/AcknowledgeableConditionTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/AcknowledgeableConditionTypeNode.java
@@ -15,12 +15,11 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
-import org.eclipse.milo.opcua.stack.core.util.FutureUtils;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public class AcknowledgeableConditionTypeNode extends ConditionTypeNode implements AcknowledgeableConditionType {
     public AcknowledgeableConditionTypeNode(OpcUaClient client, NodeId nodeId, NodeClass nodeClass,
@@ -65,17 +64,10 @@ public class AcknowledgeableConditionTypeNode extends ConditionTypeNode implemen
     }
 
     @Override
-    public CompletableFuture<Unit> writeEnabledStateAsync(LocalizedText enabledState) {
+    public CompletableFuture<StatusCode> writeEnabledStateAsync(LocalizedText enabledState) {
         DataValue value = DataValue.valueOnly(new Variant(enabledState));
         return getEnabledStateNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -129,17 +121,10 @@ public class AcknowledgeableConditionTypeNode extends ConditionTypeNode implemen
     }
 
     @Override
-    public CompletableFuture<Unit> writeAckedStateAsync(LocalizedText ackedState) {
+    public CompletableFuture<StatusCode> writeAckedStateAsync(LocalizedText ackedState) {
         DataValue value = DataValue.valueOnly(new Variant(ackedState));
         return getAckedStateNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -193,17 +178,10 @@ public class AcknowledgeableConditionTypeNode extends ConditionTypeNode implemen
     }
 
     @Override
-    public CompletableFuture<Unit> writeConfirmedStateAsync(LocalizedText confirmedState) {
+    public CompletableFuture<StatusCode> writeConfirmedStateAsync(LocalizedText confirmedState) {
         DataValue value = DataValue.valueOnly(new Variant(confirmedState));
         return getConfirmedStateNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/AggregateConfigurationTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/AggregateConfigurationTypeNode.java
@@ -15,12 +15,11 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
-import org.eclipse.milo.opcua.stack.core.util.FutureUtils;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public class AggregateConfigurationTypeNode extends BaseObjectTypeNode implements AggregateConfigurationType {
     public AggregateConfigurationTypeNode(OpcUaClient client, NodeId nodeId, NodeClass nodeClass,
@@ -65,17 +64,10 @@ public class AggregateConfigurationTypeNode extends BaseObjectTypeNode implement
     }
 
     @Override
-    public CompletableFuture<Unit> writeTreatUncertainAsBadAsync(Boolean treatUncertainAsBad) {
+    public CompletableFuture<StatusCode> writeTreatUncertainAsBadAsync(Boolean treatUncertainAsBad) {
         DataValue value = DataValue.valueOnly(new Variant(treatUncertainAsBad));
         return getTreatUncertainAsBadNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -129,17 +121,10 @@ public class AggregateConfigurationTypeNode extends BaseObjectTypeNode implement
     }
 
     @Override
-    public CompletableFuture<Unit> writePercentDataBadAsync(UByte percentDataBad) {
+    public CompletableFuture<StatusCode> writePercentDataBadAsync(UByte percentDataBad) {
         DataValue value = DataValue.valueOnly(new Variant(percentDataBad));
         return getPercentDataBadNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -193,17 +178,10 @@ public class AggregateConfigurationTypeNode extends BaseObjectTypeNode implement
     }
 
     @Override
-    public CompletableFuture<Unit> writePercentDataGoodAsync(UByte percentDataGood) {
+    public CompletableFuture<StatusCode> writePercentDataGoodAsync(UByte percentDataGood) {
         DataValue value = DataValue.valueOnly(new Variant(percentDataGood));
         return getPercentDataGoodNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -257,17 +235,11 @@ public class AggregateConfigurationTypeNode extends BaseObjectTypeNode implement
     }
 
     @Override
-    public CompletableFuture<Unit> writeUseSlopedExtrapolationAsync(Boolean useSlopedExtrapolation) {
+    public CompletableFuture<StatusCode> writeUseSlopedExtrapolationAsync(
+        Boolean useSlopedExtrapolation) {
         DataValue value = DataValue.valueOnly(new Variant(useSlopedExtrapolation));
         return getUseSlopedExtrapolationNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/AlarmConditionTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/AlarmConditionTypeNode.java
@@ -16,12 +16,11 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
-import org.eclipse.milo.opcua.stack.core.util.FutureUtils;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public class AlarmConditionTypeNode extends AcknowledgeableConditionTypeNode implements AlarmConditionType {
     public AlarmConditionTypeNode(OpcUaClient client, NodeId nodeId, NodeClass nodeClass,
@@ -66,17 +65,10 @@ public class AlarmConditionTypeNode extends AcknowledgeableConditionTypeNode imp
     }
 
     @Override
-    public CompletableFuture<Unit> writeInputNodeAsync(NodeId inputNode) {
+    public CompletableFuture<StatusCode> writeInputNodeAsync(NodeId inputNode) {
         DataValue value = DataValue.valueOnly(new Variant(inputNode));
         return getInputNodeNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -130,17 +122,10 @@ public class AlarmConditionTypeNode extends AcknowledgeableConditionTypeNode imp
     }
 
     @Override
-    public CompletableFuture<Unit> writeSuppressedOrShelvedAsync(Boolean suppressedOrShelved) {
+    public CompletableFuture<StatusCode> writeSuppressedOrShelvedAsync(Boolean suppressedOrShelved) {
         DataValue value = DataValue.valueOnly(new Variant(suppressedOrShelved));
         return getSuppressedOrShelvedNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -194,17 +179,10 @@ public class AlarmConditionTypeNode extends AcknowledgeableConditionTypeNode imp
     }
 
     @Override
-    public CompletableFuture<Unit> writeMaxTimeShelvedAsync(Double maxTimeShelved) {
+    public CompletableFuture<StatusCode> writeMaxTimeShelvedAsync(Double maxTimeShelved) {
         DataValue value = DataValue.valueOnly(new Variant(maxTimeShelved));
         return getMaxTimeShelvedNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -258,17 +236,10 @@ public class AlarmConditionTypeNode extends AcknowledgeableConditionTypeNode imp
     }
 
     @Override
-    public CompletableFuture<Unit> writeEnabledStateAsync(LocalizedText enabledState) {
+    public CompletableFuture<StatusCode> writeEnabledStateAsync(LocalizedText enabledState) {
         DataValue value = DataValue.valueOnly(new Variant(enabledState));
         return getEnabledStateNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -322,17 +293,10 @@ public class AlarmConditionTypeNode extends AcknowledgeableConditionTypeNode imp
     }
 
     @Override
-    public CompletableFuture<Unit> writeActiveStateAsync(LocalizedText activeState) {
+    public CompletableFuture<StatusCode> writeActiveStateAsync(LocalizedText activeState) {
         DataValue value = DataValue.valueOnly(new Variant(activeState));
         return getActiveStateNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -386,17 +350,10 @@ public class AlarmConditionTypeNode extends AcknowledgeableConditionTypeNode imp
     }
 
     @Override
-    public CompletableFuture<Unit> writeSuppressedStateAsync(LocalizedText suppressedState) {
+    public CompletableFuture<StatusCode> writeSuppressedStateAsync(LocalizedText suppressedState) {
         DataValue value = DataValue.valueOnly(new Variant(suppressedState));
         return getSuppressedStateNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/AuditActivateSessionEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/AuditActivateSessionEventTypeNode.java
@@ -16,14 +16,13 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.ExtensionObject;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
 import org.eclipse.milo.opcua.stack.core.types.structured.SignedSoftwareCertificate;
 import org.eclipse.milo.opcua.stack.core.types.structured.UserIdentityToken;
-import org.eclipse.milo.opcua.stack.core.util.FutureUtils;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public class AuditActivateSessionEventTypeNode extends AuditSessionEventTypeNode implements AuditActivateSessionEventType {
     public AuditActivateSessionEventTypeNode(OpcUaClient client, NodeId nodeId, NodeClass nodeClass,
@@ -72,19 +71,12 @@ public class AuditActivateSessionEventTypeNode extends AuditSessionEventTypeNode
     }
 
     @Override
-    public CompletableFuture<Unit> writeClientSoftwareCertificatesAsync(
+    public CompletableFuture<StatusCode> writeClientSoftwareCertificatesAsync(
         SignedSoftwareCertificate[] clientSoftwareCertificates) {
         ExtensionObject[] encoded = ExtensionObject.encodeArray(client.getSerializationContext(), clientSoftwareCertificates);
         DataValue value = DataValue.valueOnly(new Variant(encoded));
         return getClientSoftwareCertificatesNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -139,18 +131,12 @@ public class AuditActivateSessionEventTypeNode extends AuditSessionEventTypeNode
     }
 
     @Override
-    public CompletableFuture<Unit> writeUserIdentityTokenAsync(UserIdentityToken userIdentityToken) {
+    public CompletableFuture<StatusCode> writeUserIdentityTokenAsync(
+        UserIdentityToken userIdentityToken) {
         ExtensionObject encoded = ExtensionObject.encode(client.getSerializationContext(), userIdentityToken);
         DataValue value = DataValue.valueOnly(new Variant(encoded));
         return getUserIdentityTokenNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -204,17 +190,10 @@ public class AuditActivateSessionEventTypeNode extends AuditSessionEventTypeNode
     }
 
     @Override
-    public CompletableFuture<Unit> writeSecureChannelIdAsync(String secureChannelId) {
+    public CompletableFuture<StatusCode> writeSecureChannelIdAsync(String secureChannelId) {
         DataValue value = DataValue.valueOnly(new Variant(secureChannelId));
         return getSecureChannelIdNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/AuditAddNodesEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/AuditAddNodesEventTypeNode.java
@@ -16,13 +16,12 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.ExtensionObject;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
 import org.eclipse.milo.opcua.stack.core.types.structured.AddNodesItem;
-import org.eclipse.milo.opcua.stack.core.util.FutureUtils;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public class AuditAddNodesEventTypeNode extends AuditNodeManagementEventTypeNode implements AuditAddNodesEventType {
     public AuditAddNodesEventTypeNode(OpcUaClient client, NodeId nodeId, NodeClass nodeClass,
@@ -68,18 +67,11 @@ public class AuditAddNodesEventTypeNode extends AuditNodeManagementEventTypeNode
     }
 
     @Override
-    public CompletableFuture<Unit> writeNodesToAddAsync(AddNodesItem[] nodesToAdd) {
+    public CompletableFuture<StatusCode> writeNodesToAddAsync(AddNodesItem[] nodesToAdd) {
         ExtensionObject[] encoded = ExtensionObject.encodeArray(client.getSerializationContext(), nodesToAdd);
         DataValue value = DataValue.valueOnly(new Variant(encoded));
         return getNodesToAddNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/AuditAddReferencesEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/AuditAddReferencesEventTypeNode.java
@@ -16,13 +16,12 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.ExtensionObject;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
 import org.eclipse.milo.opcua.stack.core.types.structured.AddReferencesItem;
-import org.eclipse.milo.opcua.stack.core.util.FutureUtils;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public class AuditAddReferencesEventTypeNode extends AuditNodeManagementEventTypeNode implements AuditAddReferencesEventType {
     public AuditAddReferencesEventTypeNode(OpcUaClient client, NodeId nodeId, NodeClass nodeClass,
@@ -68,18 +67,12 @@ public class AuditAddReferencesEventTypeNode extends AuditNodeManagementEventTyp
     }
 
     @Override
-    public CompletableFuture<Unit> writeReferencesToAddAsync(AddReferencesItem[] referencesToAdd) {
+    public CompletableFuture<StatusCode> writeReferencesToAddAsync(
+        AddReferencesItem[] referencesToAdd) {
         ExtensionObject[] encoded = ExtensionObject.encodeArray(client.getSerializationContext(), referencesToAdd);
         DataValue value = DataValue.valueOnly(new Variant(encoded));
         return getReferencesToAddNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/AuditCancelEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/AuditCancelEventTypeNode.java
@@ -15,12 +15,11 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
-import org.eclipse.milo.opcua.stack.core.util.FutureUtils;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public class AuditCancelEventTypeNode extends AuditSessionEventTypeNode implements AuditCancelEventType {
     public AuditCancelEventTypeNode(OpcUaClient client, NodeId nodeId, NodeClass nodeClass,
@@ -65,17 +64,10 @@ public class AuditCancelEventTypeNode extends AuditSessionEventTypeNode implemen
     }
 
     @Override
-    public CompletableFuture<Unit> writeRequestHandleAsync(UInteger requestHandle) {
+    public CompletableFuture<StatusCode> writeRequestHandleAsync(UInteger requestHandle) {
         DataValue value = DataValue.valueOnly(new Variant(requestHandle));
         return getRequestHandleNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/AuditCertificateDataMismatchEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/AuditCertificateDataMismatchEventTypeNode.java
@@ -15,12 +15,11 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
-import org.eclipse.milo.opcua.stack.core.util.FutureUtils;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public class AuditCertificateDataMismatchEventTypeNode extends AuditCertificateEventTypeNode implements AuditCertificateDataMismatchEventType {
     public AuditCertificateDataMismatchEventTypeNode(OpcUaClient client, NodeId nodeId,
@@ -65,17 +64,10 @@ public class AuditCertificateDataMismatchEventTypeNode extends AuditCertificateE
     }
 
     @Override
-    public CompletableFuture<Unit> writeInvalidHostnameAsync(String invalidHostname) {
+    public CompletableFuture<StatusCode> writeInvalidHostnameAsync(String invalidHostname) {
         DataValue value = DataValue.valueOnly(new Variant(invalidHostname));
         return getInvalidHostnameNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -129,17 +121,10 @@ public class AuditCertificateDataMismatchEventTypeNode extends AuditCertificateE
     }
 
     @Override
-    public CompletableFuture<Unit> writeInvalidUriAsync(String invalidUri) {
+    public CompletableFuture<StatusCode> writeInvalidUriAsync(String invalidUri) {
         DataValue value = DataValue.valueOnly(new Variant(invalidUri));
         return getInvalidUriNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/AuditCertificateEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/AuditCertificateEventTypeNode.java
@@ -16,12 +16,11 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
-import org.eclipse.milo.opcua.stack.core.util.FutureUtils;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public class AuditCertificateEventTypeNode extends AuditSecurityEventTypeNode implements AuditCertificateEventType {
     public AuditCertificateEventTypeNode(OpcUaClient client, NodeId nodeId, NodeClass nodeClass,
@@ -66,17 +65,10 @@ public class AuditCertificateEventTypeNode extends AuditSecurityEventTypeNode im
     }
 
     @Override
-    public CompletableFuture<Unit> writeCertificateAsync(ByteString certificate) {
+    public CompletableFuture<StatusCode> writeCertificateAsync(ByteString certificate) {
         DataValue value = DataValue.valueOnly(new Variant(certificate));
         return getCertificateNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/AuditChannelEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/AuditChannelEventTypeNode.java
@@ -15,12 +15,11 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
-import org.eclipse.milo.opcua.stack.core.util.FutureUtils;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public class AuditChannelEventTypeNode extends AuditSecurityEventTypeNode implements AuditChannelEventType {
     public AuditChannelEventTypeNode(OpcUaClient client, NodeId nodeId, NodeClass nodeClass,
@@ -65,17 +64,10 @@ public class AuditChannelEventTypeNode extends AuditSecurityEventTypeNode implem
     }
 
     @Override
-    public CompletableFuture<Unit> writeSecureChannelIdAsync(String secureChannelId) {
+    public CompletableFuture<StatusCode> writeSecureChannelIdAsync(String secureChannelId) {
         DataValue value = DataValue.valueOnly(new Variant(secureChannelId));
         return getSecureChannelIdNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/AuditConditionAcknowledgeEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/AuditConditionAcknowledgeEventTypeNode.java
@@ -16,12 +16,11 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
-import org.eclipse.milo.opcua.stack.core.util.FutureUtils;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public class AuditConditionAcknowledgeEventTypeNode extends AuditConditionEventTypeNode implements AuditConditionAcknowledgeEventType {
     public AuditConditionAcknowledgeEventTypeNode(OpcUaClient client, NodeId nodeId,
@@ -66,17 +65,10 @@ public class AuditConditionAcknowledgeEventTypeNode extends AuditConditionEventT
     }
 
     @Override
-    public CompletableFuture<Unit> writeConditionEventIdAsync(ByteString conditionEventId) {
+    public CompletableFuture<StatusCode> writeConditionEventIdAsync(ByteString conditionEventId) {
         DataValue value = DataValue.valueOnly(new Variant(conditionEventId));
         return getConditionEventIdNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -130,17 +122,10 @@ public class AuditConditionAcknowledgeEventTypeNode extends AuditConditionEventT
     }
 
     @Override
-    public CompletableFuture<Unit> writeCommentAsync(LocalizedText comment) {
+    public CompletableFuture<StatusCode> writeCommentAsync(LocalizedText comment) {
         DataValue value = DataValue.valueOnly(new Variant(comment));
         return getCommentNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/AuditConditionCommentEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/AuditConditionCommentEventTypeNode.java
@@ -16,12 +16,11 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
-import org.eclipse.milo.opcua.stack.core.util.FutureUtils;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public class AuditConditionCommentEventTypeNode extends AuditConditionEventTypeNode implements AuditConditionCommentEventType {
     public AuditConditionCommentEventTypeNode(OpcUaClient client, NodeId nodeId, NodeClass nodeClass,
@@ -66,17 +65,10 @@ public class AuditConditionCommentEventTypeNode extends AuditConditionEventTypeN
     }
 
     @Override
-    public CompletableFuture<Unit> writeConditionEventIdAsync(ByteString conditionEventId) {
+    public CompletableFuture<StatusCode> writeConditionEventIdAsync(ByteString conditionEventId) {
         DataValue value = DataValue.valueOnly(new Variant(conditionEventId));
         return getConditionEventIdNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -130,17 +122,10 @@ public class AuditConditionCommentEventTypeNode extends AuditConditionEventTypeN
     }
 
     @Override
-    public CompletableFuture<Unit> writeCommentAsync(LocalizedText comment) {
+    public CompletableFuture<StatusCode> writeCommentAsync(LocalizedText comment) {
         DataValue value = DataValue.valueOnly(new Variant(comment));
         return getCommentNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/AuditConditionConfirmEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/AuditConditionConfirmEventTypeNode.java
@@ -16,12 +16,11 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
-import org.eclipse.milo.opcua.stack.core.util.FutureUtils;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public class AuditConditionConfirmEventTypeNode extends AuditConditionEventTypeNode implements AuditConditionConfirmEventType {
     public AuditConditionConfirmEventTypeNode(OpcUaClient client, NodeId nodeId, NodeClass nodeClass,
@@ -66,17 +65,10 @@ public class AuditConditionConfirmEventTypeNode extends AuditConditionEventTypeN
     }
 
     @Override
-    public CompletableFuture<Unit> writeConditionEventIdAsync(ByteString conditionEventId) {
+    public CompletableFuture<StatusCode> writeConditionEventIdAsync(ByteString conditionEventId) {
         DataValue value = DataValue.valueOnly(new Variant(conditionEventId));
         return getConditionEventIdNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -130,17 +122,10 @@ public class AuditConditionConfirmEventTypeNode extends AuditConditionEventTypeN
     }
 
     @Override
-    public CompletableFuture<Unit> writeCommentAsync(LocalizedText comment) {
+    public CompletableFuture<StatusCode> writeCommentAsync(LocalizedText comment) {
         DataValue value = DataValue.valueOnly(new Variant(comment));
         return getCommentNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/AuditConditionRespondEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/AuditConditionRespondEventTypeNode.java
@@ -15,12 +15,11 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
-import org.eclipse.milo.opcua.stack.core.util.FutureUtils;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public class AuditConditionRespondEventTypeNode extends AuditConditionEventTypeNode implements AuditConditionRespondEventType {
     public AuditConditionRespondEventTypeNode(OpcUaClient client, NodeId nodeId, NodeClass nodeClass,
@@ -65,17 +64,10 @@ public class AuditConditionRespondEventTypeNode extends AuditConditionEventTypeN
     }
 
     @Override
-    public CompletableFuture<Unit> writeSelectedResponseAsync(Integer selectedResponse) {
+    public CompletableFuture<StatusCode> writeSelectedResponseAsync(Integer selectedResponse) {
         DataValue value = DataValue.valueOnly(new Variant(selectedResponse));
         return getSelectedResponseNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/AuditConditionShelvingEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/AuditConditionShelvingEventTypeNode.java
@@ -15,12 +15,11 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
-import org.eclipse.milo.opcua.stack.core.util.FutureUtils;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public class AuditConditionShelvingEventTypeNode extends AuditConditionEventTypeNode implements AuditConditionShelvingEventType {
     public AuditConditionShelvingEventTypeNode(OpcUaClient client, NodeId nodeId, NodeClass nodeClass,
@@ -65,17 +64,10 @@ public class AuditConditionShelvingEventTypeNode extends AuditConditionEventType
     }
 
     @Override
-    public CompletableFuture<Unit> writeShelvingTimeAsync(Double shelvingTime) {
+    public CompletableFuture<StatusCode> writeShelvingTimeAsync(Double shelvingTime) {
         DataValue value = DataValue.valueOnly(new Variant(shelvingTime));
         return getShelvingTimeNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/AuditCreateSessionEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/AuditCreateSessionEventTypeNode.java
@@ -16,12 +16,11 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
-import org.eclipse.milo.opcua.stack.core.util.FutureUtils;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public class AuditCreateSessionEventTypeNode extends AuditSessionEventTypeNode implements AuditCreateSessionEventType {
     public AuditCreateSessionEventTypeNode(OpcUaClient client, NodeId nodeId, NodeClass nodeClass,
@@ -66,17 +65,10 @@ public class AuditCreateSessionEventTypeNode extends AuditSessionEventTypeNode i
     }
 
     @Override
-    public CompletableFuture<Unit> writeSecureChannelIdAsync(String secureChannelId) {
+    public CompletableFuture<StatusCode> writeSecureChannelIdAsync(String secureChannelId) {
         DataValue value = DataValue.valueOnly(new Variant(secureChannelId));
         return getSecureChannelIdNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -130,17 +122,10 @@ public class AuditCreateSessionEventTypeNode extends AuditSessionEventTypeNode i
     }
 
     @Override
-    public CompletableFuture<Unit> writeClientCertificateAsync(ByteString clientCertificate) {
+    public CompletableFuture<StatusCode> writeClientCertificateAsync(ByteString clientCertificate) {
         DataValue value = DataValue.valueOnly(new Variant(clientCertificate));
         return getClientCertificateNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -196,18 +181,11 @@ public class AuditCreateSessionEventTypeNode extends AuditSessionEventTypeNode i
     }
 
     @Override
-    public CompletableFuture<Unit> writeClientCertificateThumbprintAsync(
+    public CompletableFuture<StatusCode> writeClientCertificateThumbprintAsync(
         String clientCertificateThumbprint) {
         DataValue value = DataValue.valueOnly(new Variant(clientCertificateThumbprint));
         return getClientCertificateThumbprintNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -261,17 +239,11 @@ public class AuditCreateSessionEventTypeNode extends AuditSessionEventTypeNode i
     }
 
     @Override
-    public CompletableFuture<Unit> writeRevisedSessionTimeoutAsync(Double revisedSessionTimeout) {
+    public CompletableFuture<StatusCode> writeRevisedSessionTimeoutAsync(
+        Double revisedSessionTimeout) {
         DataValue value = DataValue.valueOnly(new Variant(revisedSessionTimeout));
         return getRevisedSessionTimeoutNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/AuditDeleteNodesEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/AuditDeleteNodesEventTypeNode.java
@@ -16,13 +16,12 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.ExtensionObject;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
 import org.eclipse.milo.opcua.stack.core.types.structured.DeleteNodesItem;
-import org.eclipse.milo.opcua.stack.core.util.FutureUtils;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public class AuditDeleteNodesEventTypeNode extends AuditNodeManagementEventTypeNode implements AuditDeleteNodesEventType {
     public AuditDeleteNodesEventTypeNode(OpcUaClient client, NodeId nodeId, NodeClass nodeClass,
@@ -68,18 +67,11 @@ public class AuditDeleteNodesEventTypeNode extends AuditNodeManagementEventTypeN
     }
 
     @Override
-    public CompletableFuture<Unit> writeNodesToDeleteAsync(DeleteNodesItem[] nodesToDelete) {
+    public CompletableFuture<StatusCode> writeNodesToDeleteAsync(DeleteNodesItem[] nodesToDelete) {
         ExtensionObject[] encoded = ExtensionObject.encodeArray(client.getSerializationContext(), nodesToDelete);
         DataValue value = DataValue.valueOnly(new Variant(encoded));
         return getNodesToDeleteNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/AuditDeleteReferencesEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/AuditDeleteReferencesEventTypeNode.java
@@ -16,13 +16,12 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.ExtensionObject;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
 import org.eclipse.milo.opcua.stack.core.types.structured.DeleteReferencesItem;
-import org.eclipse.milo.opcua.stack.core.util.FutureUtils;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public class AuditDeleteReferencesEventTypeNode extends AuditNodeManagementEventTypeNode implements AuditDeleteReferencesEventType {
     public AuditDeleteReferencesEventTypeNode(OpcUaClient client, NodeId nodeId, NodeClass nodeClass,
@@ -69,19 +68,12 @@ public class AuditDeleteReferencesEventTypeNode extends AuditNodeManagementEvent
     }
 
     @Override
-    public CompletableFuture<Unit> writeReferencesToDeleteAsync(
+    public CompletableFuture<StatusCode> writeReferencesToDeleteAsync(
         DeleteReferencesItem[] referencesToDelete) {
         ExtensionObject[] encoded = ExtensionObject.encodeArray(client.getSerializationContext(), referencesToDelete);
         DataValue value = DataValue.valueOnly(new Variant(encoded));
         return getReferencesToDeleteNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/AuditEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/AuditEventTypeNode.java
@@ -16,12 +16,11 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
-import org.eclipse.milo.opcua.stack.core.util.FutureUtils;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public class AuditEventTypeNode extends BaseEventTypeNode implements AuditEventType {
     public AuditEventTypeNode(OpcUaClient client, NodeId nodeId, NodeClass nodeClass,
@@ -66,17 +65,10 @@ public class AuditEventTypeNode extends BaseEventTypeNode implements AuditEventT
     }
 
     @Override
-    public CompletableFuture<Unit> writeActionTimeStampAsync(DateTime actionTimeStamp) {
+    public CompletableFuture<StatusCode> writeActionTimeStampAsync(DateTime actionTimeStamp) {
         DataValue value = DataValue.valueOnly(new Variant(actionTimeStamp));
         return getActionTimeStampNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -130,17 +122,10 @@ public class AuditEventTypeNode extends BaseEventTypeNode implements AuditEventT
     }
 
     @Override
-    public CompletableFuture<Unit> writeStatusAsync(Boolean status) {
+    public CompletableFuture<StatusCode> writeStatusAsync(Boolean status) {
         DataValue value = DataValue.valueOnly(new Variant(status));
         return getStatusNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -194,17 +179,10 @@ public class AuditEventTypeNode extends BaseEventTypeNode implements AuditEventT
     }
 
     @Override
-    public CompletableFuture<Unit> writeServerIdAsync(String serverId) {
+    public CompletableFuture<StatusCode> writeServerIdAsync(String serverId) {
         DataValue value = DataValue.valueOnly(new Variant(serverId));
         return getServerIdNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -258,17 +236,10 @@ public class AuditEventTypeNode extends BaseEventTypeNode implements AuditEventT
     }
 
     @Override
-    public CompletableFuture<Unit> writeClientAuditEntryIdAsync(String clientAuditEntryId) {
+    public CompletableFuture<StatusCode> writeClientAuditEntryIdAsync(String clientAuditEntryId) {
         DataValue value = DataValue.valueOnly(new Variant(clientAuditEntryId));
         return getClientAuditEntryIdNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -322,17 +293,10 @@ public class AuditEventTypeNode extends BaseEventTypeNode implements AuditEventT
     }
 
     @Override
-    public CompletableFuture<Unit> writeClientUserIdAsync(String clientUserId) {
+    public CompletableFuture<StatusCode> writeClientUserIdAsync(String clientUserId) {
         DataValue value = DataValue.valueOnly(new Variant(clientUserId));
         return getClientUserIdNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/AuditHistoryAtTimeDeleteEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/AuditHistoryAtTimeDeleteEventTypeNode.java
@@ -16,12 +16,11 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
-import org.eclipse.milo.opcua.stack.core.util.FutureUtils;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public class AuditHistoryAtTimeDeleteEventTypeNode extends AuditHistoryDeleteEventTypeNode implements AuditHistoryAtTimeDeleteEventType {
     public AuditHistoryAtTimeDeleteEventTypeNode(OpcUaClient client, NodeId nodeId,
@@ -66,17 +65,10 @@ public class AuditHistoryAtTimeDeleteEventTypeNode extends AuditHistoryDeleteEve
     }
 
     @Override
-    public CompletableFuture<Unit> writeReqTimesAsync(DateTime[] reqTimes) {
+    public CompletableFuture<StatusCode> writeReqTimesAsync(DateTime[] reqTimes) {
         DataValue value = DataValue.valueOnly(new Variant(reqTimes));
         return getReqTimesNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -130,17 +122,10 @@ public class AuditHistoryAtTimeDeleteEventTypeNode extends AuditHistoryDeleteEve
     }
 
     @Override
-    public CompletableFuture<Unit> writeOldValuesAsync(DataValue[] oldValues) {
+    public CompletableFuture<StatusCode> writeOldValuesAsync(DataValue[] oldValues) {
         DataValue value = DataValue.valueOnly(new Variant(oldValues));
         return getOldValuesNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/AuditHistoryDeleteEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/AuditHistoryDeleteEventTypeNode.java
@@ -15,12 +15,11 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
-import org.eclipse.milo.opcua.stack.core.util.FutureUtils;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public class AuditHistoryDeleteEventTypeNode extends AuditHistoryUpdateEventTypeNode implements AuditHistoryDeleteEventType {
     public AuditHistoryDeleteEventTypeNode(OpcUaClient client, NodeId nodeId, NodeClass nodeClass,
@@ -65,17 +64,10 @@ public class AuditHistoryDeleteEventTypeNode extends AuditHistoryUpdateEventType
     }
 
     @Override
-    public CompletableFuture<Unit> writeUpdatedNodeAsync(NodeId updatedNode) {
+    public CompletableFuture<StatusCode> writeUpdatedNodeAsync(NodeId updatedNode) {
         DataValue value = DataValue.valueOnly(new Variant(updatedNode));
         return getUpdatedNodeNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/AuditHistoryEventDeleteEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/AuditHistoryEventDeleteEventTypeNode.java
@@ -17,13 +17,12 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.ExtensionObject;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
 import org.eclipse.milo.opcua.stack.core.types.structured.HistoryEventFieldList;
-import org.eclipse.milo.opcua.stack.core.util.FutureUtils;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public class AuditHistoryEventDeleteEventTypeNode extends AuditHistoryDeleteEventTypeNode implements AuditHistoryEventDeleteEventType {
     public AuditHistoryEventDeleteEventTypeNode(OpcUaClient client, NodeId nodeId,
@@ -68,17 +67,10 @@ public class AuditHistoryEventDeleteEventTypeNode extends AuditHistoryDeleteEven
     }
 
     @Override
-    public CompletableFuture<Unit> writeEventIdsAsync(ByteString[] eventIds) {
+    public CompletableFuture<StatusCode> writeEventIdsAsync(ByteString[] eventIds) {
         DataValue value = DataValue.valueOnly(new Variant(eventIds));
         return getEventIdsNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -133,18 +125,11 @@ public class AuditHistoryEventDeleteEventTypeNode extends AuditHistoryDeleteEven
     }
 
     @Override
-    public CompletableFuture<Unit> writeOldValuesAsync(HistoryEventFieldList oldValues) {
+    public CompletableFuture<StatusCode> writeOldValuesAsync(HistoryEventFieldList oldValues) {
         ExtensionObject encoded = ExtensionObject.encode(client.getSerializationContext(), oldValues);
         DataValue value = DataValue.valueOnly(new Variant(encoded));
         return getOldValuesNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/AuditHistoryRawModifyDeleteEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/AuditHistoryRawModifyDeleteEventTypeNode.java
@@ -16,12 +16,11 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
-import org.eclipse.milo.opcua.stack.core.util.FutureUtils;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public class AuditHistoryRawModifyDeleteEventTypeNode extends AuditHistoryDeleteEventTypeNode implements AuditHistoryRawModifyDeleteEventType {
     public AuditHistoryRawModifyDeleteEventTypeNode(OpcUaClient client, NodeId nodeId,
@@ -66,17 +65,10 @@ public class AuditHistoryRawModifyDeleteEventTypeNode extends AuditHistoryDelete
     }
 
     @Override
-    public CompletableFuture<Unit> writeIsDeleteModifiedAsync(Boolean isDeleteModified) {
+    public CompletableFuture<StatusCode> writeIsDeleteModifiedAsync(Boolean isDeleteModified) {
         DataValue value = DataValue.valueOnly(new Variant(isDeleteModified));
         return getIsDeleteModifiedNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -130,17 +122,10 @@ public class AuditHistoryRawModifyDeleteEventTypeNode extends AuditHistoryDelete
     }
 
     @Override
-    public CompletableFuture<Unit> writeStartTimeAsync(DateTime startTime) {
+    public CompletableFuture<StatusCode> writeStartTimeAsync(DateTime startTime) {
         DataValue value = DataValue.valueOnly(new Variant(startTime));
         return getStartTimeNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -194,17 +179,10 @@ public class AuditHistoryRawModifyDeleteEventTypeNode extends AuditHistoryDelete
     }
 
     @Override
-    public CompletableFuture<Unit> writeEndTimeAsync(DateTime endTime) {
+    public CompletableFuture<StatusCode> writeEndTimeAsync(DateTime endTime) {
         DataValue value = DataValue.valueOnly(new Variant(endTime));
         return getEndTimeNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -258,17 +236,10 @@ public class AuditHistoryRawModifyDeleteEventTypeNode extends AuditHistoryDelete
     }
 
     @Override
-    public CompletableFuture<Unit> writeOldValuesAsync(DataValue[] oldValues) {
+    public CompletableFuture<StatusCode> writeOldValuesAsync(DataValue[] oldValues) {
         DataValue value = DataValue.valueOnly(new Variant(oldValues));
         return getOldValuesNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/AuditHistoryUpdateEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/AuditHistoryUpdateEventTypeNode.java
@@ -15,12 +15,11 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
-import org.eclipse.milo.opcua.stack.core.util.FutureUtils;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public class AuditHistoryUpdateEventTypeNode extends AuditUpdateEventTypeNode implements AuditHistoryUpdateEventType {
     public AuditHistoryUpdateEventTypeNode(OpcUaClient client, NodeId nodeId, NodeClass nodeClass,
@@ -65,17 +64,10 @@ public class AuditHistoryUpdateEventTypeNode extends AuditUpdateEventTypeNode im
     }
 
     @Override
-    public CompletableFuture<Unit> writeParameterDataTypeIdAsync(NodeId parameterDataTypeId) {
+    public CompletableFuture<StatusCode> writeParameterDataTypeIdAsync(NodeId parameterDataTypeId) {
         DataValue value = DataValue.valueOnly(new Variant(parameterDataTypeId));
         return getParameterDataTypeIdNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/AuditHistoryValueUpdateEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/AuditHistoryValueUpdateEventTypeNode.java
@@ -15,13 +15,12 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.PerformUpdateType;
-import org.eclipse.milo.opcua.stack.core.util.FutureUtils;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public class AuditHistoryValueUpdateEventTypeNode extends AuditHistoryUpdateEventTypeNode implements AuditHistoryValueUpdateEventType {
     public AuditHistoryValueUpdateEventTypeNode(OpcUaClient client, NodeId nodeId,
@@ -66,17 +65,10 @@ public class AuditHistoryValueUpdateEventTypeNode extends AuditHistoryUpdateEven
     }
 
     @Override
-    public CompletableFuture<Unit> writeUpdatedNodeAsync(NodeId updatedNode) {
+    public CompletableFuture<StatusCode> writeUpdatedNodeAsync(NodeId updatedNode) {
         DataValue value = DataValue.valueOnly(new Variant(updatedNode));
         return getUpdatedNodeNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -97,7 +89,14 @@ public class AuditHistoryValueUpdateEventTypeNode extends AuditHistoryUpdateEven
     @Override
     public PerformUpdateType getPerformInsertReplace() throws UaException {
         PropertyTypeNode node = getPerformInsertReplaceNode();
-        return (PerformUpdateType) node.getValue().getValue().getValue();
+        Object value = node.getValue().getValue().getValue();
+        if (value instanceof Integer) {
+            return PerformUpdateType.from((Integer) value);
+        } else if (value instanceof PerformUpdateType) {
+            return (PerformUpdateType) value;
+        } else {
+            return null;
+        }
     }
 
     @Override
@@ -126,22 +125,24 @@ public class AuditHistoryValueUpdateEventTypeNode extends AuditHistoryUpdateEven
 
     @Override
     public CompletableFuture<? extends PerformUpdateType> readPerformInsertReplaceAsync() {
-        return getPerformInsertReplaceNodeAsync().thenCompose(node -> node.readAttributeAsync(AttributeId.Value)).thenApply(v -> (PerformUpdateType) v.getValue().getValue());
+        return getPerformInsertReplaceNodeAsync()
+            .thenCompose(node -> node.readAttributeAsync(AttributeId.Value))
+            .thenApply(v -> {
+                Object value = v.getValue().getValue();
+                if (value instanceof Integer) {
+                    return PerformUpdateType.from((Integer) value);
+                } else {
+                    return null;
+                }
+            });
     }
 
     @Override
-    public CompletableFuture<Unit> writePerformInsertReplaceAsync(
+    public CompletableFuture<StatusCode> writePerformInsertReplaceAsync(
         PerformUpdateType performInsertReplace) {
         DataValue value = DataValue.valueOnly(new Variant(performInsertReplace));
         return getPerformInsertReplaceNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -195,17 +196,10 @@ public class AuditHistoryValueUpdateEventTypeNode extends AuditHistoryUpdateEven
     }
 
     @Override
-    public CompletableFuture<Unit> writeNewValuesAsync(DataValue[] newValues) {
+    public CompletableFuture<StatusCode> writeNewValuesAsync(DataValue[] newValues) {
         DataValue value = DataValue.valueOnly(new Variant(newValues));
         return getNewValuesNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -259,17 +253,10 @@ public class AuditHistoryValueUpdateEventTypeNode extends AuditHistoryUpdateEven
     }
 
     @Override
-    public CompletableFuture<Unit> writeOldValuesAsync(DataValue[] oldValues) {
+    public CompletableFuture<StatusCode> writeOldValuesAsync(DataValue[] oldValues) {
         DataValue value = DataValue.valueOnly(new Variant(oldValues));
         return getOldValuesNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/AuditOpenSecureChannelEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/AuditOpenSecureChannelEventTypeNode.java
@@ -16,14 +16,13 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.MessageSecurityMode;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.SecurityTokenRequestType;
-import org.eclipse.milo.opcua.stack.core.util.FutureUtils;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public class AuditOpenSecureChannelEventTypeNode extends AuditChannelEventTypeNode implements AuditOpenSecureChannelEventType {
     public AuditOpenSecureChannelEventTypeNode(OpcUaClient client, NodeId nodeId, NodeClass nodeClass,
@@ -68,17 +67,10 @@ public class AuditOpenSecureChannelEventTypeNode extends AuditChannelEventTypeNo
     }
 
     @Override
-    public CompletableFuture<Unit> writeClientCertificateAsync(ByteString clientCertificate) {
+    public CompletableFuture<StatusCode> writeClientCertificateAsync(ByteString clientCertificate) {
         DataValue value = DataValue.valueOnly(new Variant(clientCertificate));
         return getClientCertificateNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -134,18 +126,11 @@ public class AuditOpenSecureChannelEventTypeNode extends AuditChannelEventTypeNo
     }
 
     @Override
-    public CompletableFuture<Unit> writeClientCertificateThumbprintAsync(
+    public CompletableFuture<StatusCode> writeClientCertificateThumbprintAsync(
         String clientCertificateThumbprint) {
         DataValue value = DataValue.valueOnly(new Variant(clientCertificateThumbprint));
         return getClientCertificateThumbprintNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -166,7 +151,14 @@ public class AuditOpenSecureChannelEventTypeNode extends AuditChannelEventTypeNo
     @Override
     public SecurityTokenRequestType getRequestType() throws UaException {
         PropertyTypeNode node = getRequestTypeNode();
-        return (SecurityTokenRequestType) node.getValue().getValue().getValue();
+        Object value = node.getValue().getValue().getValue();
+        if (value instanceof Integer) {
+            return SecurityTokenRequestType.from((Integer) value);
+        } else if (value instanceof SecurityTokenRequestType) {
+            return (SecurityTokenRequestType) value;
+        } else {
+            return null;
+        }
     }
 
     @Override
@@ -195,21 +187,23 @@ public class AuditOpenSecureChannelEventTypeNode extends AuditChannelEventTypeNo
 
     @Override
     public CompletableFuture<? extends SecurityTokenRequestType> readRequestTypeAsync() {
-        return getRequestTypeNodeAsync().thenCompose(node -> node.readAttributeAsync(AttributeId.Value)).thenApply(v -> (SecurityTokenRequestType) v.getValue().getValue());
+        return getRequestTypeNodeAsync()
+            .thenCompose(node -> node.readAttributeAsync(AttributeId.Value))
+            .thenApply(v -> {
+                Object value = v.getValue().getValue();
+                if (value instanceof Integer) {
+                    return SecurityTokenRequestType.from((Integer) value);
+                } else {
+                    return null;
+                }
+            });
     }
 
     @Override
-    public CompletableFuture<Unit> writeRequestTypeAsync(SecurityTokenRequestType requestType) {
+    public CompletableFuture<StatusCode> writeRequestTypeAsync(SecurityTokenRequestType requestType) {
         DataValue value = DataValue.valueOnly(new Variant(requestType));
         return getRequestTypeNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -263,17 +257,10 @@ public class AuditOpenSecureChannelEventTypeNode extends AuditChannelEventTypeNo
     }
 
     @Override
-    public CompletableFuture<Unit> writeSecurityPolicyUriAsync(String securityPolicyUri) {
+    public CompletableFuture<StatusCode> writeSecurityPolicyUriAsync(String securityPolicyUri) {
         DataValue value = DataValue.valueOnly(new Variant(securityPolicyUri));
         return getSecurityPolicyUriNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -294,7 +281,14 @@ public class AuditOpenSecureChannelEventTypeNode extends AuditChannelEventTypeNo
     @Override
     public MessageSecurityMode getSecurityMode() throws UaException {
         PropertyTypeNode node = getSecurityModeNode();
-        return (MessageSecurityMode) node.getValue().getValue().getValue();
+        Object value = node.getValue().getValue().getValue();
+        if (value instanceof Integer) {
+            return MessageSecurityMode.from((Integer) value);
+        } else if (value instanceof MessageSecurityMode) {
+            return (MessageSecurityMode) value;
+        } else {
+            return null;
+        }
     }
 
     @Override
@@ -323,21 +317,23 @@ public class AuditOpenSecureChannelEventTypeNode extends AuditChannelEventTypeNo
 
     @Override
     public CompletableFuture<? extends MessageSecurityMode> readSecurityModeAsync() {
-        return getSecurityModeNodeAsync().thenCompose(node -> node.readAttributeAsync(AttributeId.Value)).thenApply(v -> (MessageSecurityMode) v.getValue().getValue());
+        return getSecurityModeNodeAsync()
+            .thenCompose(node -> node.readAttributeAsync(AttributeId.Value))
+            .thenApply(v -> {
+                Object value = v.getValue().getValue();
+                if (value instanceof Integer) {
+                    return MessageSecurityMode.from((Integer) value);
+                } else {
+                    return null;
+                }
+            });
     }
 
     @Override
-    public CompletableFuture<Unit> writeSecurityModeAsync(MessageSecurityMode securityMode) {
+    public CompletableFuture<StatusCode> writeSecurityModeAsync(MessageSecurityMode securityMode) {
         DataValue value = DataValue.valueOnly(new Variant(securityMode));
         return getSecurityModeNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -391,17 +387,10 @@ public class AuditOpenSecureChannelEventTypeNode extends AuditChannelEventTypeNo
     }
 
     @Override
-    public CompletableFuture<Unit> writeRequestedLifetimeAsync(Double requestedLifetime) {
+    public CompletableFuture<StatusCode> writeRequestedLifetimeAsync(Double requestedLifetime) {
         DataValue value = DataValue.valueOnly(new Variant(requestedLifetime));
         return getRequestedLifetimeNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/AuditProgramTransitionEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/AuditProgramTransitionEventTypeNode.java
@@ -15,12 +15,11 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
-import org.eclipse.milo.opcua.stack.core.util.FutureUtils;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public class AuditProgramTransitionEventTypeNode extends AuditUpdateStateEventTypeNode implements AuditProgramTransitionEventType {
     public AuditProgramTransitionEventTypeNode(OpcUaClient client, NodeId nodeId, NodeClass nodeClass,
@@ -65,17 +64,10 @@ public class AuditProgramTransitionEventTypeNode extends AuditUpdateStateEventTy
     }
 
     @Override
-    public CompletableFuture<Unit> writeTransitionNumberAsync(UInteger transitionNumber) {
+    public CompletableFuture<StatusCode> writeTransitionNumberAsync(UInteger transitionNumber) {
         DataValue value = DataValue.valueOnly(new Variant(transitionNumber));
         return getTransitionNumberNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/AuditSessionEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/AuditSessionEventTypeNode.java
@@ -15,12 +15,11 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
-import org.eclipse.milo.opcua.stack.core.util.FutureUtils;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public class AuditSessionEventTypeNode extends AuditSecurityEventTypeNode implements AuditSessionEventType {
     public AuditSessionEventTypeNode(OpcUaClient client, NodeId nodeId, NodeClass nodeClass,
@@ -65,17 +64,10 @@ public class AuditSessionEventTypeNode extends AuditSecurityEventTypeNode implem
     }
 
     @Override
-    public CompletableFuture<Unit> writeSessionIdAsync(NodeId sessionId) {
+    public CompletableFuture<StatusCode> writeSessionIdAsync(NodeId sessionId) {
         DataValue value = DataValue.valueOnly(new Variant(sessionId));
         return getSessionIdNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/AuditUpdateMethodEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/AuditUpdateMethodEventTypeNode.java
@@ -15,12 +15,11 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
-import org.eclipse.milo.opcua.stack.core.util.FutureUtils;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public class AuditUpdateMethodEventTypeNode extends AuditEventTypeNode implements AuditUpdateMethodEventType {
     public AuditUpdateMethodEventTypeNode(OpcUaClient client, NodeId nodeId, NodeClass nodeClass,
@@ -65,17 +64,10 @@ public class AuditUpdateMethodEventTypeNode extends AuditEventTypeNode implement
     }
 
     @Override
-    public CompletableFuture<Unit> writeMethodIdAsync(NodeId methodId) {
+    public CompletableFuture<StatusCode> writeMethodIdAsync(NodeId methodId) {
         DataValue value = DataValue.valueOnly(new Variant(methodId));
         return getMethodIdNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -129,17 +121,10 @@ public class AuditUpdateMethodEventTypeNode extends AuditEventTypeNode implement
     }
 
     @Override
-    public CompletableFuture<Unit> writeInputArgumentsAsync(Object[] inputArguments) {
+    public CompletableFuture<StatusCode> writeInputArgumentsAsync(Object[] inputArguments) {
         DataValue value = DataValue.valueOnly(new Variant(inputArguments));
         return getInputArgumentsNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/AuditUpdateStateEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/AuditUpdateStateEventTypeNode.java
@@ -15,12 +15,11 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
-import org.eclipse.milo.opcua.stack.core.util.FutureUtils;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public class AuditUpdateStateEventTypeNode extends AuditUpdateMethodEventTypeNode implements AuditUpdateStateEventType {
     public AuditUpdateStateEventTypeNode(OpcUaClient client, NodeId nodeId, NodeClass nodeClass,
@@ -65,17 +64,10 @@ public class AuditUpdateStateEventTypeNode extends AuditUpdateMethodEventTypeNod
     }
 
     @Override
-    public CompletableFuture<Unit> writeOldStateIdAsync(Object oldStateId) {
+    public CompletableFuture<StatusCode> writeOldStateIdAsync(Object oldStateId) {
         DataValue value = DataValue.valueOnly(new Variant(oldStateId));
         return getOldStateIdNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -129,17 +121,10 @@ public class AuditUpdateStateEventTypeNode extends AuditUpdateMethodEventTypeNod
     }
 
     @Override
-    public CompletableFuture<Unit> writeNewStateIdAsync(Object newStateId) {
+    public CompletableFuture<StatusCode> writeNewStateIdAsync(Object newStateId) {
         DataValue value = DataValue.valueOnly(new Variant(newStateId));
         return getNewStateIdNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/AuditUrlMismatchEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/AuditUrlMismatchEventTypeNode.java
@@ -15,12 +15,11 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
-import org.eclipse.milo.opcua.stack.core.util.FutureUtils;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public class AuditUrlMismatchEventTypeNode extends AuditCreateSessionEventTypeNode implements AuditUrlMismatchEventType {
     public AuditUrlMismatchEventTypeNode(OpcUaClient client, NodeId nodeId, NodeClass nodeClass,
@@ -65,17 +64,10 @@ public class AuditUrlMismatchEventTypeNode extends AuditCreateSessionEventTypeNo
     }
 
     @Override
-    public CompletableFuture<Unit> writeEndpointUrlAsync(String endpointUrl) {
+    public CompletableFuture<StatusCode> writeEndpointUrlAsync(String endpointUrl) {
         DataValue value = DataValue.valueOnly(new Variant(endpointUrl));
         return getEndpointUrlNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/AuditWriteUpdateEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/AuditWriteUpdateEventTypeNode.java
@@ -15,12 +15,11 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
-import org.eclipse.milo.opcua.stack.core.util.FutureUtils;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public class AuditWriteUpdateEventTypeNode extends AuditUpdateEventTypeNode implements AuditWriteUpdateEventType {
     public AuditWriteUpdateEventTypeNode(OpcUaClient client, NodeId nodeId, NodeClass nodeClass,
@@ -65,17 +64,10 @@ public class AuditWriteUpdateEventTypeNode extends AuditUpdateEventTypeNode impl
     }
 
     @Override
-    public CompletableFuture<Unit> writeAttributeIdAsync(UInteger attributeId) {
+    public CompletableFuture<StatusCode> writeAttributeIdAsync(UInteger attributeId) {
         DataValue value = DataValue.valueOnly(new Variant(attributeId));
         return getAttributeIdNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -129,17 +121,10 @@ public class AuditWriteUpdateEventTypeNode extends AuditUpdateEventTypeNode impl
     }
 
     @Override
-    public CompletableFuture<Unit> writeIndexRangeAsync(String indexRange) {
+    public CompletableFuture<StatusCode> writeIndexRangeAsync(String indexRange) {
         DataValue value = DataValue.valueOnly(new Variant(indexRange));
         return getIndexRangeNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -193,17 +178,10 @@ public class AuditWriteUpdateEventTypeNode extends AuditUpdateEventTypeNode impl
     }
 
     @Override
-    public CompletableFuture<Unit> writeOldValueAsync(Object oldValue) {
+    public CompletableFuture<StatusCode> writeOldValueAsync(Object oldValue) {
         DataValue value = DataValue.valueOnly(new Variant(oldValue));
         return getOldValueNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -257,17 +235,10 @@ public class AuditWriteUpdateEventTypeNode extends AuditUpdateEventTypeNode impl
     }
 
     @Override
-    public CompletableFuture<Unit> writeNewValueAsync(Object newValue) {
+    public CompletableFuture<StatusCode> writeNewValueAsync(Object newValue) {
         DataValue value = DataValue.valueOnly(new Variant(newValue));
         return getNewValueNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/BaseEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/BaseEventTypeNode.java
@@ -18,14 +18,13 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.ExtensionObject;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UShort;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
 import org.eclipse.milo.opcua.stack.core.types.structured.TimeZoneDataType;
-import org.eclipse.milo.opcua.stack.core.util.FutureUtils;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public class BaseEventTypeNode extends BaseObjectTypeNode implements BaseEventType {
     public BaseEventTypeNode(OpcUaClient client, NodeId nodeId, NodeClass nodeClass,
@@ -70,17 +69,10 @@ public class BaseEventTypeNode extends BaseObjectTypeNode implements BaseEventTy
     }
 
     @Override
-    public CompletableFuture<Unit> writeEventIdAsync(ByteString eventId) {
+    public CompletableFuture<StatusCode> writeEventIdAsync(ByteString eventId) {
         DataValue value = DataValue.valueOnly(new Variant(eventId));
         return getEventIdNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -134,17 +126,10 @@ public class BaseEventTypeNode extends BaseObjectTypeNode implements BaseEventTy
     }
 
     @Override
-    public CompletableFuture<Unit> writeEventTypeAsync(NodeId eventType) {
+    public CompletableFuture<StatusCode> writeEventTypeAsync(NodeId eventType) {
         DataValue value = DataValue.valueOnly(new Variant(eventType));
         return getEventTypeNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -198,17 +183,10 @@ public class BaseEventTypeNode extends BaseObjectTypeNode implements BaseEventTy
     }
 
     @Override
-    public CompletableFuture<Unit> writeSourceNodeAsync(NodeId sourceNode) {
+    public CompletableFuture<StatusCode> writeSourceNodeAsync(NodeId sourceNode) {
         DataValue value = DataValue.valueOnly(new Variant(sourceNode));
         return getSourceNodeNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -262,17 +240,10 @@ public class BaseEventTypeNode extends BaseObjectTypeNode implements BaseEventTy
     }
 
     @Override
-    public CompletableFuture<Unit> writeSourceNameAsync(String sourceName) {
+    public CompletableFuture<StatusCode> writeSourceNameAsync(String sourceName) {
         DataValue value = DataValue.valueOnly(new Variant(sourceName));
         return getSourceNameNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -326,17 +297,10 @@ public class BaseEventTypeNode extends BaseObjectTypeNode implements BaseEventTy
     }
 
     @Override
-    public CompletableFuture<Unit> writeTimeAsync(DateTime time) {
+    public CompletableFuture<StatusCode> writeTimeAsync(DateTime time) {
         DataValue value = DataValue.valueOnly(new Variant(time));
         return getTimeNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -390,17 +354,10 @@ public class BaseEventTypeNode extends BaseObjectTypeNode implements BaseEventTy
     }
 
     @Override
-    public CompletableFuture<Unit> writeReceiveTimeAsync(DateTime receiveTime) {
+    public CompletableFuture<StatusCode> writeReceiveTimeAsync(DateTime receiveTime) {
         DataValue value = DataValue.valueOnly(new Variant(receiveTime));
         return getReceiveTimeNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -455,18 +412,11 @@ public class BaseEventTypeNode extends BaseObjectTypeNode implements BaseEventTy
     }
 
     @Override
-    public CompletableFuture<Unit> writeLocalTimeAsync(TimeZoneDataType localTime) {
+    public CompletableFuture<StatusCode> writeLocalTimeAsync(TimeZoneDataType localTime) {
         ExtensionObject encoded = ExtensionObject.encode(client.getSerializationContext(), localTime);
         DataValue value = DataValue.valueOnly(new Variant(encoded));
         return getLocalTimeNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -520,17 +470,10 @@ public class BaseEventTypeNode extends BaseObjectTypeNode implements BaseEventTy
     }
 
     @Override
-    public CompletableFuture<Unit> writeMessageAsync(LocalizedText message) {
+    public CompletableFuture<StatusCode> writeMessageAsync(LocalizedText message) {
         DataValue value = DataValue.valueOnly(new Variant(message));
         return getMessageNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -584,17 +527,10 @@ public class BaseEventTypeNode extends BaseObjectTypeNode implements BaseEventTy
     }
 
     @Override
-    public CompletableFuture<Unit> writeSeverityAsync(UShort severity) {
+    public CompletableFuture<StatusCode> writeSeverityAsync(UShort severity) {
         DataValue value = DataValue.valueOnly(new Variant(severity));
         return getSeverityNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/CertificateExpirationAlarmTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/CertificateExpirationAlarmTypeNode.java
@@ -17,12 +17,11 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
-import org.eclipse.milo.opcua.stack.core.util.FutureUtils;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public class CertificateExpirationAlarmTypeNode extends SystemOffNormalAlarmTypeNode implements CertificateExpirationAlarmType {
     public CertificateExpirationAlarmTypeNode(OpcUaClient client, NodeId nodeId, NodeClass nodeClass,
@@ -67,17 +66,10 @@ public class CertificateExpirationAlarmTypeNode extends SystemOffNormalAlarmType
     }
 
     @Override
-    public CompletableFuture<Unit> writeExpirationDateAsync(DateTime expirationDate) {
+    public CompletableFuture<StatusCode> writeExpirationDateAsync(DateTime expirationDate) {
         DataValue value = DataValue.valueOnly(new Variant(expirationDate));
         return getExpirationDateNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -131,17 +123,10 @@ public class CertificateExpirationAlarmTypeNode extends SystemOffNormalAlarmType
     }
 
     @Override
-    public CompletableFuture<Unit> writeExpirationLimitAsync(Double expirationLimit) {
+    public CompletableFuture<StatusCode> writeExpirationLimitAsync(Double expirationLimit) {
         DataValue value = DataValue.valueOnly(new Variant(expirationLimit));
         return getExpirationLimitNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -195,17 +180,10 @@ public class CertificateExpirationAlarmTypeNode extends SystemOffNormalAlarmType
     }
 
     @Override
-    public CompletableFuture<Unit> writeCertificateTypeAsync(NodeId certificateType) {
+    public CompletableFuture<StatusCode> writeCertificateTypeAsync(NodeId certificateType) {
         DataValue value = DataValue.valueOnly(new Variant(certificateType));
         return getCertificateTypeNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -259,17 +237,10 @@ public class CertificateExpirationAlarmTypeNode extends SystemOffNormalAlarmType
     }
 
     @Override
-    public CompletableFuture<Unit> writeCertificateAsync(ByteString certificate) {
+    public CompletableFuture<StatusCode> writeCertificateAsync(ByteString certificate) {
         DataValue value = DataValue.valueOnly(new Variant(certificate));
         return getCertificateNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/CertificateGroupTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/CertificateGroupTypeNode.java
@@ -15,12 +15,11 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
-import org.eclipse.milo.opcua.stack.core.util.FutureUtils;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public class CertificateGroupTypeNode extends BaseObjectTypeNode implements CertificateGroupType {
     public CertificateGroupTypeNode(OpcUaClient client, NodeId nodeId, NodeClass nodeClass,
@@ -65,17 +64,10 @@ public class CertificateGroupTypeNode extends BaseObjectTypeNode implements Cert
     }
 
     @Override
-    public CompletableFuture<Unit> writeCertificateTypesAsync(NodeId[] certificateTypes) {
+    public CompletableFuture<StatusCode> writeCertificateTypesAsync(NodeId[] certificateTypes) {
         DataValue value = DataValue.valueOnly(new Variant(certificateTypes));
         return getCertificateTypesNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/CertificateUpdatedAuditEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/CertificateUpdatedAuditEventTypeNode.java
@@ -15,12 +15,11 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
-import org.eclipse.milo.opcua.stack.core.util.FutureUtils;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public class CertificateUpdatedAuditEventTypeNode extends AuditUpdateMethodEventTypeNode implements CertificateUpdatedAuditEventType {
     public CertificateUpdatedAuditEventTypeNode(OpcUaClient client, NodeId nodeId,
@@ -65,17 +64,10 @@ public class CertificateUpdatedAuditEventTypeNode extends AuditUpdateMethodEvent
     }
 
     @Override
-    public CompletableFuture<Unit> writeCertificateGroupAsync(NodeId certificateGroup) {
+    public CompletableFuture<StatusCode> writeCertificateGroupAsync(NodeId certificateGroup) {
         DataValue value = DataValue.valueOnly(new Variant(certificateGroup));
         return getCertificateGroupNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -129,17 +121,10 @@ public class CertificateUpdatedAuditEventTypeNode extends AuditUpdateMethodEvent
     }
 
     @Override
-    public CompletableFuture<Unit> writeCertificateTypeAsync(NodeId certificateType) {
+    public CompletableFuture<StatusCode> writeCertificateTypeAsync(NodeId certificateType) {
         DataValue value = DataValue.valueOnly(new Variant(certificateType));
         return getCertificateTypeNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/ConditionTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/ConditionTypeNode.java
@@ -23,8 +23,6 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UShort;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
-import org.eclipse.milo.opcua.stack.core.util.FutureUtils;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public class ConditionTypeNode extends BaseEventTypeNode implements ConditionType {
     public ConditionTypeNode(OpcUaClient client, NodeId nodeId, NodeClass nodeClass,
@@ -69,17 +67,10 @@ public class ConditionTypeNode extends BaseEventTypeNode implements ConditionTyp
     }
 
     @Override
-    public CompletableFuture<Unit> writeConditionClassIdAsync(NodeId conditionClassId) {
+    public CompletableFuture<StatusCode> writeConditionClassIdAsync(NodeId conditionClassId) {
         DataValue value = DataValue.valueOnly(new Variant(conditionClassId));
         return getConditionClassIdNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -133,17 +124,11 @@ public class ConditionTypeNode extends BaseEventTypeNode implements ConditionTyp
     }
 
     @Override
-    public CompletableFuture<Unit> writeConditionClassNameAsync(LocalizedText conditionClassName) {
+    public CompletableFuture<StatusCode> writeConditionClassNameAsync(
+        LocalizedText conditionClassName) {
         DataValue value = DataValue.valueOnly(new Variant(conditionClassName));
         return getConditionClassNameNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -197,17 +182,10 @@ public class ConditionTypeNode extends BaseEventTypeNode implements ConditionTyp
     }
 
     @Override
-    public CompletableFuture<Unit> writeConditionNameAsync(String conditionName) {
+    public CompletableFuture<StatusCode> writeConditionNameAsync(String conditionName) {
         DataValue value = DataValue.valueOnly(new Variant(conditionName));
         return getConditionNameNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -261,17 +239,10 @@ public class ConditionTypeNode extends BaseEventTypeNode implements ConditionTyp
     }
 
     @Override
-    public CompletableFuture<Unit> writeBranchIdAsync(NodeId branchId) {
+    public CompletableFuture<StatusCode> writeBranchIdAsync(NodeId branchId) {
         DataValue value = DataValue.valueOnly(new Variant(branchId));
         return getBranchIdNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -325,17 +296,10 @@ public class ConditionTypeNode extends BaseEventTypeNode implements ConditionTyp
     }
 
     @Override
-    public CompletableFuture<Unit> writeRetainAsync(Boolean retain) {
+    public CompletableFuture<StatusCode> writeRetainAsync(Boolean retain) {
         DataValue value = DataValue.valueOnly(new Variant(retain));
         return getRetainNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -389,17 +353,10 @@ public class ConditionTypeNode extends BaseEventTypeNode implements ConditionTyp
     }
 
     @Override
-    public CompletableFuture<Unit> writeClientUserIdAsync(String clientUserId) {
+    public CompletableFuture<StatusCode> writeClientUserIdAsync(String clientUserId) {
         DataValue value = DataValue.valueOnly(new Variant(clientUserId));
         return getClientUserIdNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -453,17 +410,10 @@ public class ConditionTypeNode extends BaseEventTypeNode implements ConditionTyp
     }
 
     @Override
-    public CompletableFuture<Unit> writeEnabledStateAsync(LocalizedText enabledState) {
+    public CompletableFuture<StatusCode> writeEnabledStateAsync(LocalizedText enabledState) {
         DataValue value = DataValue.valueOnly(new Variant(enabledState));
         return getEnabledStateNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -517,17 +467,10 @@ public class ConditionTypeNode extends BaseEventTypeNode implements ConditionTyp
     }
 
     @Override
-    public CompletableFuture<Unit> writeQualityAsync(StatusCode quality) {
+    public CompletableFuture<StatusCode> writeQualityAsync(StatusCode quality) {
         DataValue value = DataValue.valueOnly(new Variant(quality));
         return getQualityNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -581,17 +524,10 @@ public class ConditionTypeNode extends BaseEventTypeNode implements ConditionTyp
     }
 
     @Override
-    public CompletableFuture<Unit> writeLastSeverityAsync(UShort lastSeverity) {
+    public CompletableFuture<StatusCode> writeLastSeverityAsync(UShort lastSeverity) {
         DataValue value = DataValue.valueOnly(new Variant(lastSeverity));
         return getLastSeverityNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -645,17 +581,10 @@ public class ConditionTypeNode extends BaseEventTypeNode implements ConditionTyp
     }
 
     @Override
-    public CompletableFuture<Unit> writeCommentAsync(LocalizedText comment) {
+    public CompletableFuture<StatusCode> writeCommentAsync(LocalizedText comment) {
         DataValue value = DataValue.valueOnly(new Variant(comment));
         return getCommentNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/DialogConditionTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/DialogConditionTypeNode.java
@@ -16,12 +16,11 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
-import org.eclipse.milo.opcua.stack.core.util.FutureUtils;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public class DialogConditionTypeNode extends ConditionTypeNode implements DialogConditionType {
     public DialogConditionTypeNode(OpcUaClient client, NodeId nodeId, NodeClass nodeClass,
@@ -66,17 +65,10 @@ public class DialogConditionTypeNode extends ConditionTypeNode implements Dialog
     }
 
     @Override
-    public CompletableFuture<Unit> writePromptAsync(LocalizedText prompt) {
+    public CompletableFuture<StatusCode> writePromptAsync(LocalizedText prompt) {
         DataValue value = DataValue.valueOnly(new Variant(prompt));
         return getPromptNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -130,17 +122,11 @@ public class DialogConditionTypeNode extends ConditionTypeNode implements Dialog
     }
 
     @Override
-    public CompletableFuture<Unit> writeResponseOptionSetAsync(LocalizedText[] responseOptionSet) {
+    public CompletableFuture<StatusCode> writeResponseOptionSetAsync(
+        LocalizedText[] responseOptionSet) {
         DataValue value = DataValue.valueOnly(new Variant(responseOptionSet));
         return getResponseOptionSetNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -194,17 +180,10 @@ public class DialogConditionTypeNode extends ConditionTypeNode implements Dialog
     }
 
     @Override
-    public CompletableFuture<Unit> writeDefaultResponseAsync(Integer defaultResponse) {
+    public CompletableFuture<StatusCode> writeDefaultResponseAsync(Integer defaultResponse) {
         DataValue value = DataValue.valueOnly(new Variant(defaultResponse));
         return getDefaultResponseNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -258,17 +237,10 @@ public class DialogConditionTypeNode extends ConditionTypeNode implements Dialog
     }
 
     @Override
-    public CompletableFuture<Unit> writeOkResponseAsync(Integer okResponse) {
+    public CompletableFuture<StatusCode> writeOkResponseAsync(Integer okResponse) {
         DataValue value = DataValue.valueOnly(new Variant(okResponse));
         return getOkResponseNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -322,17 +294,10 @@ public class DialogConditionTypeNode extends ConditionTypeNode implements Dialog
     }
 
     @Override
-    public CompletableFuture<Unit> writeCancelResponseAsync(Integer cancelResponse) {
+    public CompletableFuture<StatusCode> writeCancelResponseAsync(Integer cancelResponse) {
         DataValue value = DataValue.valueOnly(new Variant(cancelResponse));
         return getCancelResponseNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -386,17 +351,10 @@ public class DialogConditionTypeNode extends ConditionTypeNode implements Dialog
     }
 
     @Override
-    public CompletableFuture<Unit> writeLastResponseAsync(Integer lastResponse) {
+    public CompletableFuture<StatusCode> writeLastResponseAsync(Integer lastResponse) {
         DataValue value = DataValue.valueOnly(new Variant(lastResponse));
         return getLastResponseNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -450,17 +408,10 @@ public class DialogConditionTypeNode extends ConditionTypeNode implements Dialog
     }
 
     @Override
-    public CompletableFuture<Unit> writeEnabledStateAsync(LocalizedText enabledState) {
+    public CompletableFuture<StatusCode> writeEnabledStateAsync(LocalizedText enabledState) {
         DataValue value = DataValue.valueOnly(new Variant(enabledState));
         return getEnabledStateNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -514,17 +465,10 @@ public class DialogConditionTypeNode extends ConditionTypeNode implements Dialog
     }
 
     @Override
-    public CompletableFuture<Unit> writeDialogStateAsync(LocalizedText dialogState) {
+    public CompletableFuture<StatusCode> writeDialogStateAsync(LocalizedText dialogState) {
         DataValue value = DataValue.valueOnly(new Variant(dialogState));
         return getDialogStateNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/ExclusiveDeviationAlarmTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/ExclusiveDeviationAlarmTypeNode.java
@@ -15,12 +15,11 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
-import org.eclipse.milo.opcua.stack.core.util.FutureUtils;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public class ExclusiveDeviationAlarmTypeNode extends ExclusiveLimitAlarmTypeNode implements ExclusiveDeviationAlarmType {
     public ExclusiveDeviationAlarmTypeNode(OpcUaClient client, NodeId nodeId, NodeClass nodeClass,
@@ -65,17 +64,10 @@ public class ExclusiveDeviationAlarmTypeNode extends ExclusiveLimitAlarmTypeNode
     }
 
     @Override
-    public CompletableFuture<Unit> writeSetpointNodeAsync(NodeId setpointNode) {
+    public CompletableFuture<StatusCode> writeSetpointNodeAsync(NodeId setpointNode) {
         DataValue value = DataValue.valueOnly(new Variant(setpointNode));
         return getSetpointNodeNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/ExclusiveLimitAlarmTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/ExclusiveLimitAlarmTypeNode.java
@@ -15,12 +15,11 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
-import org.eclipse.milo.opcua.stack.core.util.FutureUtils;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public class ExclusiveLimitAlarmTypeNode extends LimitAlarmTypeNode implements ExclusiveLimitAlarmType {
     public ExclusiveLimitAlarmTypeNode(OpcUaClient client, NodeId nodeId, NodeClass nodeClass,
@@ -65,17 +64,10 @@ public class ExclusiveLimitAlarmTypeNode extends LimitAlarmTypeNode implements E
     }
 
     @Override
-    public CompletableFuture<Unit> writeActiveStateAsync(LocalizedText activeState) {
+    public CompletableFuture<StatusCode> writeActiveStateAsync(LocalizedText activeState) {
         DataValue value = DataValue.valueOnly(new Variant(activeState));
         return getActiveStateNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/FileTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/FileTypeNode.java
@@ -15,14 +15,13 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.ULong;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UShort;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
-import org.eclipse.milo.opcua.stack.core.util.FutureUtils;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public class FileTypeNode extends BaseObjectTypeNode implements FileType {
     public FileTypeNode(OpcUaClient client, NodeId nodeId, NodeClass nodeClass,
@@ -67,17 +66,10 @@ public class FileTypeNode extends BaseObjectTypeNode implements FileType {
     }
 
     @Override
-    public CompletableFuture<Unit> writeSizeAsync(ULong size) {
+    public CompletableFuture<StatusCode> writeSizeAsync(ULong size) {
         DataValue value = DataValue.valueOnly(new Variant(size));
         return getSizeNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -131,17 +123,10 @@ public class FileTypeNode extends BaseObjectTypeNode implements FileType {
     }
 
     @Override
-    public CompletableFuture<Unit> writeWritableAsync(Boolean writable) {
+    public CompletableFuture<StatusCode> writeWritableAsync(Boolean writable) {
         DataValue value = DataValue.valueOnly(new Variant(writable));
         return getWritableNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -195,17 +180,10 @@ public class FileTypeNode extends BaseObjectTypeNode implements FileType {
     }
 
     @Override
-    public CompletableFuture<Unit> writeUserWritableAsync(Boolean userWritable) {
+    public CompletableFuture<StatusCode> writeUserWritableAsync(Boolean userWritable) {
         DataValue value = DataValue.valueOnly(new Variant(userWritable));
         return getUserWritableNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -259,17 +237,10 @@ public class FileTypeNode extends BaseObjectTypeNode implements FileType {
     }
 
     @Override
-    public CompletableFuture<Unit> writeOpenCountAsync(UShort openCount) {
+    public CompletableFuture<StatusCode> writeOpenCountAsync(UShort openCount) {
         DataValue value = DataValue.valueOnly(new Variant(openCount));
         return getOpenCountNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -323,17 +294,10 @@ public class FileTypeNode extends BaseObjectTypeNode implements FileType {
     }
 
     @Override
-    public CompletableFuture<Unit> writeMimeTypeAsync(String mimeType) {
+    public CompletableFuture<StatusCode> writeMimeTypeAsync(String mimeType) {
         DataValue value = DataValue.valueOnly(new Variant(mimeType));
         return getMimeTypeNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/FiniteStateMachineTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/FiniteStateMachineTypeNode.java
@@ -16,12 +16,11 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
-import org.eclipse.milo.opcua.stack.core.util.FutureUtils;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public class FiniteStateMachineTypeNode extends StateMachineTypeNode implements FiniteStateMachineType {
     public FiniteStateMachineTypeNode(OpcUaClient client, NodeId nodeId, NodeClass nodeClass,
@@ -66,17 +65,10 @@ public class FiniteStateMachineTypeNode extends StateMachineTypeNode implements 
     }
 
     @Override
-    public CompletableFuture<Unit> writeCurrentStateAsync(LocalizedText currentState) {
+    public CompletableFuture<StatusCode> writeCurrentStateAsync(LocalizedText currentState) {
         DataValue value = DataValue.valueOnly(new Variant(currentState));
         return getCurrentStateNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -130,17 +122,10 @@ public class FiniteStateMachineTypeNode extends StateMachineTypeNode implements 
     }
 
     @Override
-    public CompletableFuture<Unit> writeLastTransitionAsync(LocalizedText lastTransition) {
+    public CompletableFuture<StatusCode> writeLastTransitionAsync(LocalizedText lastTransition) {
         DataValue value = DataValue.valueOnly(new Variant(lastTransition));
         return getLastTransitionNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/GeneralModelChangeEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/GeneralModelChangeEventTypeNode.java
@@ -16,13 +16,12 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.ExtensionObject;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
 import org.eclipse.milo.opcua.stack.core.types.structured.ModelChangeStructureDataType;
-import org.eclipse.milo.opcua.stack.core.util.FutureUtils;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public class GeneralModelChangeEventTypeNode extends BaseModelChangeEventTypeNode implements GeneralModelChangeEventType {
     public GeneralModelChangeEventTypeNode(OpcUaClient client, NodeId nodeId, NodeClass nodeClass,
@@ -68,18 +67,11 @@ public class GeneralModelChangeEventTypeNode extends BaseModelChangeEventTypeNod
     }
 
     @Override
-    public CompletableFuture<Unit> writeChangesAsync(ModelChangeStructureDataType[] changes) {
+    public CompletableFuture<StatusCode> writeChangesAsync(ModelChangeStructureDataType[] changes) {
         ExtensionObject[] encoded = ExtensionObject.encodeArray(client.getSerializationContext(), changes);
         DataValue value = DataValue.valueOnly(new Variant(encoded));
         return getChangesNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/HistoricalDataConfigurationTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/HistoricalDataConfigurationTypeNode.java
@@ -16,13 +16,12 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.ExceptionDeviationFormat;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
-import org.eclipse.milo.opcua.stack.core.util.FutureUtils;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public class HistoricalDataConfigurationTypeNode extends BaseObjectTypeNode implements HistoricalDataConfigurationType {
     public HistoricalDataConfigurationTypeNode(OpcUaClient client, NodeId nodeId, NodeClass nodeClass,
@@ -67,17 +66,10 @@ public class HistoricalDataConfigurationTypeNode extends BaseObjectTypeNode impl
     }
 
     @Override
-    public CompletableFuture<Unit> writeSteppedAsync(Boolean stepped) {
+    public CompletableFuture<StatusCode> writeSteppedAsync(Boolean stepped) {
         DataValue value = DataValue.valueOnly(new Variant(stepped));
         return getSteppedNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -131,17 +123,10 @@ public class HistoricalDataConfigurationTypeNode extends BaseObjectTypeNode impl
     }
 
     @Override
-    public CompletableFuture<Unit> writeDefinitionAsync(String definition) {
+    public CompletableFuture<StatusCode> writeDefinitionAsync(String definition) {
         DataValue value = DataValue.valueOnly(new Variant(definition));
         return getDefinitionNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -195,17 +180,10 @@ public class HistoricalDataConfigurationTypeNode extends BaseObjectTypeNode impl
     }
 
     @Override
-    public CompletableFuture<Unit> writeMaxTimeIntervalAsync(Double maxTimeInterval) {
+    public CompletableFuture<StatusCode> writeMaxTimeIntervalAsync(Double maxTimeInterval) {
         DataValue value = DataValue.valueOnly(new Variant(maxTimeInterval));
         return getMaxTimeIntervalNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -259,17 +237,10 @@ public class HistoricalDataConfigurationTypeNode extends BaseObjectTypeNode impl
     }
 
     @Override
-    public CompletableFuture<Unit> writeMinTimeIntervalAsync(Double minTimeInterval) {
+    public CompletableFuture<StatusCode> writeMinTimeIntervalAsync(Double minTimeInterval) {
         DataValue value = DataValue.valueOnly(new Variant(minTimeInterval));
         return getMinTimeIntervalNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -323,17 +294,10 @@ public class HistoricalDataConfigurationTypeNode extends BaseObjectTypeNode impl
     }
 
     @Override
-    public CompletableFuture<Unit> writeExceptionDeviationAsync(Double exceptionDeviation) {
+    public CompletableFuture<StatusCode> writeExceptionDeviationAsync(Double exceptionDeviation) {
         DataValue value = DataValue.valueOnly(new Variant(exceptionDeviation));
         return getExceptionDeviationNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -354,7 +318,14 @@ public class HistoricalDataConfigurationTypeNode extends BaseObjectTypeNode impl
     @Override
     public ExceptionDeviationFormat getExceptionDeviationFormat() throws UaException {
         PropertyTypeNode node = getExceptionDeviationFormatNode();
-        return (ExceptionDeviationFormat) node.getValue().getValue().getValue();
+        Object value = node.getValue().getValue().getValue();
+        if (value instanceof Integer) {
+            return ExceptionDeviationFormat.from((Integer) value);
+        } else if (value instanceof ExceptionDeviationFormat) {
+            return (ExceptionDeviationFormat) value;
+        } else {
+            return null;
+        }
     }
 
     @Override
@@ -385,22 +356,24 @@ public class HistoricalDataConfigurationTypeNode extends BaseObjectTypeNode impl
 
     @Override
     public CompletableFuture<? extends ExceptionDeviationFormat> readExceptionDeviationFormatAsync() {
-        return getExceptionDeviationFormatNodeAsync().thenCompose(node -> node.readAttributeAsync(AttributeId.Value)).thenApply(v -> (ExceptionDeviationFormat) v.getValue().getValue());
+        return getExceptionDeviationFormatNodeAsync()
+            .thenCompose(node -> node.readAttributeAsync(AttributeId.Value))
+            .thenApply(v -> {
+                Object value = v.getValue().getValue();
+                if (value instanceof Integer) {
+                    return ExceptionDeviationFormat.from((Integer) value);
+                } else {
+                    return null;
+                }
+            });
     }
 
     @Override
-    public CompletableFuture<Unit> writeExceptionDeviationFormatAsync(
+    public CompletableFuture<StatusCode> writeExceptionDeviationFormatAsync(
         ExceptionDeviationFormat exceptionDeviationFormat) {
         DataValue value = DataValue.valueOnly(new Variant(exceptionDeviationFormat));
         return getExceptionDeviationFormatNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -454,17 +427,10 @@ public class HistoricalDataConfigurationTypeNode extends BaseObjectTypeNode impl
     }
 
     @Override
-    public CompletableFuture<Unit> writeStartOfArchiveAsync(DateTime startOfArchive) {
+    public CompletableFuture<StatusCode> writeStartOfArchiveAsync(DateTime startOfArchive) {
         DataValue value = DataValue.valueOnly(new Variant(startOfArchive));
         return getStartOfArchiveNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -518,17 +484,11 @@ public class HistoricalDataConfigurationTypeNode extends BaseObjectTypeNode impl
     }
 
     @Override
-    public CompletableFuture<Unit> writeStartOfOnlineArchiveAsync(DateTime startOfOnlineArchive) {
+    public CompletableFuture<StatusCode> writeStartOfOnlineArchiveAsync(
+        DateTime startOfOnlineArchive) {
         DataValue value = DataValue.valueOnly(new Variant(startOfOnlineArchive));
         return getStartOfOnlineArchiveNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/HistoryServerCapabilitiesTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/HistoryServerCapabilitiesTypeNode.java
@@ -15,12 +15,11 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
-import org.eclipse.milo.opcua.stack.core.util.FutureUtils;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public class HistoryServerCapabilitiesTypeNode extends BaseObjectTypeNode implements HistoryServerCapabilitiesType {
     public HistoryServerCapabilitiesTypeNode(OpcUaClient client, NodeId nodeId, NodeClass nodeClass,
@@ -67,18 +66,11 @@ public class HistoryServerCapabilitiesTypeNode extends BaseObjectTypeNode implem
     }
 
     @Override
-    public CompletableFuture<Unit> writeAccessHistoryDataCapabilityAsync(
+    public CompletableFuture<StatusCode> writeAccessHistoryDataCapabilityAsync(
         Boolean accessHistoryDataCapability) {
         DataValue value = DataValue.valueOnly(new Variant(accessHistoryDataCapability));
         return getAccessHistoryDataCapabilityNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -134,18 +126,11 @@ public class HistoryServerCapabilitiesTypeNode extends BaseObjectTypeNode implem
     }
 
     @Override
-    public CompletableFuture<Unit> writeAccessHistoryEventsCapabilityAsync(
+    public CompletableFuture<StatusCode> writeAccessHistoryEventsCapabilityAsync(
         Boolean accessHistoryEventsCapability) {
         DataValue value = DataValue.valueOnly(new Variant(accessHistoryEventsCapability));
         return getAccessHistoryEventsCapabilityNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -199,17 +184,10 @@ public class HistoryServerCapabilitiesTypeNode extends BaseObjectTypeNode implem
     }
 
     @Override
-    public CompletableFuture<Unit> writeMaxReturnDataValuesAsync(UInteger maxReturnDataValues) {
+    public CompletableFuture<StatusCode> writeMaxReturnDataValuesAsync(UInteger maxReturnDataValues) {
         DataValue value = DataValue.valueOnly(new Variant(maxReturnDataValues));
         return getMaxReturnDataValuesNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -263,17 +241,11 @@ public class HistoryServerCapabilitiesTypeNode extends BaseObjectTypeNode implem
     }
 
     @Override
-    public CompletableFuture<Unit> writeMaxReturnEventValuesAsync(UInteger maxReturnEventValues) {
+    public CompletableFuture<StatusCode> writeMaxReturnEventValuesAsync(
+        UInteger maxReturnEventValues) {
         DataValue value = DataValue.valueOnly(new Variant(maxReturnEventValues));
         return getMaxReturnEventValuesNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -327,17 +299,11 @@ public class HistoryServerCapabilitiesTypeNode extends BaseObjectTypeNode implem
     }
 
     @Override
-    public CompletableFuture<Unit> writeInsertDataCapabilityAsync(Boolean insertDataCapability) {
+    public CompletableFuture<StatusCode> writeInsertDataCapabilityAsync(
+        Boolean insertDataCapability) {
         DataValue value = DataValue.valueOnly(new Variant(insertDataCapability));
         return getInsertDataCapabilityNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -391,17 +357,11 @@ public class HistoryServerCapabilitiesTypeNode extends BaseObjectTypeNode implem
     }
 
     @Override
-    public CompletableFuture<Unit> writeReplaceDataCapabilityAsync(Boolean replaceDataCapability) {
+    public CompletableFuture<StatusCode> writeReplaceDataCapabilityAsync(
+        Boolean replaceDataCapability) {
         DataValue value = DataValue.valueOnly(new Variant(replaceDataCapability));
         return getReplaceDataCapabilityNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -455,17 +415,11 @@ public class HistoryServerCapabilitiesTypeNode extends BaseObjectTypeNode implem
     }
 
     @Override
-    public CompletableFuture<Unit> writeUpdateDataCapabilityAsync(Boolean updateDataCapability) {
+    public CompletableFuture<StatusCode> writeUpdateDataCapabilityAsync(
+        Boolean updateDataCapability) {
         DataValue value = DataValue.valueOnly(new Variant(updateDataCapability));
         return getUpdateDataCapabilityNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -519,17 +473,10 @@ public class HistoryServerCapabilitiesTypeNode extends BaseObjectTypeNode implem
     }
 
     @Override
-    public CompletableFuture<Unit> writeDeleteRawCapabilityAsync(Boolean deleteRawCapability) {
+    public CompletableFuture<StatusCode> writeDeleteRawCapabilityAsync(Boolean deleteRawCapability) {
         DataValue value = DataValue.valueOnly(new Variant(deleteRawCapability));
         return getDeleteRawCapabilityNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -583,17 +530,11 @@ public class HistoryServerCapabilitiesTypeNode extends BaseObjectTypeNode implem
     }
 
     @Override
-    public CompletableFuture<Unit> writeDeleteAtTimeCapabilityAsync(Boolean deleteAtTimeCapability) {
+    public CompletableFuture<StatusCode> writeDeleteAtTimeCapabilityAsync(
+        Boolean deleteAtTimeCapability) {
         DataValue value = DataValue.valueOnly(new Variant(deleteAtTimeCapability));
         return getDeleteAtTimeCapabilityNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -647,17 +588,11 @@ public class HistoryServerCapabilitiesTypeNode extends BaseObjectTypeNode implem
     }
 
     @Override
-    public CompletableFuture<Unit> writeInsertEventCapabilityAsync(Boolean insertEventCapability) {
+    public CompletableFuture<StatusCode> writeInsertEventCapabilityAsync(
+        Boolean insertEventCapability) {
         DataValue value = DataValue.valueOnly(new Variant(insertEventCapability));
         return getInsertEventCapabilityNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -711,17 +646,11 @@ public class HistoryServerCapabilitiesTypeNode extends BaseObjectTypeNode implem
     }
 
     @Override
-    public CompletableFuture<Unit> writeReplaceEventCapabilityAsync(Boolean replaceEventCapability) {
+    public CompletableFuture<StatusCode> writeReplaceEventCapabilityAsync(
+        Boolean replaceEventCapability) {
         DataValue value = DataValue.valueOnly(new Variant(replaceEventCapability));
         return getReplaceEventCapabilityNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -775,17 +704,11 @@ public class HistoryServerCapabilitiesTypeNode extends BaseObjectTypeNode implem
     }
 
     @Override
-    public CompletableFuture<Unit> writeUpdateEventCapabilityAsync(Boolean updateEventCapability) {
+    public CompletableFuture<StatusCode> writeUpdateEventCapabilityAsync(
+        Boolean updateEventCapability) {
         DataValue value = DataValue.valueOnly(new Variant(updateEventCapability));
         return getUpdateEventCapabilityNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -839,17 +762,11 @@ public class HistoryServerCapabilitiesTypeNode extends BaseObjectTypeNode implem
     }
 
     @Override
-    public CompletableFuture<Unit> writeDeleteEventCapabilityAsync(Boolean deleteEventCapability) {
+    public CompletableFuture<StatusCode> writeDeleteEventCapabilityAsync(
+        Boolean deleteEventCapability) {
         DataValue value = DataValue.valueOnly(new Variant(deleteEventCapability));
         return getDeleteEventCapabilityNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -904,18 +821,11 @@ public class HistoryServerCapabilitiesTypeNode extends BaseObjectTypeNode implem
     }
 
     @Override
-    public CompletableFuture<Unit> writeInsertAnnotationCapabilityAsync(
+    public CompletableFuture<StatusCode> writeInsertAnnotationCapabilityAsync(
         Boolean insertAnnotationCapability) {
         DataValue value = DataValue.valueOnly(new Variant(insertAnnotationCapability));
         return getInsertAnnotationCapabilityNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/LimitAlarmTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/LimitAlarmTypeNode.java
@@ -15,12 +15,11 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
-import org.eclipse.milo.opcua.stack.core.util.FutureUtils;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public class LimitAlarmTypeNode extends AlarmConditionTypeNode implements LimitAlarmType {
     public LimitAlarmTypeNode(OpcUaClient client, NodeId nodeId, NodeClass nodeClass,
@@ -65,17 +64,10 @@ public class LimitAlarmTypeNode extends AlarmConditionTypeNode implements LimitA
     }
 
     @Override
-    public CompletableFuture<Unit> writeHighHighLimitAsync(Double highHighLimit) {
+    public CompletableFuture<StatusCode> writeHighHighLimitAsync(Double highHighLimit) {
         DataValue value = DataValue.valueOnly(new Variant(highHighLimit));
         return getHighHighLimitNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -129,17 +121,10 @@ public class LimitAlarmTypeNode extends AlarmConditionTypeNode implements LimitA
     }
 
     @Override
-    public CompletableFuture<Unit> writeHighLimitAsync(Double highLimit) {
+    public CompletableFuture<StatusCode> writeHighLimitAsync(Double highLimit) {
         DataValue value = DataValue.valueOnly(new Variant(highLimit));
         return getHighLimitNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -193,17 +178,10 @@ public class LimitAlarmTypeNode extends AlarmConditionTypeNode implements LimitA
     }
 
     @Override
-    public CompletableFuture<Unit> writeLowLimitAsync(Double lowLimit) {
+    public CompletableFuture<StatusCode> writeLowLimitAsync(Double lowLimit) {
         DataValue value = DataValue.valueOnly(new Variant(lowLimit));
         return getLowLimitNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -257,17 +235,10 @@ public class LimitAlarmTypeNode extends AlarmConditionTypeNode implements LimitA
     }
 
     @Override
-    public CompletableFuture<Unit> writeLowLowLimitAsync(Double lowLowLimit) {
+    public CompletableFuture<StatusCode> writeLowLowLimitAsync(Double lowLowLimit) {
         DataValue value = DataValue.valueOnly(new Variant(lowLowLimit));
         return getLowLowLimitNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/NonExclusiveDeviationAlarmTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/NonExclusiveDeviationAlarmTypeNode.java
@@ -15,12 +15,11 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
-import org.eclipse.milo.opcua.stack.core.util.FutureUtils;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public class NonExclusiveDeviationAlarmTypeNode extends NonExclusiveLimitAlarmTypeNode implements NonExclusiveDeviationAlarmType {
     public NonExclusiveDeviationAlarmTypeNode(OpcUaClient client, NodeId nodeId, NodeClass nodeClass,
@@ -65,17 +64,10 @@ public class NonExclusiveDeviationAlarmTypeNode extends NonExclusiveLimitAlarmTy
     }
 
     @Override
-    public CompletableFuture<Unit> writeSetpointNodeAsync(NodeId setpointNode) {
+    public CompletableFuture<StatusCode> writeSetpointNodeAsync(NodeId setpointNode) {
         DataValue value = DataValue.valueOnly(new Variant(setpointNode));
         return getSetpointNodeNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/NonExclusiveLimitAlarmTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/NonExclusiveLimitAlarmTypeNode.java
@@ -15,12 +15,11 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
-import org.eclipse.milo.opcua.stack.core.util.FutureUtils;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public class NonExclusiveLimitAlarmTypeNode extends LimitAlarmTypeNode implements NonExclusiveLimitAlarmType {
     public NonExclusiveLimitAlarmTypeNode(OpcUaClient client, NodeId nodeId, NodeClass nodeClass,
@@ -65,17 +64,10 @@ public class NonExclusiveLimitAlarmTypeNode extends LimitAlarmTypeNode implement
     }
 
     @Override
-    public CompletableFuture<Unit> writeActiveStateAsync(LocalizedText activeState) {
+    public CompletableFuture<StatusCode> writeActiveStateAsync(LocalizedText activeState) {
         DataValue value = DataValue.valueOnly(new Variant(activeState));
         return getActiveStateNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -129,17 +121,10 @@ public class NonExclusiveLimitAlarmTypeNode extends LimitAlarmTypeNode implement
     }
 
     @Override
-    public CompletableFuture<Unit> writeHighHighStateAsync(LocalizedText highHighState) {
+    public CompletableFuture<StatusCode> writeHighHighStateAsync(LocalizedText highHighState) {
         DataValue value = DataValue.valueOnly(new Variant(highHighState));
         return getHighHighStateNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -193,17 +178,10 @@ public class NonExclusiveLimitAlarmTypeNode extends LimitAlarmTypeNode implement
     }
 
     @Override
-    public CompletableFuture<Unit> writeHighStateAsync(LocalizedText highState) {
+    public CompletableFuture<StatusCode> writeHighStateAsync(LocalizedText highState) {
         DataValue value = DataValue.valueOnly(new Variant(highState));
         return getHighStateNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -257,17 +235,10 @@ public class NonExclusiveLimitAlarmTypeNode extends LimitAlarmTypeNode implement
     }
 
     @Override
-    public CompletableFuture<Unit> writeLowStateAsync(LocalizedText lowState) {
+    public CompletableFuture<StatusCode> writeLowStateAsync(LocalizedText lowState) {
         DataValue value = DataValue.valueOnly(new Variant(lowState));
         return getLowStateNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -321,17 +292,10 @@ public class NonExclusiveLimitAlarmTypeNode extends LimitAlarmTypeNode implement
     }
 
     @Override
-    public CompletableFuture<Unit> writeLowLowStateAsync(LocalizedText lowLowState) {
+    public CompletableFuture<StatusCode> writeLowLowStateAsync(LocalizedText lowLowState) {
         DataValue value = DataValue.valueOnly(new Variant(lowLowState));
         return getLowLowStateNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/NonTransparentNetworkRedundancyTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/NonTransparentNetworkRedundancyTypeNode.java
@@ -16,13 +16,12 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.ExtensionObject;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
 import org.eclipse.milo.opcua.stack.core.types.structured.NetworkGroupDataType;
-import org.eclipse.milo.opcua.stack.core.util.FutureUtils;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public class NonTransparentNetworkRedundancyTypeNode extends NonTransparentRedundancyTypeNode implements NonTransparentNetworkRedundancyType {
     public NonTransparentNetworkRedundancyTypeNode(OpcUaClient client, NodeId nodeId,
@@ -70,19 +69,12 @@ public class NonTransparentNetworkRedundancyTypeNode extends NonTransparentRedun
     }
 
     @Override
-    public CompletableFuture<Unit> writeServerNetworkGroupsAsync(
+    public CompletableFuture<StatusCode> writeServerNetworkGroupsAsync(
         NetworkGroupDataType[] serverNetworkGroups) {
         ExtensionObject[] encoded = ExtensionObject.encodeArray(client.getSerializationContext(), serverNetworkGroups);
         DataValue value = DataValue.valueOnly(new Variant(encoded));
         return getServerNetworkGroupsNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/NonTransparentRedundancyTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/NonTransparentRedundancyTypeNode.java
@@ -15,12 +15,11 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
-import org.eclipse.milo.opcua.stack.core.util.FutureUtils;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public class NonTransparentRedundancyTypeNode extends ServerRedundancyTypeNode implements NonTransparentRedundancyType {
     public NonTransparentRedundancyTypeNode(OpcUaClient client, NodeId nodeId, NodeClass nodeClass,
@@ -65,17 +64,10 @@ public class NonTransparentRedundancyTypeNode extends ServerRedundancyTypeNode i
     }
 
     @Override
-    public CompletableFuture<Unit> writeServerUriArrayAsync(String[] serverUriArray) {
+    public CompletableFuture<StatusCode> writeServerUriArrayAsync(String[] serverUriArray) {
         DataValue value = DataValue.valueOnly(new Variant(serverUriArray));
         return getServerUriArrayNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/OffNormalAlarmTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/OffNormalAlarmTypeNode.java
@@ -15,12 +15,11 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
-import org.eclipse.milo.opcua.stack.core.util.FutureUtils;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public class OffNormalAlarmTypeNode extends DiscreteAlarmTypeNode implements OffNormalAlarmType {
     public OffNormalAlarmTypeNode(OpcUaClient client, NodeId nodeId, NodeClass nodeClass,
@@ -65,17 +64,10 @@ public class OffNormalAlarmTypeNode extends DiscreteAlarmTypeNode implements Off
     }
 
     @Override
-    public CompletableFuture<Unit> writeNormalStateAsync(NodeId normalState) {
+    public CompletableFuture<StatusCode> writeNormalStateAsync(NodeId normalState) {
         DataValue value = DataValue.valueOnly(new Variant(normalState));
         return getNormalStateNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/OperationLimitsTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/OperationLimitsTypeNode.java
@@ -15,12 +15,11 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
-import org.eclipse.milo.opcua.stack.core.util.FutureUtils;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public class OperationLimitsTypeNode extends FolderTypeNode implements OperationLimitsType {
     public OperationLimitsTypeNode(OpcUaClient client, NodeId nodeId, NodeClass nodeClass,
@@ -65,17 +64,10 @@ public class OperationLimitsTypeNode extends FolderTypeNode implements Operation
     }
 
     @Override
-    public CompletableFuture<Unit> writeMaxNodesPerReadAsync(UInteger maxNodesPerRead) {
+    public CompletableFuture<StatusCode> writeMaxNodesPerReadAsync(UInteger maxNodesPerRead) {
         DataValue value = DataValue.valueOnly(new Variant(maxNodesPerRead));
         return getMaxNodesPerReadNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -131,18 +123,11 @@ public class OperationLimitsTypeNode extends FolderTypeNode implements Operation
     }
 
     @Override
-    public CompletableFuture<Unit> writeMaxNodesPerHistoryReadDataAsync(
+    public CompletableFuture<StatusCode> writeMaxNodesPerHistoryReadDataAsync(
         UInteger maxNodesPerHistoryReadData) {
         DataValue value = DataValue.valueOnly(new Variant(maxNodesPerHistoryReadData));
         return getMaxNodesPerHistoryReadDataNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -198,18 +183,11 @@ public class OperationLimitsTypeNode extends FolderTypeNode implements Operation
     }
 
     @Override
-    public CompletableFuture<Unit> writeMaxNodesPerHistoryReadEventsAsync(
+    public CompletableFuture<StatusCode> writeMaxNodesPerHistoryReadEventsAsync(
         UInteger maxNodesPerHistoryReadEvents) {
         DataValue value = DataValue.valueOnly(new Variant(maxNodesPerHistoryReadEvents));
         return getMaxNodesPerHistoryReadEventsNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -263,17 +241,10 @@ public class OperationLimitsTypeNode extends FolderTypeNode implements Operation
     }
 
     @Override
-    public CompletableFuture<Unit> writeMaxNodesPerWriteAsync(UInteger maxNodesPerWrite) {
+    public CompletableFuture<StatusCode> writeMaxNodesPerWriteAsync(UInteger maxNodesPerWrite) {
         DataValue value = DataValue.valueOnly(new Variant(maxNodesPerWrite));
         return getMaxNodesPerWriteNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -329,18 +300,11 @@ public class OperationLimitsTypeNode extends FolderTypeNode implements Operation
     }
 
     @Override
-    public CompletableFuture<Unit> writeMaxNodesPerHistoryUpdateDataAsync(
+    public CompletableFuture<StatusCode> writeMaxNodesPerHistoryUpdateDataAsync(
         UInteger maxNodesPerHistoryUpdateData) {
         DataValue value = DataValue.valueOnly(new Variant(maxNodesPerHistoryUpdateData));
         return getMaxNodesPerHistoryUpdateDataNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -396,18 +360,11 @@ public class OperationLimitsTypeNode extends FolderTypeNode implements Operation
     }
 
     @Override
-    public CompletableFuture<Unit> writeMaxNodesPerHistoryUpdateEventsAsync(
+    public CompletableFuture<StatusCode> writeMaxNodesPerHistoryUpdateEventsAsync(
         UInteger maxNodesPerHistoryUpdateEvents) {
         DataValue value = DataValue.valueOnly(new Variant(maxNodesPerHistoryUpdateEvents));
         return getMaxNodesPerHistoryUpdateEventsNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -462,17 +419,11 @@ public class OperationLimitsTypeNode extends FolderTypeNode implements Operation
     }
 
     @Override
-    public CompletableFuture<Unit> writeMaxNodesPerMethodCallAsync(UInteger maxNodesPerMethodCall) {
+    public CompletableFuture<StatusCode> writeMaxNodesPerMethodCallAsync(
+        UInteger maxNodesPerMethodCall) {
         DataValue value = DataValue.valueOnly(new Variant(maxNodesPerMethodCall));
         return getMaxNodesPerMethodCallNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -526,17 +477,10 @@ public class OperationLimitsTypeNode extends FolderTypeNode implements Operation
     }
 
     @Override
-    public CompletableFuture<Unit> writeMaxNodesPerBrowseAsync(UInteger maxNodesPerBrowse) {
+    public CompletableFuture<StatusCode> writeMaxNodesPerBrowseAsync(UInteger maxNodesPerBrowse) {
         DataValue value = DataValue.valueOnly(new Variant(maxNodesPerBrowse));
         return getMaxNodesPerBrowseNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -590,18 +534,11 @@ public class OperationLimitsTypeNode extends FolderTypeNode implements Operation
     }
 
     @Override
-    public CompletableFuture<Unit> writeMaxNodesPerRegisterNodesAsync(
+    public CompletableFuture<StatusCode> writeMaxNodesPerRegisterNodesAsync(
         UInteger maxNodesPerRegisterNodes) {
         DataValue value = DataValue.valueOnly(new Variant(maxNodesPerRegisterNodes));
         return getMaxNodesPerRegisterNodesNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -657,18 +594,11 @@ public class OperationLimitsTypeNode extends FolderTypeNode implements Operation
     }
 
     @Override
-    public CompletableFuture<Unit> writeMaxNodesPerTranslateBrowsePathsToNodeIdsAsync(
+    public CompletableFuture<StatusCode> writeMaxNodesPerTranslateBrowsePathsToNodeIdsAsync(
         UInteger maxNodesPerTranslateBrowsePathsToNodeIds) {
         DataValue value = DataValue.valueOnly(new Variant(maxNodesPerTranslateBrowsePathsToNodeIds));
         return getMaxNodesPerTranslateBrowsePathsToNodeIdsNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -724,18 +654,11 @@ public class OperationLimitsTypeNode extends FolderTypeNode implements Operation
     }
 
     @Override
-    public CompletableFuture<Unit> writeMaxNodesPerNodeManagementAsync(
+    public CompletableFuture<StatusCode> writeMaxNodesPerNodeManagementAsync(
         UInteger maxNodesPerNodeManagement) {
         DataValue value = DataValue.valueOnly(new Variant(maxNodesPerNodeManagement));
         return getMaxNodesPerNodeManagementNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -789,18 +712,11 @@ public class OperationLimitsTypeNode extends FolderTypeNode implements Operation
     }
 
     @Override
-    public CompletableFuture<Unit> writeMaxMonitoredItemsPerCallAsync(
+    public CompletableFuture<StatusCode> writeMaxMonitoredItemsPerCallAsync(
         UInteger maxMonitoredItemsPerCall) {
         DataValue value = DataValue.valueOnly(new Variant(maxMonitoredItemsPerCall));
         return getMaxMonitoredItemsPerCallNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/ProgramStateMachineTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/ProgramStateMachineTypeNode.java
@@ -19,13 +19,12 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.ExtensionObject;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
 import org.eclipse.milo.opcua.stack.core.types.structured.ProgramDiagnosticDataType;
-import org.eclipse.milo.opcua.stack.core.util.FutureUtils;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public class ProgramStateMachineTypeNode extends FiniteStateMachineTypeNode implements ProgramStateMachineType {
     public ProgramStateMachineTypeNode(OpcUaClient client, NodeId nodeId, NodeClass nodeClass,
@@ -70,17 +69,10 @@ public class ProgramStateMachineTypeNode extends FiniteStateMachineTypeNode impl
     }
 
     @Override
-    public CompletableFuture<Unit> writeCreatableAsync(Boolean creatable) {
+    public CompletableFuture<StatusCode> writeCreatableAsync(Boolean creatable) {
         DataValue value = DataValue.valueOnly(new Variant(creatable));
         return getCreatableNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -134,17 +126,10 @@ public class ProgramStateMachineTypeNode extends FiniteStateMachineTypeNode impl
     }
 
     @Override
-    public CompletableFuture<Unit> writeDeletableAsync(Boolean deletable) {
+    public CompletableFuture<StatusCode> writeDeletableAsync(Boolean deletable) {
         DataValue value = DataValue.valueOnly(new Variant(deletable));
         return getDeletableNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -198,17 +183,10 @@ public class ProgramStateMachineTypeNode extends FiniteStateMachineTypeNode impl
     }
 
     @Override
-    public CompletableFuture<Unit> writeAutoDeleteAsync(Boolean autoDelete) {
+    public CompletableFuture<StatusCode> writeAutoDeleteAsync(Boolean autoDelete) {
         DataValue value = DataValue.valueOnly(new Variant(autoDelete));
         return getAutoDeleteNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -262,17 +240,10 @@ public class ProgramStateMachineTypeNode extends FiniteStateMachineTypeNode impl
     }
 
     @Override
-    public CompletableFuture<Unit> writeRecycleCountAsync(Integer recycleCount) {
+    public CompletableFuture<StatusCode> writeRecycleCountAsync(Integer recycleCount) {
         DataValue value = DataValue.valueOnly(new Variant(recycleCount));
         return getRecycleCountNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -326,17 +297,10 @@ public class ProgramStateMachineTypeNode extends FiniteStateMachineTypeNode impl
     }
 
     @Override
-    public CompletableFuture<Unit> writeInstanceCountAsync(UInteger instanceCount) {
+    public CompletableFuture<StatusCode> writeInstanceCountAsync(UInteger instanceCount) {
         DataValue value = DataValue.valueOnly(new Variant(instanceCount));
         return getInstanceCountNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -390,17 +354,10 @@ public class ProgramStateMachineTypeNode extends FiniteStateMachineTypeNode impl
     }
 
     @Override
-    public CompletableFuture<Unit> writeMaxInstanceCountAsync(UInteger maxInstanceCount) {
+    public CompletableFuture<StatusCode> writeMaxInstanceCountAsync(UInteger maxInstanceCount) {
         DataValue value = DataValue.valueOnly(new Variant(maxInstanceCount));
         return getMaxInstanceCountNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -454,17 +411,10 @@ public class ProgramStateMachineTypeNode extends FiniteStateMachineTypeNode impl
     }
 
     @Override
-    public CompletableFuture<Unit> writeMaxRecycleCountAsync(UInteger maxRecycleCount) {
+    public CompletableFuture<StatusCode> writeMaxRecycleCountAsync(UInteger maxRecycleCount) {
         DataValue value = DataValue.valueOnly(new Variant(maxRecycleCount));
         return getMaxRecycleCountNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -518,17 +468,10 @@ public class ProgramStateMachineTypeNode extends FiniteStateMachineTypeNode impl
     }
 
     @Override
-    public CompletableFuture<Unit> writeCurrentStateAsync(LocalizedText currentState) {
+    public CompletableFuture<StatusCode> writeCurrentStateAsync(LocalizedText currentState) {
         DataValue value = DataValue.valueOnly(new Variant(currentState));
         return getCurrentStateNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -582,17 +525,10 @@ public class ProgramStateMachineTypeNode extends FiniteStateMachineTypeNode impl
     }
 
     @Override
-    public CompletableFuture<Unit> writeLastTransitionAsync(LocalizedText lastTransition) {
+    public CompletableFuture<StatusCode> writeLastTransitionAsync(LocalizedText lastTransition) {
         DataValue value = DataValue.valueOnly(new Variant(lastTransition));
         return getLastTransitionNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -650,19 +586,12 @@ public class ProgramStateMachineTypeNode extends FiniteStateMachineTypeNode impl
     }
 
     @Override
-    public CompletableFuture<Unit> writeProgramDiagnosticsAsync(
+    public CompletableFuture<StatusCode> writeProgramDiagnosticsAsync(
         ProgramDiagnosticDataType programDiagnostics) {
         ExtensionObject encoded = ExtensionObject.encode(client.getSerializationContext(), programDiagnostics);
         DataValue value = DataValue.valueOnly(new Variant(encoded));
         return getProgramDiagnosticsNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/ProgramTransitionAuditEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/ProgramTransitionAuditEventTypeNode.java
@@ -15,12 +15,11 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
-import org.eclipse.milo.opcua.stack.core.util.FutureUtils;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public class ProgramTransitionAuditEventTypeNode extends AuditUpdateStateEventTypeNode implements ProgramTransitionAuditEventType {
     public ProgramTransitionAuditEventTypeNode(OpcUaClient client, NodeId nodeId, NodeClass nodeClass,
@@ -65,17 +64,10 @@ public class ProgramTransitionAuditEventTypeNode extends AuditUpdateStateEventTy
     }
 
     @Override
-    public CompletableFuture<Unit> writeTransitionAsync(LocalizedText transition) {
+    public CompletableFuture<StatusCode> writeTransitionAsync(LocalizedText transition) {
         DataValue value = DataValue.valueOnly(new Variant(transition));
         return getTransitionNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/ProgramTransitionEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/ProgramTransitionEventTypeNode.java
@@ -15,12 +15,11 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
-import org.eclipse.milo.opcua.stack.core.util.FutureUtils;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public class ProgramTransitionEventTypeNode extends TransitionEventTypeNode implements ProgramTransitionEventType {
     public ProgramTransitionEventTypeNode(OpcUaClient client, NodeId nodeId, NodeClass nodeClass,
@@ -65,17 +64,10 @@ public class ProgramTransitionEventTypeNode extends TransitionEventTypeNode impl
     }
 
     @Override
-    public CompletableFuture<Unit> writeIntermediateResultAsync(Object intermediateResult) {
+    public CompletableFuture<StatusCode> writeIntermediateResultAsync(Object intermediateResult) {
         DataValue value = DataValue.valueOnly(new Variant(intermediateResult));
         return getIntermediateResultNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/ProgressEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/ProgressEventTypeNode.java
@@ -15,13 +15,12 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UShort;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
-import org.eclipse.milo.opcua.stack.core.util.FutureUtils;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public class ProgressEventTypeNode extends BaseEventTypeNode implements ProgressEventType {
     public ProgressEventTypeNode(OpcUaClient client, NodeId nodeId, NodeClass nodeClass,
@@ -66,17 +65,10 @@ public class ProgressEventTypeNode extends BaseEventTypeNode implements Progress
     }
 
     @Override
-    public CompletableFuture<Unit> writeContextAsync(Object context) {
+    public CompletableFuture<StatusCode> writeContextAsync(Object context) {
         DataValue value = DataValue.valueOnly(new Variant(context));
         return getContextNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -130,17 +122,10 @@ public class ProgressEventTypeNode extends BaseEventTypeNode implements Progress
     }
 
     @Override
-    public CompletableFuture<Unit> writeProgressAsync(UShort progress) {
+    public CompletableFuture<StatusCode> writeProgressAsync(UShort progress) {
         DataValue value = DataValue.valueOnly(new Variant(progress));
         return getProgressNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/SemanticChangeEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/SemanticChangeEventTypeNode.java
@@ -16,13 +16,12 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.ExtensionObject;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
 import org.eclipse.milo.opcua.stack.core.types.structured.SemanticChangeStructureDataType;
-import org.eclipse.milo.opcua.stack.core.util.FutureUtils;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public class SemanticChangeEventTypeNode extends BaseModelChangeEventTypeNode implements SemanticChangeEventType {
     public SemanticChangeEventTypeNode(OpcUaClient client, NodeId nodeId, NodeClass nodeClass,
@@ -68,18 +67,12 @@ public class SemanticChangeEventTypeNode extends BaseModelChangeEventTypeNode im
     }
 
     @Override
-    public CompletableFuture<Unit> writeChangesAsync(SemanticChangeStructureDataType[] changes) {
+    public CompletableFuture<StatusCode> writeChangesAsync(
+        SemanticChangeStructureDataType[] changes) {
         ExtensionObject[] encoded = ExtensionObject.encodeArray(client.getSerializationContext(), changes);
         DataValue value = DataValue.valueOnly(new Variant(encoded));
         return getChangesNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/ServerCapabilitiesTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/ServerCapabilitiesTypeNode.java
@@ -16,14 +16,13 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.ExtensionObject;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UShort;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
 import org.eclipse.milo.opcua.stack.core.types.structured.SignedSoftwareCertificate;
-import org.eclipse.milo.opcua.stack.core.util.FutureUtils;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode implements ServerCapabilitiesType {
     public ServerCapabilitiesTypeNode(OpcUaClient client, NodeId nodeId, NodeClass nodeClass,
@@ -68,17 +67,10 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode implements Se
     }
 
     @Override
-    public CompletableFuture<Unit> writeServerProfileArrayAsync(String[] serverProfileArray) {
+    public CompletableFuture<StatusCode> writeServerProfileArrayAsync(String[] serverProfileArray) {
         DataValue value = DataValue.valueOnly(new Variant(serverProfileArray));
         return getServerProfileArrayNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -132,17 +124,10 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode implements Se
     }
 
     @Override
-    public CompletableFuture<Unit> writeLocaleIdArrayAsync(String[] localeIdArray) {
+    public CompletableFuture<StatusCode> writeLocaleIdArrayAsync(String[] localeIdArray) {
         DataValue value = DataValue.valueOnly(new Variant(localeIdArray));
         return getLocaleIdArrayNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -196,17 +181,11 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode implements Se
     }
 
     @Override
-    public CompletableFuture<Unit> writeMinSupportedSampleRateAsync(Double minSupportedSampleRate) {
+    public CompletableFuture<StatusCode> writeMinSupportedSampleRateAsync(
+        Double minSupportedSampleRate) {
         DataValue value = DataValue.valueOnly(new Variant(minSupportedSampleRate));
         return getMinSupportedSampleRateNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -262,18 +241,11 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode implements Se
     }
 
     @Override
-    public CompletableFuture<Unit> writeMaxBrowseContinuationPointsAsync(
+    public CompletableFuture<StatusCode> writeMaxBrowseContinuationPointsAsync(
         UShort maxBrowseContinuationPoints) {
         DataValue value = DataValue.valueOnly(new Variant(maxBrowseContinuationPoints));
         return getMaxBrowseContinuationPointsNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -328,18 +300,11 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode implements Se
     }
 
     @Override
-    public CompletableFuture<Unit> writeMaxQueryContinuationPointsAsync(
+    public CompletableFuture<StatusCode> writeMaxQueryContinuationPointsAsync(
         UShort maxQueryContinuationPoints) {
         DataValue value = DataValue.valueOnly(new Variant(maxQueryContinuationPoints));
         return getMaxQueryContinuationPointsNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -395,18 +360,11 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode implements Se
     }
 
     @Override
-    public CompletableFuture<Unit> writeMaxHistoryContinuationPointsAsync(
+    public CompletableFuture<StatusCode> writeMaxHistoryContinuationPointsAsync(
         UShort maxHistoryContinuationPoints) {
         DataValue value = DataValue.valueOnly(new Variant(maxHistoryContinuationPoints));
         return getMaxHistoryContinuationPointsNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -463,19 +421,12 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode implements Se
     }
 
     @Override
-    public CompletableFuture<Unit> writeSoftwareCertificatesAsync(
+    public CompletableFuture<StatusCode> writeSoftwareCertificatesAsync(
         SignedSoftwareCertificate[] softwareCertificates) {
         ExtensionObject[] encoded = ExtensionObject.encodeArray(client.getSerializationContext(), softwareCertificates);
         DataValue value = DataValue.valueOnly(new Variant(encoded));
         return getSoftwareCertificatesNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -529,17 +480,10 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode implements Se
     }
 
     @Override
-    public CompletableFuture<Unit> writeMaxArrayLengthAsync(UInteger maxArrayLength) {
+    public CompletableFuture<StatusCode> writeMaxArrayLengthAsync(UInteger maxArrayLength) {
         DataValue value = DataValue.valueOnly(new Variant(maxArrayLength));
         return getMaxArrayLengthNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -593,17 +537,10 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode implements Se
     }
 
     @Override
-    public CompletableFuture<Unit> writeMaxStringLengthAsync(UInteger maxStringLength) {
+    public CompletableFuture<StatusCode> writeMaxStringLengthAsync(UInteger maxStringLength) {
         DataValue value = DataValue.valueOnly(new Variant(maxStringLength));
         return getMaxStringLengthNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -657,17 +594,10 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode implements Se
     }
 
     @Override
-    public CompletableFuture<Unit> writeMaxByteStringLengthAsync(UInteger maxByteStringLength) {
+    public CompletableFuture<StatusCode> writeMaxByteStringLengthAsync(UInteger maxByteStringLength) {
         DataValue value = DataValue.valueOnly(new Variant(maxByteStringLength));
         return getMaxByteStringLengthNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/ServerConfigurationTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/ServerConfigurationTypeNode.java
@@ -15,12 +15,11 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
-import org.eclipse.milo.opcua.stack.core.util.FutureUtils;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public class ServerConfigurationTypeNode extends BaseObjectTypeNode implements ServerConfigurationType {
     public ServerConfigurationTypeNode(OpcUaClient client, NodeId nodeId, NodeClass nodeClass,
@@ -65,17 +64,10 @@ public class ServerConfigurationTypeNode extends BaseObjectTypeNode implements S
     }
 
     @Override
-    public CompletableFuture<Unit> writeServerCapabilitiesAsync(String[] serverCapabilities) {
+    public CompletableFuture<StatusCode> writeServerCapabilitiesAsync(String[] serverCapabilities) {
         DataValue value = DataValue.valueOnly(new Variant(serverCapabilities));
         return getServerCapabilitiesNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -131,18 +123,11 @@ public class ServerConfigurationTypeNode extends BaseObjectTypeNode implements S
     }
 
     @Override
-    public CompletableFuture<Unit> writeSupportedPrivateKeyFormatsAsync(
+    public CompletableFuture<StatusCode> writeSupportedPrivateKeyFormatsAsync(
         String[] supportedPrivateKeyFormats) {
         DataValue value = DataValue.valueOnly(new Variant(supportedPrivateKeyFormats));
         return getSupportedPrivateKeyFormatsNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -196,17 +181,10 @@ public class ServerConfigurationTypeNode extends BaseObjectTypeNode implements S
     }
 
     @Override
-    public CompletableFuture<Unit> writeMaxTrustListSizeAsync(UInteger maxTrustListSize) {
+    public CompletableFuture<StatusCode> writeMaxTrustListSizeAsync(UInteger maxTrustListSize) {
         DataValue value = DataValue.valueOnly(new Variant(maxTrustListSize));
         return getMaxTrustListSizeNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -260,17 +238,10 @@ public class ServerConfigurationTypeNode extends BaseObjectTypeNode implements S
     }
 
     @Override
-    public CompletableFuture<Unit> writeMulticastDnsEnabledAsync(Boolean multicastDnsEnabled) {
+    public CompletableFuture<StatusCode> writeMulticastDnsEnabledAsync(Boolean multicastDnsEnabled) {
         DataValue value = DataValue.valueOnly(new Variant(multicastDnsEnabled));
         return getMulticastDnsEnabledNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/ServerDiagnosticsTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/ServerDiagnosticsTypeNode.java
@@ -19,6 +19,7 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.ExtensionObject;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
@@ -26,8 +27,6 @@ import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
 import org.eclipse.milo.opcua.stack.core.types.structured.SamplingIntervalDiagnosticsDataType;
 import org.eclipse.milo.opcua.stack.core.types.structured.ServerDiagnosticsSummaryDataType;
 import org.eclipse.milo.opcua.stack.core.types.structured.SubscriptionDiagnosticsDataType;
-import org.eclipse.milo.opcua.stack.core.util.FutureUtils;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public class ServerDiagnosticsTypeNode extends BaseObjectTypeNode implements ServerDiagnosticsType {
     public ServerDiagnosticsTypeNode(OpcUaClient client, NodeId nodeId, NodeClass nodeClass,
@@ -72,17 +71,10 @@ public class ServerDiagnosticsTypeNode extends BaseObjectTypeNode implements Ser
     }
 
     @Override
-    public CompletableFuture<Unit> writeEnabledFlagAsync(Boolean enabledFlag) {
+    public CompletableFuture<StatusCode> writeEnabledFlagAsync(Boolean enabledFlag) {
         DataValue value = DataValue.valueOnly(new Variant(enabledFlag));
         return getEnabledFlagNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -140,19 +132,12 @@ public class ServerDiagnosticsTypeNode extends BaseObjectTypeNode implements Ser
     }
 
     @Override
-    public CompletableFuture<Unit> writeServerDiagnosticsSummaryAsync(
+    public CompletableFuture<StatusCode> writeServerDiagnosticsSummaryAsync(
         ServerDiagnosticsSummaryDataType serverDiagnosticsSummary) {
         ExtensionObject encoded = ExtensionObject.encode(client.getSerializationContext(), serverDiagnosticsSummary);
         DataValue value = DataValue.valueOnly(new Variant(encoded));
         return getServerDiagnosticsSummaryNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -213,19 +198,12 @@ public class ServerDiagnosticsTypeNode extends BaseObjectTypeNode implements Ser
     }
 
     @Override
-    public CompletableFuture<Unit> writeSamplingIntervalDiagnosticsArrayAsync(
+    public CompletableFuture<StatusCode> writeSamplingIntervalDiagnosticsArrayAsync(
         SamplingIntervalDiagnosticsDataType[] samplingIntervalDiagnosticsArray) {
         ExtensionObject[] encoded = ExtensionObject.encodeArray(client.getSerializationContext(), samplingIntervalDiagnosticsArray);
         DataValue value = DataValue.valueOnly(new Variant(encoded));
         return getSamplingIntervalDiagnosticsArrayNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -285,19 +263,12 @@ public class ServerDiagnosticsTypeNode extends BaseObjectTypeNode implements Ser
     }
 
     @Override
-    public CompletableFuture<Unit> writeSubscriptionDiagnosticsArrayAsync(
+    public CompletableFuture<StatusCode> writeSubscriptionDiagnosticsArrayAsync(
         SubscriptionDiagnosticsDataType[] subscriptionDiagnosticsArray) {
         ExtensionObject[] encoded = ExtensionObject.encodeArray(client.getSerializationContext(), subscriptionDiagnosticsArray);
         DataValue value = DataValue.valueOnly(new Variant(encoded));
         return getSubscriptionDiagnosticsArrayNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/ServerTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/ServerTypeNode.java
@@ -18,13 +18,12 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.ExtensionObject;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
 import org.eclipse.milo.opcua.stack.core.types.structured.ServerStatusDataType;
-import org.eclipse.milo.opcua.stack.core.util.FutureUtils;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public class ServerTypeNode extends BaseObjectTypeNode implements ServerType {
     public ServerTypeNode(OpcUaClient client, NodeId nodeId, NodeClass nodeClass,
@@ -69,17 +68,10 @@ public class ServerTypeNode extends BaseObjectTypeNode implements ServerType {
     }
 
     @Override
-    public CompletableFuture<Unit> writeServerArrayAsync(String[] serverArray) {
+    public CompletableFuture<StatusCode> writeServerArrayAsync(String[] serverArray) {
         DataValue value = DataValue.valueOnly(new Variant(serverArray));
         return getServerArrayNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -133,17 +125,10 @@ public class ServerTypeNode extends BaseObjectTypeNode implements ServerType {
     }
 
     @Override
-    public CompletableFuture<Unit> writeNamespaceArrayAsync(String[] namespaceArray) {
+    public CompletableFuture<StatusCode> writeNamespaceArrayAsync(String[] namespaceArray) {
         DataValue value = DataValue.valueOnly(new Variant(namespaceArray));
         return getNamespaceArrayNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -197,17 +182,10 @@ public class ServerTypeNode extends BaseObjectTypeNode implements ServerType {
     }
 
     @Override
-    public CompletableFuture<Unit> writeServiceLevelAsync(UByte serviceLevel) {
+    public CompletableFuture<StatusCode> writeServiceLevelAsync(UByte serviceLevel) {
         DataValue value = DataValue.valueOnly(new Variant(serviceLevel));
         return getServiceLevelNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -261,17 +239,10 @@ public class ServerTypeNode extends BaseObjectTypeNode implements ServerType {
     }
 
     @Override
-    public CompletableFuture<Unit> writeAuditingAsync(Boolean auditing) {
+    public CompletableFuture<StatusCode> writeAuditingAsync(Boolean auditing) {
         DataValue value = DataValue.valueOnly(new Variant(auditing));
         return getAuditingNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -325,17 +296,10 @@ public class ServerTypeNode extends BaseObjectTypeNode implements ServerType {
     }
 
     @Override
-    public CompletableFuture<Unit> writeEstimatedReturnTimeAsync(DateTime estimatedReturnTime) {
+    public CompletableFuture<StatusCode> writeEstimatedReturnTimeAsync(DateTime estimatedReturnTime) {
         DataValue value = DataValue.valueOnly(new Variant(estimatedReturnTime));
         return getEstimatedReturnTimeNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -390,18 +354,11 @@ public class ServerTypeNode extends BaseObjectTypeNode implements ServerType {
     }
 
     @Override
-    public CompletableFuture<Unit> writeServerStatusAsync(ServerStatusDataType serverStatus) {
+    public CompletableFuture<StatusCode> writeServerStatusAsync(ServerStatusDataType serverStatus) {
         ExtensionObject encoded = ExtensionObject.encode(client.getSerializationContext(), serverStatus);
         DataValue value = DataValue.valueOnly(new Variant(encoded));
         return getServerStatusNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/SessionDiagnosticsObjectTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/SessionDiagnosticsObjectTypeNode.java
@@ -18,6 +18,7 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.ExtensionObject;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
@@ -25,8 +26,6 @@ import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
 import org.eclipse.milo.opcua.stack.core.types.structured.SessionDiagnosticsDataType;
 import org.eclipse.milo.opcua.stack.core.types.structured.SessionSecurityDiagnosticsDataType;
 import org.eclipse.milo.opcua.stack.core.types.structured.SubscriptionDiagnosticsDataType;
-import org.eclipse.milo.opcua.stack.core.util.FutureUtils;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public class SessionDiagnosticsObjectTypeNode extends BaseObjectTypeNode implements SessionDiagnosticsObjectType {
     public SessionDiagnosticsObjectTypeNode(OpcUaClient client, NodeId nodeId, NodeClass nodeClass,
@@ -74,19 +73,12 @@ public class SessionDiagnosticsObjectTypeNode extends BaseObjectTypeNode impleme
     }
 
     @Override
-    public CompletableFuture<Unit> writeSessionDiagnosticsAsync(
+    public CompletableFuture<StatusCode> writeSessionDiagnosticsAsync(
         SessionDiagnosticsDataType sessionDiagnostics) {
         ExtensionObject encoded = ExtensionObject.encode(client.getSerializationContext(), sessionDiagnostics);
         DataValue value = DataValue.valueOnly(new Variant(encoded));
         return getSessionDiagnosticsNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -145,19 +137,12 @@ public class SessionDiagnosticsObjectTypeNode extends BaseObjectTypeNode impleme
     }
 
     @Override
-    public CompletableFuture<Unit> writeSessionSecurityDiagnosticsAsync(
+    public CompletableFuture<StatusCode> writeSessionSecurityDiagnosticsAsync(
         SessionSecurityDiagnosticsDataType sessionSecurityDiagnostics) {
         ExtensionObject encoded = ExtensionObject.encode(client.getSerializationContext(), sessionSecurityDiagnostics);
         DataValue value = DataValue.valueOnly(new Variant(encoded));
         return getSessionSecurityDiagnosticsNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -216,19 +201,12 @@ public class SessionDiagnosticsObjectTypeNode extends BaseObjectTypeNode impleme
     }
 
     @Override
-    public CompletableFuture<Unit> writeSubscriptionDiagnosticsArrayAsync(
+    public CompletableFuture<StatusCode> writeSubscriptionDiagnosticsArrayAsync(
         SubscriptionDiagnosticsDataType[] subscriptionDiagnosticsArray) {
         ExtensionObject[] encoded = ExtensionObject.encodeArray(client.getSerializationContext(), subscriptionDiagnosticsArray);
         DataValue value = DataValue.valueOnly(new Variant(encoded));
         return getSubscriptionDiagnosticsArrayNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/SessionsDiagnosticsSummaryTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/SessionsDiagnosticsSummaryTypeNode.java
@@ -17,14 +17,13 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.ExtensionObject;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
 import org.eclipse.milo.opcua.stack.core.types.structured.SessionDiagnosticsDataType;
 import org.eclipse.milo.opcua.stack.core.types.structured.SessionSecurityDiagnosticsDataType;
-import org.eclipse.milo.opcua.stack.core.util.FutureUtils;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public class SessionsDiagnosticsSummaryTypeNode extends BaseObjectTypeNode implements SessionsDiagnosticsSummaryType {
     public SessionsDiagnosticsSummaryTypeNode(OpcUaClient client, NodeId nodeId, NodeClass nodeClass,
@@ -73,19 +72,12 @@ public class SessionsDiagnosticsSummaryTypeNode extends BaseObjectTypeNode imple
     }
 
     @Override
-    public CompletableFuture<Unit> writeSessionDiagnosticsArrayAsync(
+    public CompletableFuture<StatusCode> writeSessionDiagnosticsArrayAsync(
         SessionDiagnosticsDataType[] sessionDiagnosticsArray) {
         ExtensionObject[] encoded = ExtensionObject.encodeArray(client.getSerializationContext(), sessionDiagnosticsArray);
         DataValue value = DataValue.valueOnly(new Variant(encoded));
         return getSessionDiagnosticsArrayNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -146,19 +138,12 @@ public class SessionsDiagnosticsSummaryTypeNode extends BaseObjectTypeNode imple
     }
 
     @Override
-    public CompletableFuture<Unit> writeSessionSecurityDiagnosticsArrayAsync(
+    public CompletableFuture<StatusCode> writeSessionSecurityDiagnosticsArrayAsync(
         SessionSecurityDiagnosticsDataType[] sessionSecurityDiagnosticsArray) {
         ExtensionObject[] encoded = ExtensionObject.encodeArray(client.getSerializationContext(), sessionSecurityDiagnosticsArray);
         DataValue value = DataValue.valueOnly(new Variant(encoded));
         return getSessionSecurityDiagnosticsArrayNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/ShelvedStateMachineTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/ShelvedStateMachineTypeNode.java
@@ -15,12 +15,11 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
-import org.eclipse.milo.opcua.stack.core.util.FutureUtils;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public class ShelvedStateMachineTypeNode extends FiniteStateMachineTypeNode implements ShelvedStateMachineType {
     public ShelvedStateMachineTypeNode(OpcUaClient client, NodeId nodeId, NodeClass nodeClass,
@@ -65,17 +64,10 @@ public class ShelvedStateMachineTypeNode extends FiniteStateMachineTypeNode impl
     }
 
     @Override
-    public CompletableFuture<Unit> writeUnshelveTimeAsync(Double unshelveTime) {
+    public CompletableFuture<StatusCode> writeUnshelveTimeAsync(Double unshelveTime) {
         DataValue value = DataValue.valueOnly(new Variant(unshelveTime));
         return getUnshelveTimeNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/StateMachineTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/StateMachineTypeNode.java
@@ -16,12 +16,11 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
-import org.eclipse.milo.opcua.stack.core.util.FutureUtils;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public class StateMachineTypeNode extends BaseObjectTypeNode implements StateMachineType {
     public StateMachineTypeNode(OpcUaClient client, NodeId nodeId, NodeClass nodeClass,
@@ -66,17 +65,10 @@ public class StateMachineTypeNode extends BaseObjectTypeNode implements StateMac
     }
 
     @Override
-    public CompletableFuture<Unit> writeCurrentStateAsync(LocalizedText currentState) {
+    public CompletableFuture<StatusCode> writeCurrentStateAsync(LocalizedText currentState) {
         DataValue value = DataValue.valueOnly(new Variant(currentState));
         return getCurrentStateNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -130,17 +122,10 @@ public class StateMachineTypeNode extends BaseObjectTypeNode implements StateMac
     }
 
     @Override
-    public CompletableFuture<Unit> writeLastTransitionAsync(LocalizedText lastTransition) {
+    public CompletableFuture<StatusCode> writeLastTransitionAsync(LocalizedText lastTransition) {
         DataValue value = DataValue.valueOnly(new Variant(lastTransition));
         return getLastTransitionNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/StateTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/StateTypeNode.java
@@ -15,12 +15,11 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
-import org.eclipse.milo.opcua.stack.core.util.FutureUtils;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public class StateTypeNode extends BaseObjectTypeNode implements StateType {
     public StateTypeNode(OpcUaClient client, NodeId nodeId, NodeClass nodeClass,
@@ -65,17 +64,10 @@ public class StateTypeNode extends BaseObjectTypeNode implements StateType {
     }
 
     @Override
-    public CompletableFuture<Unit> writeStateNumberAsync(UInteger stateNumber) {
+    public CompletableFuture<StatusCode> writeStateNumberAsync(UInteger stateNumber) {
         DataValue value = DataValue.valueOnly(new Variant(stateNumber));
         return getStateNumberNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/TransitionEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/TransitionEventTypeNode.java
@@ -16,12 +16,11 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
-import org.eclipse.milo.opcua.stack.core.util.FutureUtils;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public class TransitionEventTypeNode extends BaseEventTypeNode implements TransitionEventType {
     public TransitionEventTypeNode(OpcUaClient client, NodeId nodeId, NodeClass nodeClass,
@@ -66,17 +65,10 @@ public class TransitionEventTypeNode extends BaseEventTypeNode implements Transi
     }
 
     @Override
-    public CompletableFuture<Unit> writeTransitionAsync(LocalizedText transition) {
+    public CompletableFuture<StatusCode> writeTransitionAsync(LocalizedText transition) {
         DataValue value = DataValue.valueOnly(new Variant(transition));
         return getTransitionNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -130,17 +122,10 @@ public class TransitionEventTypeNode extends BaseEventTypeNode implements Transi
     }
 
     @Override
-    public CompletableFuture<Unit> writeFromStateAsync(LocalizedText fromState) {
+    public CompletableFuture<StatusCode> writeFromStateAsync(LocalizedText fromState) {
         DataValue value = DataValue.valueOnly(new Variant(fromState));
         return getFromStateNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -194,17 +179,10 @@ public class TransitionEventTypeNode extends BaseEventTypeNode implements Transi
     }
 
     @Override
-    public CompletableFuture<Unit> writeToStateAsync(LocalizedText toState) {
+    public CompletableFuture<StatusCode> writeToStateAsync(LocalizedText toState) {
         DataValue value = DataValue.valueOnly(new Variant(toState));
         return getToStateNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/TransitionTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/TransitionTypeNode.java
@@ -15,12 +15,11 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
-import org.eclipse.milo.opcua.stack.core.util.FutureUtils;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public class TransitionTypeNode extends BaseObjectTypeNode implements TransitionType {
     public TransitionTypeNode(OpcUaClient client, NodeId nodeId, NodeClass nodeClass,
@@ -65,17 +64,10 @@ public class TransitionTypeNode extends BaseObjectTypeNode implements Transition
     }
 
     @Override
-    public CompletableFuture<Unit> writeTransitionNumberAsync(UInteger transitionNumber) {
+    public CompletableFuture<StatusCode> writeTransitionNumberAsync(UInteger transitionNumber) {
         DataValue value = DataValue.valueOnly(new Variant(transitionNumber));
         return getTransitionNumberNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/TransparentRedundancyTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/TransparentRedundancyTypeNode.java
@@ -16,13 +16,12 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.ExtensionObject;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
 import org.eclipse.milo.opcua.stack.core.types.structured.RedundantServerDataType;
-import org.eclipse.milo.opcua.stack.core.util.FutureUtils;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public class TransparentRedundancyTypeNode extends ServerRedundancyTypeNode implements TransparentRedundancyType {
     public TransparentRedundancyTypeNode(OpcUaClient client, NodeId nodeId, NodeClass nodeClass,
@@ -67,17 +66,10 @@ public class TransparentRedundancyTypeNode extends ServerRedundancyTypeNode impl
     }
 
     @Override
-    public CompletableFuture<Unit> writeCurrentServerIdAsync(String currentServerId) {
+    public CompletableFuture<StatusCode> writeCurrentServerIdAsync(String currentServerId) {
         DataValue value = DataValue.valueOnly(new Variant(currentServerId));
         return getCurrentServerIdNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override
@@ -134,19 +126,12 @@ public class TransparentRedundancyTypeNode extends ServerRedundancyTypeNode impl
     }
 
     @Override
-    public CompletableFuture<Unit> writeRedundantServerArrayAsync(
+    public CompletableFuture<StatusCode> writeRedundantServerArrayAsync(
         RedundantServerDataType[] redundantServerArray) {
         ExtensionObject[] encoded = ExtensionObject.encodeArray(client.getSerializationContext(), redundantServerArray);
         DataValue value = DataValue.valueOnly(new Variant(encoded));
         return getRedundantServerArrayNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/TrustListTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/objects/TrustListTypeNode.java
@@ -16,12 +16,11 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
-import org.eclipse.milo.opcua.stack.core.util.FutureUtils;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public class TrustListTypeNode extends FileTypeNode implements TrustListType {
     public TrustListTypeNode(OpcUaClient client, NodeId nodeId, NodeClass nodeClass,
@@ -66,17 +65,10 @@ public class TrustListTypeNode extends FileTypeNode implements TrustListType {
     }
 
     @Override
-    public CompletableFuture<Unit> writeLastUpdateTimeAsync(DateTime lastUpdateTime) {
+    public CompletableFuture<StatusCode> writeLastUpdateTimeAsync(DateTime lastUpdateTime) {
         DataValue value = DataValue.valueOnly(new Variant(lastUpdateTime));
         return getLastUpdateTimeNodeAsync()
-            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value))
-            .thenCompose(statusCode -> {
-                if (statusCode != null && statusCode.isBad()) {
-                    return FutureUtils.failedUaFuture(statusCode);
-                } else {
-                    return CompletableFuture.completedFuture(Unit.VALUE);
-                }
-            });
+            .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }
 
     @Override

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/variables/ArrayItemTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/variables/ArrayItemTypeNode.java
@@ -270,7 +270,14 @@ public class ArrayItemTypeNode extends DataItemTypeNode implements ArrayItemType
     @Override
     public AxisScaleEnumeration getAxisScaleType() throws UaException {
         PropertyTypeNode node = getAxisScaleTypeNode();
-        return (AxisScaleEnumeration) node.getValue().getValue().getValue();
+        Object value = node.getValue().getValue().getValue();
+        if (value instanceof Integer) {
+            return AxisScaleEnumeration.from((Integer) value);
+        } else if (value instanceof AxisScaleEnumeration) {
+            return (AxisScaleEnumeration) value;
+        } else {
+            return null;
+        }
     }
 
     @Override
@@ -299,7 +306,16 @@ public class ArrayItemTypeNode extends DataItemTypeNode implements ArrayItemType
 
     @Override
     public CompletableFuture<? extends AxisScaleEnumeration> readAxisScaleTypeAsync() {
-        return getAxisScaleTypeNodeAsync().thenCompose(node -> node.readAttributeAsync(AttributeId.Value)).thenApply(v -> (AxisScaleEnumeration) v.getValue().getValue());
+        return getAxisScaleTypeNodeAsync()
+            .thenCompose(node -> node.readAttributeAsync(AttributeId.Value))
+            .thenApply(v -> {
+                Object value = v.getValue().getValue();
+                if (value instanceof Integer) {
+                    return AxisScaleEnumeration.from((Integer) value);
+                } else {
+                    return null;
+                }
+            });
     }
 
     @Override

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/variables/ServerStatusTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/variables/ServerStatusTypeNode.java
@@ -150,7 +150,14 @@ public class ServerStatusTypeNode extends BaseDataVariableTypeNode implements Se
     @Override
     public ServerState getState() throws UaException {
         BaseDataVariableTypeNode node = getStateNode();
-        return (ServerState) node.getValue().getValue().getValue();
+        Object value = node.getValue().getValue().getValue();
+        if (value instanceof Integer) {
+            return ServerState.from((Integer) value);
+        } else if (value instanceof ServerState) {
+            return (ServerState) value;
+        } else {
+            return null;
+        }
     }
 
     @Override
@@ -179,7 +186,16 @@ public class ServerStatusTypeNode extends BaseDataVariableTypeNode implements Se
 
     @Override
     public CompletableFuture<? extends ServerState> readStateAsync() {
-        return getStateNodeAsync().thenCompose(node -> node.readAttributeAsync(AttributeId.Value)).thenApply(v -> (ServerState) v.getValue().getValue());
+        return getStateNodeAsync()
+            .thenCompose(node -> node.readAttributeAsync(AttributeId.Value))
+            .thenApply(v -> {
+                Object value = v.getValue().getValue();
+                if (value instanceof Integer) {
+                    return ServerState.from((Integer) value);
+                } else {
+                    return null;
+                }
+            });
     }
 
     @Override

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/variables/SessionSecurityDiagnosticsTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/variables/SessionSecurityDiagnosticsTypeNode.java
@@ -379,7 +379,14 @@ public class SessionSecurityDiagnosticsTypeNode extends BaseDataVariableTypeNode
     @Override
     public MessageSecurityMode getSecurityMode() throws UaException {
         BaseDataVariableTypeNode node = getSecurityModeNode();
-        return (MessageSecurityMode) node.getValue().getValue().getValue();
+        Object value = node.getValue().getValue().getValue();
+        if (value instanceof Integer) {
+            return MessageSecurityMode.from((Integer) value);
+        } else if (value instanceof MessageSecurityMode) {
+            return (MessageSecurityMode) value;
+        } else {
+            return null;
+        }
     }
 
     @Override
@@ -408,7 +415,16 @@ public class SessionSecurityDiagnosticsTypeNode extends BaseDataVariableTypeNode
 
     @Override
     public CompletableFuture<? extends MessageSecurityMode> readSecurityModeAsync() {
-        return getSecurityModeNodeAsync().thenCompose(node -> node.readAttributeAsync(AttributeId.Value)).thenApply(v -> (MessageSecurityMode) v.getValue().getValue());
+        return getSecurityModeNodeAsync()
+            .thenCompose(node -> node.readAttributeAsync(AttributeId.Value))
+            .thenApply(v -> {
+                Object value = v.getValue().getValue();
+                if (value instanceof Integer) {
+                    return MessageSecurityMode.from((Integer) value);
+                } else {
+                    return null;
+                }
+            });
     }
 
     @Override

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/variables/SubscriptionDiagnosticsTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/nodes/variables/SubscriptionDiagnosticsTypeNode.java
@@ -1788,9 +1788,9 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode im
     }
 
     @Override
-    public void setEventQueueOverflowCount(UInteger eventQueueOverFlowCount) throws UaException {
+    public void setEventQueueOverflowCount(UInteger eventQueueOverflowCount) throws UaException {
         BaseDataVariableTypeNode node = getEventQueueOverflowCountNode();
-        node.setValue(new Variant(eventQueueOverFlowCount));
+        node.setValue(new Variant(eventQueueOverflowCount));
     }
 
     @Override
@@ -1803,9 +1803,9 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode im
     }
 
     @Override
-    public void writeEventQueueOverflowCount(UInteger eventQueueOverFlowCount) throws UaException {
+    public void writeEventQueueOverflowCount(UInteger eventQueueOverflowCount) throws UaException {
         try {
-            writeEventQueueOverflowCountAsync(eventQueueOverFlowCount).get();
+            writeEventQueueOverflowCountAsync(eventQueueOverflowCount).get();
         } catch (ExecutionException | InterruptedException e) {
             throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
         }
@@ -1818,8 +1818,8 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode im
 
     @Override
     public CompletableFuture<StatusCode> writeEventQueueOverflowCountAsync(
-        UInteger eventQueueOverFlowCount) {
-        DataValue value = DataValue.valueOnly(new Variant(eventQueueOverFlowCount));
+        UInteger eventQueueOverflowCount) {
+        DataValue value = DataValue.valueOnly(new Variant(eventQueueOverflowCount));
         return getEventQueueOverflowCountNodeAsync()
             .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
     }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/AcknowledgeableConditionType.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/AcknowledgeableConditionType.java
@@ -5,7 +5,7 @@ import java.util.concurrent.CompletableFuture;
 import org.eclipse.milo.opcua.sdk.client.model.types.variables.TwoStateVariableType;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 
 public interface AcknowledgeableConditionType extends ConditionType {
     /**
@@ -58,9 +58,9 @@ public interface AcknowledgeableConditionType extends ConditionType {
      * An asynchronous implementation of {@link #writeEnabledState(LocalizedText)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeEnabledStateAsync(LocalizedText enabledState);
+    CompletableFuture<StatusCode> writeEnabledStateAsync(LocalizedText enabledState);
 
     /**
      * Get the EnabledState {@link TwoStateVariableType} Node, or {@code null} if it does not exist.
@@ -131,9 +131,9 @@ public interface AcknowledgeableConditionType extends ConditionType {
      * An asynchronous implementation of {@link #writeAckedState(LocalizedText)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeAckedStateAsync(LocalizedText ackedState);
+    CompletableFuture<StatusCode> writeAckedStateAsync(LocalizedText ackedState);
 
     /**
      * Get the AckedState {@link TwoStateVariableType} Node, or {@code null} if it does not exist.
@@ -204,9 +204,9 @@ public interface AcknowledgeableConditionType extends ConditionType {
      * An asynchronous implementation of {@link #writeConfirmedState(LocalizedText)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeConfirmedStateAsync(LocalizedText confirmedState);
+    CompletableFuture<StatusCode> writeConfirmedStateAsync(LocalizedText confirmedState);
 
     /**
      * Get the ConfirmedState {@link TwoStateVariableType} Node, or {@code null} if it does not exist.

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/AggregateConfigurationType.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/AggregateConfigurationType.java
@@ -7,8 +7,8 @@ import org.eclipse.milo.opcua.sdk.core.QualifiedProperty;
 import org.eclipse.milo.opcua.sdk.core.ValueRanks;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public interface AggregateConfigurationType extends BaseObjectType {
     QualifiedProperty<Boolean> TREAT_UNCERTAIN_AS_BAD = new QualifiedProperty<>(
@@ -93,9 +93,9 @@ public interface AggregateConfigurationType extends BaseObjectType {
      * An asynchronous implementation of {@link #writeTreatUncertainAsBad(Boolean)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeTreatUncertainAsBadAsync(Boolean treatUncertainAsBad);
+    CompletableFuture<StatusCode> writeTreatUncertainAsBadAsync(Boolean treatUncertainAsBad);
 
     /**
      * Get the TreatUncertainAsBad {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -166,9 +166,9 @@ public interface AggregateConfigurationType extends BaseObjectType {
      * An asynchronous implementation of {@link #writePercentDataBad(UByte)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writePercentDataBadAsync(UByte percentDataBad);
+    CompletableFuture<StatusCode> writePercentDataBadAsync(UByte percentDataBad);
 
     /**
      * Get the PercentDataBad {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -239,9 +239,9 @@ public interface AggregateConfigurationType extends BaseObjectType {
      * An asynchronous implementation of {@link #writePercentDataGood(UByte)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writePercentDataGoodAsync(UByte percentDataGood);
+    CompletableFuture<StatusCode> writePercentDataGoodAsync(UByte percentDataGood);
 
     /**
      * Get the PercentDataGood {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -312,9 +312,9 @@ public interface AggregateConfigurationType extends BaseObjectType {
      * An asynchronous implementation of {@link #writeUseSlopedExtrapolation(Boolean)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeUseSlopedExtrapolationAsync(Boolean useSlopedExtrapolation);
+    CompletableFuture<StatusCode> writeUseSlopedExtrapolationAsync(Boolean useSlopedExtrapolation);
 
     /**
      * Get the UseSlopedExtrapolation {@link PropertyType} Node, or {@code null} if it does not exist.

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/AlarmConditionType.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/AlarmConditionType.java
@@ -10,7 +10,7 @@ import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 
 public interface AlarmConditionType extends AcknowledgeableConditionType {
     QualifiedProperty<NodeId> INPUT_NODE = new QualifiedProperty<>(
@@ -87,9 +87,9 @@ public interface AlarmConditionType extends AcknowledgeableConditionType {
      * An asynchronous implementation of {@link #writeInputNode(NodeId)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeInputNodeAsync(NodeId inputNode);
+    CompletableFuture<StatusCode> writeInputNodeAsync(NodeId inputNode);
 
     /**
      * Get the InputNode {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -160,9 +160,9 @@ public interface AlarmConditionType extends AcknowledgeableConditionType {
      * An asynchronous implementation of {@link #writeSuppressedOrShelved(Boolean)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeSuppressedOrShelvedAsync(Boolean suppressedOrShelved);
+    CompletableFuture<StatusCode> writeSuppressedOrShelvedAsync(Boolean suppressedOrShelved);
 
     /**
      * Get the SuppressedOrShelved {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -233,9 +233,9 @@ public interface AlarmConditionType extends AcknowledgeableConditionType {
      * An asynchronous implementation of {@link #writeMaxTimeShelved(Double)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeMaxTimeShelvedAsync(Double maxTimeShelved);
+    CompletableFuture<StatusCode> writeMaxTimeShelvedAsync(Double maxTimeShelved);
 
     /**
      * Get the MaxTimeShelved {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -306,9 +306,9 @@ public interface AlarmConditionType extends AcknowledgeableConditionType {
      * An asynchronous implementation of {@link #writeEnabledState(LocalizedText)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeEnabledStateAsync(LocalizedText enabledState);
+    CompletableFuture<StatusCode> writeEnabledStateAsync(LocalizedText enabledState);
 
     /**
      * Get the EnabledState {@link TwoStateVariableType} Node, or {@code null} if it does not exist.
@@ -379,9 +379,9 @@ public interface AlarmConditionType extends AcknowledgeableConditionType {
      * An asynchronous implementation of {@link #writeActiveState(LocalizedText)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeActiveStateAsync(LocalizedText activeState);
+    CompletableFuture<StatusCode> writeActiveStateAsync(LocalizedText activeState);
 
     /**
      * Get the ActiveState {@link TwoStateVariableType} Node, or {@code null} if it does not exist.
@@ -452,9 +452,9 @@ public interface AlarmConditionType extends AcknowledgeableConditionType {
      * An asynchronous implementation of {@link #writeSuppressedState(LocalizedText)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeSuppressedStateAsync(LocalizedText suppressedState);
+    CompletableFuture<StatusCode> writeSuppressedStateAsync(LocalizedText suppressedState);
 
     /**
      * Get the SuppressedState {@link TwoStateVariableType} Node, or {@code null} if it does not exist.

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/AuditActivateSessionEventType.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/AuditActivateSessionEventType.java
@@ -7,9 +7,9 @@ import org.eclipse.milo.opcua.sdk.core.QualifiedProperty;
 import org.eclipse.milo.opcua.sdk.core.ValueRanks;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.structured.SignedSoftwareCertificate;
 import org.eclipse.milo.opcua.stack.core.types.structured.UserIdentityToken;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public interface AuditActivateSessionEventType extends AuditSessionEventType {
     QualifiedProperty<SignedSoftwareCertificate[]> CLIENT_SOFTWARE_CERTIFICATES = new QualifiedProperty<>(
@@ -88,9 +88,9 @@ public interface AuditActivateSessionEventType extends AuditSessionEventType {
      * An asynchronous implementation of {@link #writeClientSoftwareCertificates(SignedSoftwareCertificate[])}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeClientSoftwareCertificatesAsync(
+    CompletableFuture<StatusCode> writeClientSoftwareCertificatesAsync(
         SignedSoftwareCertificate[] clientSoftwareCertificates);
 
     /**
@@ -162,9 +162,9 @@ public interface AuditActivateSessionEventType extends AuditSessionEventType {
      * An asynchronous implementation of {@link #writeUserIdentityToken(UserIdentityToken)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeUserIdentityTokenAsync(UserIdentityToken userIdentityToken);
+    CompletableFuture<StatusCode> writeUserIdentityTokenAsync(UserIdentityToken userIdentityToken);
 
     /**
      * Get the UserIdentityToken {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -235,9 +235,9 @@ public interface AuditActivateSessionEventType extends AuditSessionEventType {
      * An asynchronous implementation of {@link #writeSecureChannelId(String)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeSecureChannelIdAsync(String secureChannelId);
+    CompletableFuture<StatusCode> writeSecureChannelIdAsync(String secureChannelId);
 
     /**
      * Get the SecureChannelId {@link PropertyType} Node, or {@code null} if it does not exist.

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/AuditAddNodesEventType.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/AuditAddNodesEventType.java
@@ -7,8 +7,8 @@ import org.eclipse.milo.opcua.sdk.core.QualifiedProperty;
 import org.eclipse.milo.opcua.sdk.core.ValueRanks;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.structured.AddNodesItem;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public interface AuditAddNodesEventType extends AuditNodeManagementEventType {
     QualifiedProperty<AddNodesItem[]> NODES_TO_ADD = new QualifiedProperty<>(
@@ -69,9 +69,9 @@ public interface AuditAddNodesEventType extends AuditNodeManagementEventType {
      * An asynchronous implementation of {@link #writeNodesToAdd(AddNodesItem[])}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeNodesToAddAsync(AddNodesItem[] nodesToAdd);
+    CompletableFuture<StatusCode> writeNodesToAddAsync(AddNodesItem[] nodesToAdd);
 
     /**
      * Get the NodesToAdd {@link PropertyType} Node, or {@code null} if it does not exist.

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/AuditAddReferencesEventType.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/AuditAddReferencesEventType.java
@@ -7,8 +7,8 @@ import org.eclipse.milo.opcua.sdk.core.QualifiedProperty;
 import org.eclipse.milo.opcua.sdk.core.ValueRanks;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.structured.AddReferencesItem;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public interface AuditAddReferencesEventType extends AuditNodeManagementEventType {
     QualifiedProperty<AddReferencesItem[]> REFERENCES_TO_ADD = new QualifiedProperty<>(
@@ -69,9 +69,9 @@ public interface AuditAddReferencesEventType extends AuditNodeManagementEventTyp
      * An asynchronous implementation of {@link #writeReferencesToAdd(AddReferencesItem[])}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeReferencesToAddAsync(AddReferencesItem[] referencesToAdd);
+    CompletableFuture<StatusCode> writeReferencesToAddAsync(AddReferencesItem[] referencesToAdd);
 
     /**
      * Get the ReferencesToAdd {@link PropertyType} Node, or {@code null} if it does not exist.

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/AuditCancelEventType.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/AuditCancelEventType.java
@@ -7,8 +7,8 @@ import org.eclipse.milo.opcua.sdk.core.QualifiedProperty;
 import org.eclipse.milo.opcua.sdk.core.ValueRanks;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public interface AuditCancelEventType extends AuditSessionEventType {
     QualifiedProperty<UInteger> REQUEST_HANDLE = new QualifiedProperty<>(
@@ -69,9 +69,9 @@ public interface AuditCancelEventType extends AuditSessionEventType {
      * An asynchronous implementation of {@link #writeRequestHandle(UInteger)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeRequestHandleAsync(UInteger requestHandle);
+    CompletableFuture<StatusCode> writeRequestHandleAsync(UInteger requestHandle);
 
     /**
      * Get the RequestHandle {@link PropertyType} Node, or {@code null} if it does not exist.

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/AuditCertificateDataMismatchEventType.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/AuditCertificateDataMismatchEventType.java
@@ -7,7 +7,7 @@ import org.eclipse.milo.opcua.sdk.core.QualifiedProperty;
 import org.eclipse.milo.opcua.sdk.core.ValueRanks;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 
 public interface AuditCertificateDataMismatchEventType extends AuditCertificateEventType {
     QualifiedProperty<String> INVALID_HOSTNAME = new QualifiedProperty<>(
@@ -76,9 +76,9 @@ public interface AuditCertificateDataMismatchEventType extends AuditCertificateE
      * An asynchronous implementation of {@link #writeInvalidHostname(String)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeInvalidHostnameAsync(String invalidHostname);
+    CompletableFuture<StatusCode> writeInvalidHostnameAsync(String invalidHostname);
 
     /**
      * Get the InvalidHostname {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -149,9 +149,9 @@ public interface AuditCertificateDataMismatchEventType extends AuditCertificateE
      * An asynchronous implementation of {@link #writeInvalidUri(String)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeInvalidUriAsync(String invalidUri);
+    CompletableFuture<StatusCode> writeInvalidUriAsync(String invalidUri);
 
     /**
      * Get the InvalidUri {@link PropertyType} Node, or {@code null} if it does not exist.

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/AuditCertificateEventType.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/AuditCertificateEventType.java
@@ -8,7 +8,7 @@ import org.eclipse.milo.opcua.sdk.core.ValueRanks;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 
 public interface AuditCertificateEventType extends AuditSecurityEventType {
     QualifiedProperty<ByteString> CERTIFICATE = new QualifiedProperty<>(
@@ -69,9 +69,9 @@ public interface AuditCertificateEventType extends AuditSecurityEventType {
      * An asynchronous implementation of {@link #writeCertificate(ByteString)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeCertificateAsync(ByteString certificate);
+    CompletableFuture<StatusCode> writeCertificateAsync(ByteString certificate);
 
     /**
      * Get the Certificate {@link PropertyType} Node, or {@code null} if it does not exist.

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/AuditChannelEventType.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/AuditChannelEventType.java
@@ -7,7 +7,7 @@ import org.eclipse.milo.opcua.sdk.core.QualifiedProperty;
 import org.eclipse.milo.opcua.sdk.core.ValueRanks;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 
 public interface AuditChannelEventType extends AuditSecurityEventType {
     QualifiedProperty<String> SECURE_CHANNEL_ID = new QualifiedProperty<>(
@@ -68,9 +68,9 @@ public interface AuditChannelEventType extends AuditSecurityEventType {
      * An asynchronous implementation of {@link #writeSecureChannelId(String)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeSecureChannelIdAsync(String secureChannelId);
+    CompletableFuture<StatusCode> writeSecureChannelIdAsync(String secureChannelId);
 
     /**
      * Get the SecureChannelId {@link PropertyType} Node, or {@code null} if it does not exist.

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/AuditConditionAcknowledgeEventType.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/AuditConditionAcknowledgeEventType.java
@@ -9,7 +9,7 @@ import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 
 public interface AuditConditionAcknowledgeEventType extends AuditConditionEventType {
     QualifiedProperty<ByteString> CONDITION_EVENT_ID = new QualifiedProperty<>(
@@ -78,9 +78,9 @@ public interface AuditConditionAcknowledgeEventType extends AuditConditionEventT
      * An asynchronous implementation of {@link #writeConditionEventId(ByteString)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeConditionEventIdAsync(ByteString conditionEventId);
+    CompletableFuture<StatusCode> writeConditionEventIdAsync(ByteString conditionEventId);
 
     /**
      * Get the ConditionEventId {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -151,9 +151,9 @@ public interface AuditConditionAcknowledgeEventType extends AuditConditionEventT
      * An asynchronous implementation of {@link #writeComment(LocalizedText)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeCommentAsync(LocalizedText comment);
+    CompletableFuture<StatusCode> writeCommentAsync(LocalizedText comment);
 
     /**
      * Get the Comment {@link PropertyType} Node, or {@code null} if it does not exist.

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/AuditConditionCommentEventType.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/AuditConditionCommentEventType.java
@@ -9,7 +9,7 @@ import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 
 public interface AuditConditionCommentEventType extends AuditConditionEventType {
     QualifiedProperty<ByteString> CONDITION_EVENT_ID = new QualifiedProperty<>(
@@ -78,9 +78,9 @@ public interface AuditConditionCommentEventType extends AuditConditionEventType 
      * An asynchronous implementation of {@link #writeConditionEventId(ByteString)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeConditionEventIdAsync(ByteString conditionEventId);
+    CompletableFuture<StatusCode> writeConditionEventIdAsync(ByteString conditionEventId);
 
     /**
      * Get the ConditionEventId {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -151,9 +151,9 @@ public interface AuditConditionCommentEventType extends AuditConditionEventType 
      * An asynchronous implementation of {@link #writeComment(LocalizedText)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeCommentAsync(LocalizedText comment);
+    CompletableFuture<StatusCode> writeCommentAsync(LocalizedText comment);
 
     /**
      * Get the Comment {@link PropertyType} Node, or {@code null} if it does not exist.

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/AuditConditionConfirmEventType.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/AuditConditionConfirmEventType.java
@@ -9,7 +9,7 @@ import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 
 public interface AuditConditionConfirmEventType extends AuditConditionEventType {
     QualifiedProperty<ByteString> CONDITION_EVENT_ID = new QualifiedProperty<>(
@@ -78,9 +78,9 @@ public interface AuditConditionConfirmEventType extends AuditConditionEventType 
      * An asynchronous implementation of {@link #writeConditionEventId(ByteString)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeConditionEventIdAsync(ByteString conditionEventId);
+    CompletableFuture<StatusCode> writeConditionEventIdAsync(ByteString conditionEventId);
 
     /**
      * Get the ConditionEventId {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -151,9 +151,9 @@ public interface AuditConditionConfirmEventType extends AuditConditionEventType 
      * An asynchronous implementation of {@link #writeComment(LocalizedText)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeCommentAsync(LocalizedText comment);
+    CompletableFuture<StatusCode> writeCommentAsync(LocalizedText comment);
 
     /**
      * Get the Comment {@link PropertyType} Node, or {@code null} if it does not exist.

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/AuditConditionRespondEventType.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/AuditConditionRespondEventType.java
@@ -7,7 +7,7 @@ import org.eclipse.milo.opcua.sdk.core.QualifiedProperty;
 import org.eclipse.milo.opcua.sdk.core.ValueRanks;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 
 public interface AuditConditionRespondEventType extends AuditConditionEventType {
     QualifiedProperty<Integer> SELECTED_RESPONSE = new QualifiedProperty<>(
@@ -68,9 +68,9 @@ public interface AuditConditionRespondEventType extends AuditConditionEventType 
      * An asynchronous implementation of {@link #writeSelectedResponse(Integer)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeSelectedResponseAsync(Integer selectedResponse);
+    CompletableFuture<StatusCode> writeSelectedResponseAsync(Integer selectedResponse);
 
     /**
      * Get the SelectedResponse {@link PropertyType} Node, or {@code null} if it does not exist.

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/AuditConditionShelvingEventType.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/AuditConditionShelvingEventType.java
@@ -7,7 +7,7 @@ import org.eclipse.milo.opcua.sdk.core.QualifiedProperty;
 import org.eclipse.milo.opcua.sdk.core.ValueRanks;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 
 public interface AuditConditionShelvingEventType extends AuditConditionEventType {
     QualifiedProperty<Double> SHELVING_TIME = new QualifiedProperty<>(
@@ -68,9 +68,9 @@ public interface AuditConditionShelvingEventType extends AuditConditionEventType
      * An asynchronous implementation of {@link #writeShelvingTime(Double)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeShelvingTimeAsync(Double shelvingTime);
+    CompletableFuture<StatusCode> writeShelvingTimeAsync(Double shelvingTime);
 
     /**
      * Get the ShelvingTime {@link PropertyType} Node, or {@code null} if it does not exist.

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/AuditCreateSessionEventType.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/AuditCreateSessionEventType.java
@@ -8,7 +8,7 @@ import org.eclipse.milo.opcua.sdk.core.ValueRanks;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 
 public interface AuditCreateSessionEventType extends AuditSessionEventType {
     QualifiedProperty<String> SECURE_CHANNEL_ID = new QualifiedProperty<>(
@@ -93,9 +93,9 @@ public interface AuditCreateSessionEventType extends AuditSessionEventType {
      * An asynchronous implementation of {@link #writeSecureChannelId(String)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeSecureChannelIdAsync(String secureChannelId);
+    CompletableFuture<StatusCode> writeSecureChannelIdAsync(String secureChannelId);
 
     /**
      * Get the SecureChannelId {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -166,9 +166,9 @@ public interface AuditCreateSessionEventType extends AuditSessionEventType {
      * An asynchronous implementation of {@link #writeClientCertificate(ByteString)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeClientCertificateAsync(ByteString clientCertificate);
+    CompletableFuture<StatusCode> writeClientCertificateAsync(ByteString clientCertificate);
 
     /**
      * Get the ClientCertificate {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -239,9 +239,10 @@ public interface AuditCreateSessionEventType extends AuditSessionEventType {
      * An asynchronous implementation of {@link #writeClientCertificateThumbprint(String)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeClientCertificateThumbprintAsync(String clientCertificateThumbprint);
+    CompletableFuture<StatusCode> writeClientCertificateThumbprintAsync(
+        String clientCertificateThumbprint);
 
     /**
      * Get the ClientCertificateThumbprint {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -312,9 +313,9 @@ public interface AuditCreateSessionEventType extends AuditSessionEventType {
      * An asynchronous implementation of {@link #writeRevisedSessionTimeout(Double)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeRevisedSessionTimeoutAsync(Double revisedSessionTimeout);
+    CompletableFuture<StatusCode> writeRevisedSessionTimeoutAsync(Double revisedSessionTimeout);
 
     /**
      * Get the RevisedSessionTimeout {@link PropertyType} Node, or {@code null} if it does not exist.

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/AuditDeleteNodesEventType.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/AuditDeleteNodesEventType.java
@@ -7,8 +7,8 @@ import org.eclipse.milo.opcua.sdk.core.QualifiedProperty;
 import org.eclipse.milo.opcua.sdk.core.ValueRanks;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.structured.DeleteNodesItem;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public interface AuditDeleteNodesEventType extends AuditNodeManagementEventType {
     QualifiedProperty<DeleteNodesItem[]> NODES_TO_DELETE = new QualifiedProperty<>(
@@ -69,9 +69,9 @@ public interface AuditDeleteNodesEventType extends AuditNodeManagementEventType 
      * An asynchronous implementation of {@link #writeNodesToDelete(DeleteNodesItem[])}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeNodesToDeleteAsync(DeleteNodesItem[] nodesToDelete);
+    CompletableFuture<StatusCode> writeNodesToDeleteAsync(DeleteNodesItem[] nodesToDelete);
 
     /**
      * Get the NodesToDelete {@link PropertyType} Node, or {@code null} if it does not exist.

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/AuditDeleteReferencesEventType.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/AuditDeleteReferencesEventType.java
@@ -7,8 +7,8 @@ import org.eclipse.milo.opcua.sdk.core.QualifiedProperty;
 import org.eclipse.milo.opcua.sdk.core.ValueRanks;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.structured.DeleteReferencesItem;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public interface AuditDeleteReferencesEventType extends AuditNodeManagementEventType {
     QualifiedProperty<DeleteReferencesItem[]> REFERENCES_TO_DELETE = new QualifiedProperty<>(
@@ -69,9 +69,10 @@ public interface AuditDeleteReferencesEventType extends AuditNodeManagementEvent
      * An asynchronous implementation of {@link #writeReferencesToDelete(DeleteReferencesItem[])}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeReferencesToDeleteAsync(DeleteReferencesItem[] referencesToDelete);
+    CompletableFuture<StatusCode> writeReferencesToDeleteAsync(
+        DeleteReferencesItem[] referencesToDelete);
 
     /**
      * Get the ReferencesToDelete {@link PropertyType} Node, or {@code null} if it does not exist.

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/AuditEventType.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/AuditEventType.java
@@ -8,7 +8,7 @@ import org.eclipse.milo.opcua.sdk.core.ValueRanks;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 
 public interface AuditEventType extends BaseEventType {
     QualifiedProperty<DateTime> ACTION_TIME_STAMP = new QualifiedProperty<>(
@@ -101,9 +101,9 @@ public interface AuditEventType extends BaseEventType {
      * An asynchronous implementation of {@link #writeActionTimeStamp(DateTime)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeActionTimeStampAsync(DateTime actionTimeStamp);
+    CompletableFuture<StatusCode> writeActionTimeStampAsync(DateTime actionTimeStamp);
 
     /**
      * Get the ActionTimeStamp {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -174,9 +174,9 @@ public interface AuditEventType extends BaseEventType {
      * An asynchronous implementation of {@link #writeStatus(Boolean)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeStatusAsync(Boolean status);
+    CompletableFuture<StatusCode> writeStatusAsync(Boolean status);
 
     /**
      * Get the Status {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -247,9 +247,9 @@ public interface AuditEventType extends BaseEventType {
      * An asynchronous implementation of {@link #writeServerId(String)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeServerIdAsync(String serverId);
+    CompletableFuture<StatusCode> writeServerIdAsync(String serverId);
 
     /**
      * Get the ServerId {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -320,9 +320,9 @@ public interface AuditEventType extends BaseEventType {
      * An asynchronous implementation of {@link #writeClientAuditEntryId(String)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeClientAuditEntryIdAsync(String clientAuditEntryId);
+    CompletableFuture<StatusCode> writeClientAuditEntryIdAsync(String clientAuditEntryId);
 
     /**
      * Get the ClientAuditEntryId {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -393,9 +393,9 @@ public interface AuditEventType extends BaseEventType {
      * An asynchronous implementation of {@link #writeClientUserId(String)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeClientUserIdAsync(String clientUserId);
+    CompletableFuture<StatusCode> writeClientUserIdAsync(String clientUserId);
 
     /**
      * Get the ClientUserId {@link PropertyType} Node, or {@code null} if it does not exist.

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/AuditHistoryAtTimeDeleteEventType.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/AuditHistoryAtTimeDeleteEventType.java
@@ -9,7 +9,7 @@ import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
 import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 
 public interface AuditHistoryAtTimeDeleteEventType extends AuditHistoryDeleteEventType {
     QualifiedProperty<DateTime[]> REQ_TIMES = new QualifiedProperty<>(
@@ -78,9 +78,9 @@ public interface AuditHistoryAtTimeDeleteEventType extends AuditHistoryDeleteEve
      * An asynchronous implementation of {@link #writeReqTimes(DateTime[])}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeReqTimesAsync(DateTime[] reqTimes);
+    CompletableFuture<StatusCode> writeReqTimesAsync(DateTime[] reqTimes);
 
     /**
      * Get the ReqTimes {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -151,9 +151,9 @@ public interface AuditHistoryAtTimeDeleteEventType extends AuditHistoryDeleteEve
      * An asynchronous implementation of {@link #writeOldValues(DataValue[])}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeOldValuesAsync(DataValue[] oldValues);
+    CompletableFuture<StatusCode> writeOldValuesAsync(DataValue[] oldValues);
 
     /**
      * Get the OldValues {@link PropertyType} Node, or {@code null} if it does not exist.

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/AuditHistoryDeleteEventType.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/AuditHistoryDeleteEventType.java
@@ -8,7 +8,7 @@ import org.eclipse.milo.opcua.sdk.core.ValueRanks;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 
 public interface AuditHistoryDeleteEventType extends AuditHistoryUpdateEventType {
     QualifiedProperty<NodeId> UPDATED_NODE = new QualifiedProperty<>(
@@ -69,9 +69,9 @@ public interface AuditHistoryDeleteEventType extends AuditHistoryUpdateEventType
      * An asynchronous implementation of {@link #writeUpdatedNode(NodeId)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeUpdatedNodeAsync(NodeId updatedNode);
+    CompletableFuture<StatusCode> writeUpdatedNodeAsync(NodeId updatedNode);
 
     /**
      * Get the UpdatedNode {@link PropertyType} Node, or {@code null} if it does not exist.

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/AuditHistoryEventDeleteEventType.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/AuditHistoryEventDeleteEventType.java
@@ -8,8 +8,8 @@ import org.eclipse.milo.opcua.sdk.core.ValueRanks;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.structured.HistoryEventFieldList;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public interface AuditHistoryEventDeleteEventType extends AuditHistoryDeleteEventType {
     QualifiedProperty<ByteString[]> EVENT_IDS = new QualifiedProperty<>(
@@ -78,9 +78,9 @@ public interface AuditHistoryEventDeleteEventType extends AuditHistoryDeleteEven
      * An asynchronous implementation of {@link #writeEventIds(ByteString[])}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeEventIdsAsync(ByteString[] eventIds);
+    CompletableFuture<StatusCode> writeEventIdsAsync(ByteString[] eventIds);
 
     /**
      * Get the EventIds {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -151,9 +151,9 @@ public interface AuditHistoryEventDeleteEventType extends AuditHistoryDeleteEven
      * An asynchronous implementation of {@link #writeOldValues(HistoryEventFieldList)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeOldValuesAsync(HistoryEventFieldList oldValues);
+    CompletableFuture<StatusCode> writeOldValuesAsync(HistoryEventFieldList oldValues);
 
     /**
      * Get the OldValues {@link PropertyType} Node, or {@code null} if it does not exist.

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/AuditHistoryEventUpdateEventType.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/AuditHistoryEventUpdateEventType.java
@@ -8,10 +8,10 @@ import org.eclipse.milo.opcua.sdk.core.ValueRanks;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.PerformUpdateType;
 import org.eclipse.milo.opcua.stack.core.types.structured.EventFilter;
 import org.eclipse.milo.opcua.stack.core.types.structured.HistoryEventFieldList;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public interface AuditHistoryEventUpdateEventType extends AuditHistoryUpdateEventType {
     QualifiedProperty<NodeId> UPDATED_NODE = new QualifiedProperty<>(
@@ -104,9 +104,9 @@ public interface AuditHistoryEventUpdateEventType extends AuditHistoryUpdateEven
      * An asynchronous implementation of {@link #writeUpdatedNode(NodeId)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeUpdatedNodeAsync(NodeId updatedNode);
+    CompletableFuture<StatusCode> writeUpdatedNodeAsync(NodeId updatedNode);
 
     /**
      * Get the UpdatedNode {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -177,9 +177,10 @@ public interface AuditHistoryEventUpdateEventType extends AuditHistoryUpdateEven
      * An asynchronous implementation of {@link #writePerformInsertReplace(PerformUpdateType)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writePerformInsertReplaceAsync(PerformUpdateType performInsertReplace);
+    CompletableFuture<StatusCode> writePerformInsertReplaceAsync(
+        PerformUpdateType performInsertReplace);
 
     /**
      * Get the PerformInsertReplace {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -250,9 +251,9 @@ public interface AuditHistoryEventUpdateEventType extends AuditHistoryUpdateEven
      * An asynchronous implementation of {@link #writeFilter(EventFilter)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeFilterAsync(EventFilter filter);
+    CompletableFuture<StatusCode> writeFilterAsync(EventFilter filter);
 
     /**
      * Get the Filter {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -323,9 +324,9 @@ public interface AuditHistoryEventUpdateEventType extends AuditHistoryUpdateEven
      * An asynchronous implementation of {@link #writeNewValues(HistoryEventFieldList[])}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeNewValuesAsync(HistoryEventFieldList[] newValues);
+    CompletableFuture<StatusCode> writeNewValuesAsync(HistoryEventFieldList[] newValues);
 
     /**
      * Get the NewValues {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -396,9 +397,9 @@ public interface AuditHistoryEventUpdateEventType extends AuditHistoryUpdateEven
      * An asynchronous implementation of {@link #writeOldValues(HistoryEventFieldList[])}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeOldValuesAsync(HistoryEventFieldList[] oldValues);
+    CompletableFuture<StatusCode> writeOldValuesAsync(HistoryEventFieldList[] oldValues);
 
     /**
      * Get the OldValues {@link PropertyType} Node, or {@code null} if it does not exist.

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/AuditHistoryRawModifyDeleteEventType.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/AuditHistoryRawModifyDeleteEventType.java
@@ -9,7 +9,7 @@ import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
 import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 
 public interface AuditHistoryRawModifyDeleteEventType extends AuditHistoryDeleteEventType {
     QualifiedProperty<Boolean> IS_DELETE_MODIFIED = new QualifiedProperty<>(
@@ -94,9 +94,9 @@ public interface AuditHistoryRawModifyDeleteEventType extends AuditHistoryDelete
      * An asynchronous implementation of {@link #writeIsDeleteModified(Boolean)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeIsDeleteModifiedAsync(Boolean isDeleteModified);
+    CompletableFuture<StatusCode> writeIsDeleteModifiedAsync(Boolean isDeleteModified);
 
     /**
      * Get the IsDeleteModified {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -167,9 +167,9 @@ public interface AuditHistoryRawModifyDeleteEventType extends AuditHistoryDelete
      * An asynchronous implementation of {@link #writeStartTime(DateTime)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeStartTimeAsync(DateTime startTime);
+    CompletableFuture<StatusCode> writeStartTimeAsync(DateTime startTime);
 
     /**
      * Get the StartTime {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -240,9 +240,9 @@ public interface AuditHistoryRawModifyDeleteEventType extends AuditHistoryDelete
      * An asynchronous implementation of {@link #writeEndTime(DateTime)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeEndTimeAsync(DateTime endTime);
+    CompletableFuture<StatusCode> writeEndTimeAsync(DateTime endTime);
 
     /**
      * Get the EndTime {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -313,9 +313,9 @@ public interface AuditHistoryRawModifyDeleteEventType extends AuditHistoryDelete
      * An asynchronous implementation of {@link #writeOldValues(DataValue[])}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeOldValuesAsync(DataValue[] oldValues);
+    CompletableFuture<StatusCode> writeOldValuesAsync(DataValue[] oldValues);
 
     /**
      * Get the OldValues {@link PropertyType} Node, or {@code null} if it does not exist.

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/AuditHistoryUpdateEventType.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/AuditHistoryUpdateEventType.java
@@ -8,7 +8,7 @@ import org.eclipse.milo.opcua.sdk.core.ValueRanks;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 
 public interface AuditHistoryUpdateEventType extends AuditUpdateEventType {
     QualifiedProperty<NodeId> PARAMETER_DATA_TYPE_ID = new QualifiedProperty<>(
@@ -69,9 +69,9 @@ public interface AuditHistoryUpdateEventType extends AuditUpdateEventType {
      * An asynchronous implementation of {@link #writeParameterDataTypeId(NodeId)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeParameterDataTypeIdAsync(NodeId parameterDataTypeId);
+    CompletableFuture<StatusCode> writeParameterDataTypeIdAsync(NodeId parameterDataTypeId);
 
     /**
      * Get the ParameterDataTypeId {@link PropertyType} Node, or {@code null} if it does not exist.

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/AuditHistoryValueUpdateEventType.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/AuditHistoryValueUpdateEventType.java
@@ -9,8 +9,8 @@ import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.PerformUpdateType;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public interface AuditHistoryValueUpdateEventType extends AuditHistoryUpdateEventType {
     QualifiedProperty<NodeId> UPDATED_NODE = new QualifiedProperty<>(
@@ -95,9 +95,9 @@ public interface AuditHistoryValueUpdateEventType extends AuditHistoryUpdateEven
      * An asynchronous implementation of {@link #writeUpdatedNode(NodeId)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeUpdatedNodeAsync(NodeId updatedNode);
+    CompletableFuture<StatusCode> writeUpdatedNodeAsync(NodeId updatedNode);
 
     /**
      * Get the UpdatedNode {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -168,9 +168,10 @@ public interface AuditHistoryValueUpdateEventType extends AuditHistoryUpdateEven
      * An asynchronous implementation of {@link #writePerformInsertReplace(PerformUpdateType)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writePerformInsertReplaceAsync(PerformUpdateType performInsertReplace);
+    CompletableFuture<StatusCode> writePerformInsertReplaceAsync(
+        PerformUpdateType performInsertReplace);
 
     /**
      * Get the PerformInsertReplace {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -241,9 +242,9 @@ public interface AuditHistoryValueUpdateEventType extends AuditHistoryUpdateEven
      * An asynchronous implementation of {@link #writeNewValues(DataValue[])}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeNewValuesAsync(DataValue[] newValues);
+    CompletableFuture<StatusCode> writeNewValuesAsync(DataValue[] newValues);
 
     /**
      * Get the NewValues {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -314,9 +315,9 @@ public interface AuditHistoryValueUpdateEventType extends AuditHistoryUpdateEven
      * An asynchronous implementation of {@link #writeOldValues(DataValue[])}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeOldValuesAsync(DataValue[] oldValues);
+    CompletableFuture<StatusCode> writeOldValuesAsync(DataValue[] oldValues);
 
     /**
      * Get the OldValues {@link PropertyType} Node, or {@code null} if it does not exist.

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/AuditOpenSecureChannelEventType.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/AuditOpenSecureChannelEventType.java
@@ -8,9 +8,9 @@ import org.eclipse.milo.opcua.sdk.core.ValueRanks;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.MessageSecurityMode;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.SecurityTokenRequestType;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public interface AuditOpenSecureChannelEventType extends AuditChannelEventType {
     QualifiedProperty<ByteString> CLIENT_CERTIFICATE = new QualifiedProperty<>(
@@ -111,9 +111,9 @@ public interface AuditOpenSecureChannelEventType extends AuditChannelEventType {
      * An asynchronous implementation of {@link #writeClientCertificate(ByteString)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeClientCertificateAsync(ByteString clientCertificate);
+    CompletableFuture<StatusCode> writeClientCertificateAsync(ByteString clientCertificate);
 
     /**
      * Get the ClientCertificate {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -184,9 +184,10 @@ public interface AuditOpenSecureChannelEventType extends AuditChannelEventType {
      * An asynchronous implementation of {@link #writeClientCertificateThumbprint(String)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeClientCertificateThumbprintAsync(String clientCertificateThumbprint);
+    CompletableFuture<StatusCode> writeClientCertificateThumbprintAsync(
+        String clientCertificateThumbprint);
 
     /**
      * Get the ClientCertificateThumbprint {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -257,9 +258,9 @@ public interface AuditOpenSecureChannelEventType extends AuditChannelEventType {
      * An asynchronous implementation of {@link #writeRequestType(SecurityTokenRequestType)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeRequestTypeAsync(SecurityTokenRequestType requestType);
+    CompletableFuture<StatusCode> writeRequestTypeAsync(SecurityTokenRequestType requestType);
 
     /**
      * Get the RequestType {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -330,9 +331,9 @@ public interface AuditOpenSecureChannelEventType extends AuditChannelEventType {
      * An asynchronous implementation of {@link #writeSecurityPolicyUri(String)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeSecurityPolicyUriAsync(String securityPolicyUri);
+    CompletableFuture<StatusCode> writeSecurityPolicyUriAsync(String securityPolicyUri);
 
     /**
      * Get the SecurityPolicyUri {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -403,9 +404,9 @@ public interface AuditOpenSecureChannelEventType extends AuditChannelEventType {
      * An asynchronous implementation of {@link #writeSecurityMode(MessageSecurityMode)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeSecurityModeAsync(MessageSecurityMode securityMode);
+    CompletableFuture<StatusCode> writeSecurityModeAsync(MessageSecurityMode securityMode);
 
     /**
      * Get the SecurityMode {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -476,9 +477,9 @@ public interface AuditOpenSecureChannelEventType extends AuditChannelEventType {
      * An asynchronous implementation of {@link #writeRequestedLifetime(Double)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeRequestedLifetimeAsync(Double requestedLifetime);
+    CompletableFuture<StatusCode> writeRequestedLifetimeAsync(Double requestedLifetime);
 
     /**
      * Get the RequestedLifetime {@link PropertyType} Node, or {@code null} if it does not exist.

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/AuditProgramTransitionEventType.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/AuditProgramTransitionEventType.java
@@ -7,8 +7,8 @@ import org.eclipse.milo.opcua.sdk.core.QualifiedProperty;
 import org.eclipse.milo.opcua.sdk.core.ValueRanks;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public interface AuditProgramTransitionEventType extends AuditUpdateStateEventType {
     QualifiedProperty<UInteger> TRANSITION_NUMBER = new QualifiedProperty<>(
@@ -69,9 +69,9 @@ public interface AuditProgramTransitionEventType extends AuditUpdateStateEventTy
      * An asynchronous implementation of {@link #writeTransitionNumber(UInteger)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeTransitionNumberAsync(UInteger transitionNumber);
+    CompletableFuture<StatusCode> writeTransitionNumberAsync(UInteger transitionNumber);
 
     /**
      * Get the TransitionNumber {@link PropertyType} Node, or {@code null} if it does not exist.

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/AuditSessionEventType.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/AuditSessionEventType.java
@@ -8,7 +8,7 @@ import org.eclipse.milo.opcua.sdk.core.ValueRanks;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 
 public interface AuditSessionEventType extends AuditSecurityEventType {
     QualifiedProperty<NodeId> SESSION_ID = new QualifiedProperty<>(
@@ -69,9 +69,9 @@ public interface AuditSessionEventType extends AuditSecurityEventType {
      * An asynchronous implementation of {@link #writeSessionId(NodeId)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeSessionIdAsync(NodeId sessionId);
+    CompletableFuture<StatusCode> writeSessionIdAsync(NodeId sessionId);
 
     /**
      * Get the SessionId {@link PropertyType} Node, or {@code null} if it does not exist.

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/AuditUpdateMethodEventType.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/AuditUpdateMethodEventType.java
@@ -8,7 +8,7 @@ import org.eclipse.milo.opcua.sdk.core.ValueRanks;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 
 public interface AuditUpdateMethodEventType extends AuditEventType {
     QualifiedProperty<NodeId> METHOD_ID = new QualifiedProperty<>(
@@ -77,9 +77,9 @@ public interface AuditUpdateMethodEventType extends AuditEventType {
      * An asynchronous implementation of {@link #writeMethodId(NodeId)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeMethodIdAsync(NodeId methodId);
+    CompletableFuture<StatusCode> writeMethodIdAsync(NodeId methodId);
 
     /**
      * Get the MethodId {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -150,9 +150,9 @@ public interface AuditUpdateMethodEventType extends AuditEventType {
      * An asynchronous implementation of {@link #writeInputArguments(Object[])}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeInputArgumentsAsync(Object[] inputArguments);
+    CompletableFuture<StatusCode> writeInputArgumentsAsync(Object[] inputArguments);
 
     /**
      * Get the InputArguments {@link PropertyType} Node, or {@code null} if it does not exist.

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/AuditUpdateStateEventType.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/AuditUpdateStateEventType.java
@@ -7,7 +7,7 @@ import org.eclipse.milo.opcua.sdk.core.QualifiedProperty;
 import org.eclipse.milo.opcua.sdk.core.ValueRanks;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 
 public interface AuditUpdateStateEventType extends AuditUpdateMethodEventType {
     QualifiedProperty<Object> OLD_STATE_ID = new QualifiedProperty<>(
@@ -76,9 +76,9 @@ public interface AuditUpdateStateEventType extends AuditUpdateMethodEventType {
      * An asynchronous implementation of {@link #writeOldStateId(Object)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeOldStateIdAsync(Object oldStateId);
+    CompletableFuture<StatusCode> writeOldStateIdAsync(Object oldStateId);
 
     /**
      * Get the OldStateId {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -149,9 +149,9 @@ public interface AuditUpdateStateEventType extends AuditUpdateMethodEventType {
      * An asynchronous implementation of {@link #writeNewStateId(Object)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeNewStateIdAsync(Object newStateId);
+    CompletableFuture<StatusCode> writeNewStateIdAsync(Object newStateId);
 
     /**
      * Get the NewStateId {@link PropertyType} Node, or {@code null} if it does not exist.

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/AuditUrlMismatchEventType.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/AuditUrlMismatchEventType.java
@@ -7,7 +7,7 @@ import org.eclipse.milo.opcua.sdk.core.QualifiedProperty;
 import org.eclipse.milo.opcua.sdk.core.ValueRanks;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 
 public interface AuditUrlMismatchEventType extends AuditCreateSessionEventType {
     QualifiedProperty<String> ENDPOINT_URL = new QualifiedProperty<>(
@@ -68,9 +68,9 @@ public interface AuditUrlMismatchEventType extends AuditCreateSessionEventType {
      * An asynchronous implementation of {@link #writeEndpointUrl(String)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeEndpointUrlAsync(String endpointUrl);
+    CompletableFuture<StatusCode> writeEndpointUrlAsync(String endpointUrl);
 
     /**
      * Get the EndpointUrl {@link PropertyType} Node, or {@code null} if it does not exist.

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/AuditWriteUpdateEventType.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/AuditWriteUpdateEventType.java
@@ -7,8 +7,8 @@ import org.eclipse.milo.opcua.sdk.core.QualifiedProperty;
 import org.eclipse.milo.opcua.sdk.core.ValueRanks;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public interface AuditWriteUpdateEventType extends AuditUpdateEventType {
     QualifiedProperty<UInteger> ATTRIBUTE_ID = new QualifiedProperty<>(
@@ -93,9 +93,9 @@ public interface AuditWriteUpdateEventType extends AuditUpdateEventType {
      * An asynchronous implementation of {@link #writeAttributeId(UInteger)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeAttributeIdAsync(UInteger attributeId);
+    CompletableFuture<StatusCode> writeAttributeIdAsync(UInteger attributeId);
 
     /**
      * Get the AttributeId {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -166,9 +166,9 @@ public interface AuditWriteUpdateEventType extends AuditUpdateEventType {
      * An asynchronous implementation of {@link #writeIndexRange(String)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeIndexRangeAsync(String indexRange);
+    CompletableFuture<StatusCode> writeIndexRangeAsync(String indexRange);
 
     /**
      * Get the IndexRange {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -239,9 +239,9 @@ public interface AuditWriteUpdateEventType extends AuditUpdateEventType {
      * An asynchronous implementation of {@link #writeOldValue(Object)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeOldValueAsync(Object oldValue);
+    CompletableFuture<StatusCode> writeOldValueAsync(Object oldValue);
 
     /**
      * Get the OldValue {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -312,9 +312,9 @@ public interface AuditWriteUpdateEventType extends AuditUpdateEventType {
      * An asynchronous implementation of {@link #writeNewValue(Object)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeNewValueAsync(Object newValue);
+    CompletableFuture<StatusCode> writeNewValueAsync(Object newValue);
 
     /**
      * Get the NewValue {@link PropertyType} Node, or {@code null} if it does not exist.

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/BaseEventType.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/BaseEventType.java
@@ -11,9 +11,9 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UShort;
 import org.eclipse.milo.opcua.stack.core.types.structured.TimeZoneDataType;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public interface BaseEventType extends BaseObjectType {
     QualifiedProperty<ByteString> EVENT_ID = new QualifiedProperty<>(
@@ -138,9 +138,9 @@ public interface BaseEventType extends BaseObjectType {
      * An asynchronous implementation of {@link #writeEventId(ByteString)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeEventIdAsync(ByteString eventId);
+    CompletableFuture<StatusCode> writeEventIdAsync(ByteString eventId);
 
     /**
      * Get the EventId {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -211,9 +211,9 @@ public interface BaseEventType extends BaseObjectType {
      * An asynchronous implementation of {@link #writeEventType(NodeId)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeEventTypeAsync(NodeId eventType);
+    CompletableFuture<StatusCode> writeEventTypeAsync(NodeId eventType);
 
     /**
      * Get the EventType {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -284,9 +284,9 @@ public interface BaseEventType extends BaseObjectType {
      * An asynchronous implementation of {@link #writeSourceNode(NodeId)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeSourceNodeAsync(NodeId sourceNode);
+    CompletableFuture<StatusCode> writeSourceNodeAsync(NodeId sourceNode);
 
     /**
      * Get the SourceNode {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -357,9 +357,9 @@ public interface BaseEventType extends BaseObjectType {
      * An asynchronous implementation of {@link #writeSourceName(String)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeSourceNameAsync(String sourceName);
+    CompletableFuture<StatusCode> writeSourceNameAsync(String sourceName);
 
     /**
      * Get the SourceName {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -430,9 +430,9 @@ public interface BaseEventType extends BaseObjectType {
      * An asynchronous implementation of {@link #writeTime(DateTime)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeTimeAsync(DateTime time);
+    CompletableFuture<StatusCode> writeTimeAsync(DateTime time);
 
     /**
      * Get the Time {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -503,9 +503,9 @@ public interface BaseEventType extends BaseObjectType {
      * An asynchronous implementation of {@link #writeReceiveTime(DateTime)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeReceiveTimeAsync(DateTime receiveTime);
+    CompletableFuture<StatusCode> writeReceiveTimeAsync(DateTime receiveTime);
 
     /**
      * Get the ReceiveTime {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -576,9 +576,9 @@ public interface BaseEventType extends BaseObjectType {
      * An asynchronous implementation of {@link #writeLocalTime(TimeZoneDataType)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeLocalTimeAsync(TimeZoneDataType localTime);
+    CompletableFuture<StatusCode> writeLocalTimeAsync(TimeZoneDataType localTime);
 
     /**
      * Get the LocalTime {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -649,9 +649,9 @@ public interface BaseEventType extends BaseObjectType {
      * An asynchronous implementation of {@link #writeMessage(LocalizedText)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeMessageAsync(LocalizedText message);
+    CompletableFuture<StatusCode> writeMessageAsync(LocalizedText message);
 
     /**
      * Get the Message {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -722,9 +722,9 @@ public interface BaseEventType extends BaseObjectType {
      * An asynchronous implementation of {@link #writeSeverity(UShort)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeSeverityAsync(UShort severity);
+    CompletableFuture<StatusCode> writeSeverityAsync(UShort severity);
 
     /**
      * Get the Severity {@link PropertyType} Node, or {@code null} if it does not exist.

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/CertificateExpirationAlarmType.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/CertificateExpirationAlarmType.java
@@ -10,7 +10,7 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
 import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 
 public interface CertificateExpirationAlarmType extends SystemOffNormalAlarmType {
     QualifiedProperty<DateTime> EXPIRATION_DATE = new QualifiedProperty<>(
@@ -95,9 +95,9 @@ public interface CertificateExpirationAlarmType extends SystemOffNormalAlarmType
      * An asynchronous implementation of {@link #writeExpirationDate(DateTime)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeExpirationDateAsync(DateTime expirationDate);
+    CompletableFuture<StatusCode> writeExpirationDateAsync(DateTime expirationDate);
 
     /**
      * Get the ExpirationDate {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -168,9 +168,9 @@ public interface CertificateExpirationAlarmType extends SystemOffNormalAlarmType
      * An asynchronous implementation of {@link #writeExpirationLimit(Double)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeExpirationLimitAsync(Double expirationLimit);
+    CompletableFuture<StatusCode> writeExpirationLimitAsync(Double expirationLimit);
 
     /**
      * Get the ExpirationLimit {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -241,9 +241,9 @@ public interface CertificateExpirationAlarmType extends SystemOffNormalAlarmType
      * An asynchronous implementation of {@link #writeCertificateType(NodeId)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeCertificateTypeAsync(NodeId certificateType);
+    CompletableFuture<StatusCode> writeCertificateTypeAsync(NodeId certificateType);
 
     /**
      * Get the CertificateType {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -314,9 +314,9 @@ public interface CertificateExpirationAlarmType extends SystemOffNormalAlarmType
      * An asynchronous implementation of {@link #writeCertificate(ByteString)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeCertificateAsync(ByteString certificate);
+    CompletableFuture<StatusCode> writeCertificateAsync(ByteString certificate);
 
     /**
      * Get the Certificate {@link PropertyType} Node, or {@code null} if it does not exist.

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/CertificateGroupType.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/CertificateGroupType.java
@@ -8,7 +8,7 @@ import org.eclipse.milo.opcua.sdk.core.ValueRanks;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 
 public interface CertificateGroupType extends BaseObjectType {
     QualifiedProperty<NodeId[]> CERTIFICATE_TYPES = new QualifiedProperty<>(
@@ -69,9 +69,9 @@ public interface CertificateGroupType extends BaseObjectType {
      * An asynchronous implementation of {@link #writeCertificateTypes(NodeId[])}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeCertificateTypesAsync(NodeId[] certificateTypes);
+    CompletableFuture<StatusCode> writeCertificateTypesAsync(NodeId[] certificateTypes);
 
     /**
      * Get the CertificateTypes {@link PropertyType} Node, or {@code null} if it does not exist.

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/CertificateUpdatedAuditEventType.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/CertificateUpdatedAuditEventType.java
@@ -8,7 +8,7 @@ import org.eclipse.milo.opcua.sdk.core.ValueRanks;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 
 public interface CertificateUpdatedAuditEventType extends AuditUpdateMethodEventType {
     QualifiedProperty<NodeId> CERTIFICATE_GROUP = new QualifiedProperty<>(
@@ -77,9 +77,9 @@ public interface CertificateUpdatedAuditEventType extends AuditUpdateMethodEvent
      * An asynchronous implementation of {@link #writeCertificateGroup(NodeId)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeCertificateGroupAsync(NodeId certificateGroup);
+    CompletableFuture<StatusCode> writeCertificateGroupAsync(NodeId certificateGroup);
 
     /**
      * Get the CertificateGroup {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -150,9 +150,9 @@ public interface CertificateUpdatedAuditEventType extends AuditUpdateMethodEvent
      * An asynchronous implementation of {@link #writeCertificateType(NodeId)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeCertificateTypeAsync(NodeId certificateType);
+    CompletableFuture<StatusCode> writeCertificateTypeAsync(NodeId certificateType);
 
     /**
      * Get the CertificateType {@link PropertyType} Node, or {@code null} if it does not exist.

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/ConditionType.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/ConditionType.java
@@ -13,7 +13,6 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UShort;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public interface ConditionType extends BaseEventType {
     QualifiedProperty<NodeId> CONDITION_CLASS_ID = new QualifiedProperty<>(
@@ -114,9 +113,9 @@ public interface ConditionType extends BaseEventType {
      * An asynchronous implementation of {@link #writeConditionClassId(NodeId)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeConditionClassIdAsync(NodeId conditionClassId);
+    CompletableFuture<StatusCode> writeConditionClassIdAsync(NodeId conditionClassId);
 
     /**
      * Get the ConditionClassId {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -187,9 +186,9 @@ public interface ConditionType extends BaseEventType {
      * An asynchronous implementation of {@link #writeConditionClassName(LocalizedText)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeConditionClassNameAsync(LocalizedText conditionClassName);
+    CompletableFuture<StatusCode> writeConditionClassNameAsync(LocalizedText conditionClassName);
 
     /**
      * Get the ConditionClassName {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -260,9 +259,9 @@ public interface ConditionType extends BaseEventType {
      * An asynchronous implementation of {@link #writeConditionName(String)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeConditionNameAsync(String conditionName);
+    CompletableFuture<StatusCode> writeConditionNameAsync(String conditionName);
 
     /**
      * Get the ConditionName {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -333,9 +332,9 @@ public interface ConditionType extends BaseEventType {
      * An asynchronous implementation of {@link #writeBranchId(NodeId)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeBranchIdAsync(NodeId branchId);
+    CompletableFuture<StatusCode> writeBranchIdAsync(NodeId branchId);
 
     /**
      * Get the BranchId {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -406,9 +405,9 @@ public interface ConditionType extends BaseEventType {
      * An asynchronous implementation of {@link #writeRetain(Boolean)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeRetainAsync(Boolean retain);
+    CompletableFuture<StatusCode> writeRetainAsync(Boolean retain);
 
     /**
      * Get the Retain {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -479,9 +478,9 @@ public interface ConditionType extends BaseEventType {
      * An asynchronous implementation of {@link #writeClientUserId(String)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeClientUserIdAsync(String clientUserId);
+    CompletableFuture<StatusCode> writeClientUserIdAsync(String clientUserId);
 
     /**
      * Get the ClientUserId {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -552,9 +551,9 @@ public interface ConditionType extends BaseEventType {
      * An asynchronous implementation of {@link #writeEnabledState(LocalizedText)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeEnabledStateAsync(LocalizedText enabledState);
+    CompletableFuture<StatusCode> writeEnabledStateAsync(LocalizedText enabledState);
 
     /**
      * Get the EnabledState {@link TwoStateVariableType} Node, or {@code null} if it does not exist.
@@ -625,9 +624,9 @@ public interface ConditionType extends BaseEventType {
      * An asynchronous implementation of {@link #writeQuality(StatusCode)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeQualityAsync(StatusCode quality);
+    CompletableFuture<StatusCode> writeQualityAsync(StatusCode quality);
 
     /**
      * Get the Quality {@link ConditionVariableType} Node, or {@code null} if it does not exist.
@@ -698,9 +697,9 @@ public interface ConditionType extends BaseEventType {
      * An asynchronous implementation of {@link #writeLastSeverity(UShort)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeLastSeverityAsync(UShort lastSeverity);
+    CompletableFuture<StatusCode> writeLastSeverityAsync(UShort lastSeverity);
 
     /**
      * Get the LastSeverity {@link ConditionVariableType} Node, or {@code null} if it does not exist.
@@ -771,9 +770,9 @@ public interface ConditionType extends BaseEventType {
      * An asynchronous implementation of {@link #writeComment(LocalizedText)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeCommentAsync(LocalizedText comment);
+    CompletableFuture<StatusCode> writeCommentAsync(LocalizedText comment);
 
     /**
      * Get the Comment {@link ConditionVariableType} Node, or {@code null} if it does not exist.

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/DialogConditionType.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/DialogConditionType.java
@@ -9,7 +9,7 @@ import org.eclipse.milo.opcua.sdk.core.ValueRanks;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 
 public interface DialogConditionType extends ConditionType {
     QualifiedProperty<LocalizedText> PROMPT = new QualifiedProperty<>(
@@ -110,9 +110,9 @@ public interface DialogConditionType extends ConditionType {
      * An asynchronous implementation of {@link #writePrompt(LocalizedText)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writePromptAsync(LocalizedText prompt);
+    CompletableFuture<StatusCode> writePromptAsync(LocalizedText prompt);
 
     /**
      * Get the Prompt {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -183,9 +183,9 @@ public interface DialogConditionType extends ConditionType {
      * An asynchronous implementation of {@link #writeResponseOptionSet(LocalizedText[])}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeResponseOptionSetAsync(LocalizedText[] responseOptionSet);
+    CompletableFuture<StatusCode> writeResponseOptionSetAsync(LocalizedText[] responseOptionSet);
 
     /**
      * Get the ResponseOptionSet {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -256,9 +256,9 @@ public interface DialogConditionType extends ConditionType {
      * An asynchronous implementation of {@link #writeDefaultResponse(Integer)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeDefaultResponseAsync(Integer defaultResponse);
+    CompletableFuture<StatusCode> writeDefaultResponseAsync(Integer defaultResponse);
 
     /**
      * Get the DefaultResponse {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -329,9 +329,9 @@ public interface DialogConditionType extends ConditionType {
      * An asynchronous implementation of {@link #writeOkResponse(Integer)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeOkResponseAsync(Integer okResponse);
+    CompletableFuture<StatusCode> writeOkResponseAsync(Integer okResponse);
 
     /**
      * Get the OkResponse {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -402,9 +402,9 @@ public interface DialogConditionType extends ConditionType {
      * An asynchronous implementation of {@link #writeCancelResponse(Integer)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeCancelResponseAsync(Integer cancelResponse);
+    CompletableFuture<StatusCode> writeCancelResponseAsync(Integer cancelResponse);
 
     /**
      * Get the CancelResponse {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -475,9 +475,9 @@ public interface DialogConditionType extends ConditionType {
      * An asynchronous implementation of {@link #writeLastResponse(Integer)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeLastResponseAsync(Integer lastResponse);
+    CompletableFuture<StatusCode> writeLastResponseAsync(Integer lastResponse);
 
     /**
      * Get the LastResponse {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -548,9 +548,9 @@ public interface DialogConditionType extends ConditionType {
      * An asynchronous implementation of {@link #writeEnabledState(LocalizedText)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeEnabledStateAsync(LocalizedText enabledState);
+    CompletableFuture<StatusCode> writeEnabledStateAsync(LocalizedText enabledState);
 
     /**
      * Get the EnabledState {@link TwoStateVariableType} Node, or {@code null} if it does not exist.
@@ -621,9 +621,9 @@ public interface DialogConditionType extends ConditionType {
      * An asynchronous implementation of {@link #writeDialogState(LocalizedText)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeDialogStateAsync(LocalizedText dialogState);
+    CompletableFuture<StatusCode> writeDialogStateAsync(LocalizedText dialogState);
 
     /**
      * Get the DialogState {@link TwoStateVariableType} Node, or {@code null} if it does not exist.

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/ExclusiveDeviationAlarmType.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/ExclusiveDeviationAlarmType.java
@@ -8,7 +8,7 @@ import org.eclipse.milo.opcua.sdk.core.ValueRanks;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 
 public interface ExclusiveDeviationAlarmType extends ExclusiveLimitAlarmType {
     QualifiedProperty<NodeId> SETPOINT_NODE = new QualifiedProperty<>(
@@ -69,9 +69,9 @@ public interface ExclusiveDeviationAlarmType extends ExclusiveLimitAlarmType {
      * An asynchronous implementation of {@link #writeSetpointNode(NodeId)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeSetpointNodeAsync(NodeId setpointNode);
+    CompletableFuture<StatusCode> writeSetpointNodeAsync(NodeId setpointNode);
 
     /**
      * Get the SetpointNode {@link PropertyType} Node, or {@code null} if it does not exist.

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/ExclusiveLimitAlarmType.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/ExclusiveLimitAlarmType.java
@@ -5,7 +5,7 @@ import java.util.concurrent.CompletableFuture;
 import org.eclipse.milo.opcua.sdk.client.model.types.variables.TwoStateVariableType;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 
 public interface ExclusiveLimitAlarmType extends LimitAlarmType {
     /**
@@ -58,9 +58,9 @@ public interface ExclusiveLimitAlarmType extends LimitAlarmType {
      * An asynchronous implementation of {@link #writeActiveState(LocalizedText)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeActiveStateAsync(LocalizedText activeState);
+    CompletableFuture<StatusCode> writeActiveStateAsync(LocalizedText activeState);
 
     /**
      * Get the ActiveState {@link TwoStateVariableType} Node, or {@code null} if it does not exist.

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/FileType.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/FileType.java
@@ -7,9 +7,9 @@ import org.eclipse.milo.opcua.sdk.core.QualifiedProperty;
 import org.eclipse.milo.opcua.sdk.core.ValueRanks;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.ULong;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UShort;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public interface FileType extends BaseObjectType {
     QualifiedProperty<ULong> SIZE = new QualifiedProperty<>(
@@ -102,9 +102,9 @@ public interface FileType extends BaseObjectType {
      * An asynchronous implementation of {@link #writeSize(ULong)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeSizeAsync(ULong size);
+    CompletableFuture<StatusCode> writeSizeAsync(ULong size);
 
     /**
      * Get the Size {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -175,9 +175,9 @@ public interface FileType extends BaseObjectType {
      * An asynchronous implementation of {@link #writeWritable(Boolean)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeWritableAsync(Boolean writable);
+    CompletableFuture<StatusCode> writeWritableAsync(Boolean writable);
 
     /**
      * Get the Writable {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -248,9 +248,9 @@ public interface FileType extends BaseObjectType {
      * An asynchronous implementation of {@link #writeUserWritable(Boolean)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeUserWritableAsync(Boolean userWritable);
+    CompletableFuture<StatusCode> writeUserWritableAsync(Boolean userWritable);
 
     /**
      * Get the UserWritable {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -321,9 +321,9 @@ public interface FileType extends BaseObjectType {
      * An asynchronous implementation of {@link #writeOpenCount(UShort)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeOpenCountAsync(UShort openCount);
+    CompletableFuture<StatusCode> writeOpenCountAsync(UShort openCount);
 
     /**
      * Get the OpenCount {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -394,9 +394,9 @@ public interface FileType extends BaseObjectType {
      * An asynchronous implementation of {@link #writeMimeType(String)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeMimeTypeAsync(String mimeType);
+    CompletableFuture<StatusCode> writeMimeTypeAsync(String mimeType);
 
     /**
      * Get the MimeType {@link PropertyType} Node, or {@code null} if it does not exist.

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/FiniteStateMachineType.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/FiniteStateMachineType.java
@@ -6,7 +6,7 @@ import org.eclipse.milo.opcua.sdk.client.model.types.variables.FiniteStateVariab
 import org.eclipse.milo.opcua.sdk.client.model.types.variables.FiniteTransitionVariableType;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 
 public interface FiniteStateMachineType extends StateMachineType {
     /**
@@ -59,9 +59,9 @@ public interface FiniteStateMachineType extends StateMachineType {
      * An asynchronous implementation of {@link #writeCurrentState(LocalizedText)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeCurrentStateAsync(LocalizedText currentState);
+    CompletableFuture<StatusCode> writeCurrentStateAsync(LocalizedText currentState);
 
     /**
      * Get the CurrentState {@link FiniteStateVariableType} Node, or {@code null} if it does not exist.
@@ -132,9 +132,9 @@ public interface FiniteStateMachineType extends StateMachineType {
      * An asynchronous implementation of {@link #writeLastTransition(LocalizedText)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeLastTransitionAsync(LocalizedText lastTransition);
+    CompletableFuture<StatusCode> writeLastTransitionAsync(LocalizedText lastTransition);
 
     /**
      * Get the LastTransition {@link FiniteTransitionVariableType} Node, or {@code null} if it does not exist.

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/GeneralModelChangeEventType.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/GeneralModelChangeEventType.java
@@ -7,8 +7,8 @@ import org.eclipse.milo.opcua.sdk.core.QualifiedProperty;
 import org.eclipse.milo.opcua.sdk.core.ValueRanks;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.structured.ModelChangeStructureDataType;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public interface GeneralModelChangeEventType extends BaseModelChangeEventType {
     QualifiedProperty<ModelChangeStructureDataType[]> CHANGES = new QualifiedProperty<>(
@@ -69,9 +69,9 @@ public interface GeneralModelChangeEventType extends BaseModelChangeEventType {
      * An asynchronous implementation of {@link #writeChanges(ModelChangeStructureDataType[])}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeChangesAsync(ModelChangeStructureDataType[] changes);
+    CompletableFuture<StatusCode> writeChangesAsync(ModelChangeStructureDataType[] changes);
 
     /**
      * Get the Changes {@link PropertyType} Node, or {@code null} if it does not exist.

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/HistoricalDataConfigurationType.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/HistoricalDataConfigurationType.java
@@ -8,8 +8,8 @@ import org.eclipse.milo.opcua.sdk.core.ValueRanks;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.ExceptionDeviationFormat;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public interface HistoricalDataConfigurationType extends BaseObjectType {
     QualifiedProperty<Boolean> STEPPED = new QualifiedProperty<>(
@@ -126,9 +126,9 @@ public interface HistoricalDataConfigurationType extends BaseObjectType {
      * An asynchronous implementation of {@link #writeStepped(Boolean)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeSteppedAsync(Boolean stepped);
+    CompletableFuture<StatusCode> writeSteppedAsync(Boolean stepped);
 
     /**
      * Get the Stepped {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -199,9 +199,9 @@ public interface HistoricalDataConfigurationType extends BaseObjectType {
      * An asynchronous implementation of {@link #writeDefinition(String)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeDefinitionAsync(String definition);
+    CompletableFuture<StatusCode> writeDefinitionAsync(String definition);
 
     /**
      * Get the Definition {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -272,9 +272,9 @@ public interface HistoricalDataConfigurationType extends BaseObjectType {
      * An asynchronous implementation of {@link #writeMaxTimeInterval(Double)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeMaxTimeIntervalAsync(Double maxTimeInterval);
+    CompletableFuture<StatusCode> writeMaxTimeIntervalAsync(Double maxTimeInterval);
 
     /**
      * Get the MaxTimeInterval {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -345,9 +345,9 @@ public interface HistoricalDataConfigurationType extends BaseObjectType {
      * An asynchronous implementation of {@link #writeMinTimeInterval(Double)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeMinTimeIntervalAsync(Double minTimeInterval);
+    CompletableFuture<StatusCode> writeMinTimeIntervalAsync(Double minTimeInterval);
 
     /**
      * Get the MinTimeInterval {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -418,9 +418,9 @@ public interface HistoricalDataConfigurationType extends BaseObjectType {
      * An asynchronous implementation of {@link #writeExceptionDeviation(Double)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeExceptionDeviationAsync(Double exceptionDeviation);
+    CompletableFuture<StatusCode> writeExceptionDeviationAsync(Double exceptionDeviation);
 
     /**
      * Get the ExceptionDeviation {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -493,9 +493,9 @@ public interface HistoricalDataConfigurationType extends BaseObjectType {
      * An asynchronous implementation of {@link #writeExceptionDeviationFormat(ExceptionDeviationFormat)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeExceptionDeviationFormatAsync(
+    CompletableFuture<StatusCode> writeExceptionDeviationFormatAsync(
         ExceptionDeviationFormat exceptionDeviationFormat);
 
     /**
@@ -567,9 +567,9 @@ public interface HistoricalDataConfigurationType extends BaseObjectType {
      * An asynchronous implementation of {@link #writeStartOfArchive(DateTime)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeStartOfArchiveAsync(DateTime startOfArchive);
+    CompletableFuture<StatusCode> writeStartOfArchiveAsync(DateTime startOfArchive);
 
     /**
      * Get the StartOfArchive {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -640,9 +640,9 @@ public interface HistoricalDataConfigurationType extends BaseObjectType {
      * An asynchronous implementation of {@link #writeStartOfOnlineArchive(DateTime)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeStartOfOnlineArchiveAsync(DateTime startOfOnlineArchive);
+    CompletableFuture<StatusCode> writeStartOfOnlineArchiveAsync(DateTime startOfOnlineArchive);
 
     /**
      * Get the StartOfOnlineArchive {@link PropertyType} Node, or {@code null} if it does not exist.

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/HistoryServerCapabilitiesType.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/HistoryServerCapabilitiesType.java
@@ -7,8 +7,8 @@ import org.eclipse.milo.opcua.sdk.core.QualifiedProperty;
 import org.eclipse.milo.opcua.sdk.core.ValueRanks;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public interface HistoryServerCapabilitiesType extends BaseObjectType {
     QualifiedProperty<Boolean> ACCESS_HISTORY_DATA_CAPABILITY = new QualifiedProperty<>(
@@ -173,9 +173,9 @@ public interface HistoryServerCapabilitiesType extends BaseObjectType {
      * An asynchronous implementation of {@link #writeAccessHistoryDataCapability(Boolean)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeAccessHistoryDataCapabilityAsync(
+    CompletableFuture<StatusCode> writeAccessHistoryDataCapabilityAsync(
         Boolean accessHistoryDataCapability);
 
     /**
@@ -247,9 +247,9 @@ public interface HistoryServerCapabilitiesType extends BaseObjectType {
      * An asynchronous implementation of {@link #writeAccessHistoryEventsCapability(Boolean)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeAccessHistoryEventsCapabilityAsync(
+    CompletableFuture<StatusCode> writeAccessHistoryEventsCapabilityAsync(
         Boolean accessHistoryEventsCapability);
 
     /**
@@ -321,9 +321,9 @@ public interface HistoryServerCapabilitiesType extends BaseObjectType {
      * An asynchronous implementation of {@link #writeMaxReturnDataValues(UInteger)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeMaxReturnDataValuesAsync(UInteger maxReturnDataValues);
+    CompletableFuture<StatusCode> writeMaxReturnDataValuesAsync(UInteger maxReturnDataValues);
 
     /**
      * Get the MaxReturnDataValues {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -394,9 +394,9 @@ public interface HistoryServerCapabilitiesType extends BaseObjectType {
      * An asynchronous implementation of {@link #writeMaxReturnEventValues(UInteger)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeMaxReturnEventValuesAsync(UInteger maxReturnEventValues);
+    CompletableFuture<StatusCode> writeMaxReturnEventValuesAsync(UInteger maxReturnEventValues);
 
     /**
      * Get the MaxReturnEventValues {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -467,9 +467,9 @@ public interface HistoryServerCapabilitiesType extends BaseObjectType {
      * An asynchronous implementation of {@link #writeInsertDataCapability(Boolean)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeInsertDataCapabilityAsync(Boolean insertDataCapability);
+    CompletableFuture<StatusCode> writeInsertDataCapabilityAsync(Boolean insertDataCapability);
 
     /**
      * Get the InsertDataCapability {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -540,9 +540,9 @@ public interface HistoryServerCapabilitiesType extends BaseObjectType {
      * An asynchronous implementation of {@link #writeReplaceDataCapability(Boolean)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeReplaceDataCapabilityAsync(Boolean replaceDataCapability);
+    CompletableFuture<StatusCode> writeReplaceDataCapabilityAsync(Boolean replaceDataCapability);
 
     /**
      * Get the ReplaceDataCapability {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -613,9 +613,9 @@ public interface HistoryServerCapabilitiesType extends BaseObjectType {
      * An asynchronous implementation of {@link #writeUpdateDataCapability(Boolean)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeUpdateDataCapabilityAsync(Boolean updateDataCapability);
+    CompletableFuture<StatusCode> writeUpdateDataCapabilityAsync(Boolean updateDataCapability);
 
     /**
      * Get the UpdateDataCapability {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -686,9 +686,9 @@ public interface HistoryServerCapabilitiesType extends BaseObjectType {
      * An asynchronous implementation of {@link #writeDeleteRawCapability(Boolean)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeDeleteRawCapabilityAsync(Boolean deleteRawCapability);
+    CompletableFuture<StatusCode> writeDeleteRawCapabilityAsync(Boolean deleteRawCapability);
 
     /**
      * Get the DeleteRawCapability {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -759,9 +759,9 @@ public interface HistoryServerCapabilitiesType extends BaseObjectType {
      * An asynchronous implementation of {@link #writeDeleteAtTimeCapability(Boolean)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeDeleteAtTimeCapabilityAsync(Boolean deleteAtTimeCapability);
+    CompletableFuture<StatusCode> writeDeleteAtTimeCapabilityAsync(Boolean deleteAtTimeCapability);
 
     /**
      * Get the DeleteAtTimeCapability {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -832,9 +832,9 @@ public interface HistoryServerCapabilitiesType extends BaseObjectType {
      * An asynchronous implementation of {@link #writeInsertEventCapability(Boolean)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeInsertEventCapabilityAsync(Boolean insertEventCapability);
+    CompletableFuture<StatusCode> writeInsertEventCapabilityAsync(Boolean insertEventCapability);
 
     /**
      * Get the InsertEventCapability {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -905,9 +905,9 @@ public interface HistoryServerCapabilitiesType extends BaseObjectType {
      * An asynchronous implementation of {@link #writeReplaceEventCapability(Boolean)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeReplaceEventCapabilityAsync(Boolean replaceEventCapability);
+    CompletableFuture<StatusCode> writeReplaceEventCapabilityAsync(Boolean replaceEventCapability);
 
     /**
      * Get the ReplaceEventCapability {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -978,9 +978,9 @@ public interface HistoryServerCapabilitiesType extends BaseObjectType {
      * An asynchronous implementation of {@link #writeUpdateEventCapability(Boolean)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeUpdateEventCapabilityAsync(Boolean updateEventCapability);
+    CompletableFuture<StatusCode> writeUpdateEventCapabilityAsync(Boolean updateEventCapability);
 
     /**
      * Get the UpdateEventCapability {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -1051,9 +1051,9 @@ public interface HistoryServerCapabilitiesType extends BaseObjectType {
      * An asynchronous implementation of {@link #writeDeleteEventCapability(Boolean)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeDeleteEventCapabilityAsync(Boolean deleteEventCapability);
+    CompletableFuture<StatusCode> writeDeleteEventCapabilityAsync(Boolean deleteEventCapability);
 
     /**
      * Get the DeleteEventCapability {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -1124,9 +1124,10 @@ public interface HistoryServerCapabilitiesType extends BaseObjectType {
      * An asynchronous implementation of {@link #writeInsertAnnotationCapability(Boolean)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeInsertAnnotationCapabilityAsync(Boolean insertAnnotationCapability);
+    CompletableFuture<StatusCode> writeInsertAnnotationCapabilityAsync(
+        Boolean insertAnnotationCapability);
 
     /**
      * Get the InsertAnnotationCapability {@link PropertyType} Node, or {@code null} if it does not exist.

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/LimitAlarmType.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/LimitAlarmType.java
@@ -7,7 +7,7 @@ import org.eclipse.milo.opcua.sdk.core.QualifiedProperty;
 import org.eclipse.milo.opcua.sdk.core.ValueRanks;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 
 public interface LimitAlarmType extends AlarmConditionType {
     QualifiedProperty<Double> HIGH_HIGH_LIMIT = new QualifiedProperty<>(
@@ -92,9 +92,9 @@ public interface LimitAlarmType extends AlarmConditionType {
      * An asynchronous implementation of {@link #writeHighHighLimit(Double)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeHighHighLimitAsync(Double highHighLimit);
+    CompletableFuture<StatusCode> writeHighHighLimitAsync(Double highHighLimit);
 
     /**
      * Get the HighHighLimit {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -165,9 +165,9 @@ public interface LimitAlarmType extends AlarmConditionType {
      * An asynchronous implementation of {@link #writeHighLimit(Double)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeHighLimitAsync(Double highLimit);
+    CompletableFuture<StatusCode> writeHighLimitAsync(Double highLimit);
 
     /**
      * Get the HighLimit {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -238,9 +238,9 @@ public interface LimitAlarmType extends AlarmConditionType {
      * An asynchronous implementation of {@link #writeLowLimit(Double)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeLowLimitAsync(Double lowLimit);
+    CompletableFuture<StatusCode> writeLowLimitAsync(Double lowLimit);
 
     /**
      * Get the LowLimit {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -311,9 +311,9 @@ public interface LimitAlarmType extends AlarmConditionType {
      * An asynchronous implementation of {@link #writeLowLowLimit(Double)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeLowLowLimitAsync(Double lowLowLimit);
+    CompletableFuture<StatusCode> writeLowLowLimitAsync(Double lowLowLimit);
 
     /**
      * Get the LowLowLimit {@link PropertyType} Node, or {@code null} if it does not exist.

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/ModellingRuleType.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/ModellingRuleType.java
@@ -7,8 +7,8 @@ import org.eclipse.milo.opcua.sdk.core.QualifiedProperty;
 import org.eclipse.milo.opcua.sdk.core.ValueRanks;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.NamingRuleType;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public interface ModellingRuleType extends BaseObjectType {
     QualifiedProperty<NamingRuleType> NAMING_RULE = new QualifiedProperty<>(
@@ -69,9 +69,9 @@ public interface ModellingRuleType extends BaseObjectType {
      * An asynchronous implementation of {@link #writeNamingRule(NamingRuleType)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeNamingRuleAsync(NamingRuleType namingRule);
+    CompletableFuture<StatusCode> writeNamingRuleAsync(NamingRuleType namingRule);
 
     /**
      * Get the NamingRule {@link PropertyType} Node, or {@code null} if it does not exist.

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/NamespaceMetadataType.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/NamespaceMetadataType.java
@@ -8,8 +8,8 @@ import org.eclipse.milo.opcua.sdk.core.ValueRanks;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.IdType;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public interface NamespaceMetadataType extends BaseObjectType {
     QualifiedProperty<String> NAMESPACE_URI = new QualifiedProperty<>(
@@ -118,9 +118,9 @@ public interface NamespaceMetadataType extends BaseObjectType {
      * An asynchronous implementation of {@link #writeNamespaceUri(String)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeNamespaceUriAsync(String namespaceUri);
+    CompletableFuture<StatusCode> writeNamespaceUriAsync(String namespaceUri);
 
     /**
      * Get the NamespaceUri {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -191,9 +191,9 @@ public interface NamespaceMetadataType extends BaseObjectType {
      * An asynchronous implementation of {@link #writeNamespaceVersion(String)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeNamespaceVersionAsync(String namespaceVersion);
+    CompletableFuture<StatusCode> writeNamespaceVersionAsync(String namespaceVersion);
 
     /**
      * Get the NamespaceVersion {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -264,9 +264,10 @@ public interface NamespaceMetadataType extends BaseObjectType {
      * An asynchronous implementation of {@link #writeNamespacePublicationDate(DateTime)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeNamespacePublicationDateAsync(DateTime namespacePublicationDate);
+    CompletableFuture<StatusCode> writeNamespacePublicationDateAsync(
+        DateTime namespacePublicationDate);
 
     /**
      * Get the NamespacePublicationDate {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -337,9 +338,9 @@ public interface NamespaceMetadataType extends BaseObjectType {
      * An asynchronous implementation of {@link #writeIsNamespaceSubset(Boolean)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeIsNamespaceSubsetAsync(Boolean isNamespaceSubset);
+    CompletableFuture<StatusCode> writeIsNamespaceSubsetAsync(Boolean isNamespaceSubset);
 
     /**
      * Get the IsNamespaceSubset {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -410,9 +411,9 @@ public interface NamespaceMetadataType extends BaseObjectType {
      * An asynchronous implementation of {@link #writeStaticNodeIdTypes(IdType[])}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeStaticNodeIdTypesAsync(IdType[] staticNodeIdTypes);
+    CompletableFuture<StatusCode> writeStaticNodeIdTypesAsync(IdType[] staticNodeIdTypes);
 
     /**
      * Get the StaticNodeIdTypes {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -483,9 +484,10 @@ public interface NamespaceMetadataType extends BaseObjectType {
      * An asynchronous implementation of {@link #writeStaticNumericNodeIdRange(String[])}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeStaticNumericNodeIdRangeAsync(String[] staticNumericNodeIdRange);
+    CompletableFuture<StatusCode> writeStaticNumericNodeIdRangeAsync(
+        String[] staticNumericNodeIdRange);
 
     /**
      * Get the StaticNumericNodeIdRange {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -556,9 +558,10 @@ public interface NamespaceMetadataType extends BaseObjectType {
      * An asynchronous implementation of {@link #writeStaticStringNodeIdPattern(String)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeStaticStringNodeIdPatternAsync(String staticStringNodeIdPattern);
+    CompletableFuture<StatusCode> writeStaticStringNodeIdPatternAsync(
+        String staticStringNodeIdPattern);
 
     /**
      * Get the StaticStringNodeIdPattern {@link PropertyType} Node, or {@code null} if it does not exist.

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/NonExclusiveDeviationAlarmType.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/NonExclusiveDeviationAlarmType.java
@@ -8,7 +8,7 @@ import org.eclipse.milo.opcua.sdk.core.ValueRanks;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 
 public interface NonExclusiveDeviationAlarmType extends NonExclusiveLimitAlarmType {
     QualifiedProperty<NodeId> SETPOINT_NODE = new QualifiedProperty<>(
@@ -69,9 +69,9 @@ public interface NonExclusiveDeviationAlarmType extends NonExclusiveLimitAlarmTy
      * An asynchronous implementation of {@link #writeSetpointNode(NodeId)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeSetpointNodeAsync(NodeId setpointNode);
+    CompletableFuture<StatusCode> writeSetpointNodeAsync(NodeId setpointNode);
 
     /**
      * Get the SetpointNode {@link PropertyType} Node, or {@code null} if it does not exist.

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/NonExclusiveLimitAlarmType.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/NonExclusiveLimitAlarmType.java
@@ -5,7 +5,7 @@ import java.util.concurrent.CompletableFuture;
 import org.eclipse.milo.opcua.sdk.client.model.types.variables.TwoStateVariableType;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 
 public interface NonExclusiveLimitAlarmType extends LimitAlarmType {
     /**
@@ -58,9 +58,9 @@ public interface NonExclusiveLimitAlarmType extends LimitAlarmType {
      * An asynchronous implementation of {@link #writeActiveState(LocalizedText)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeActiveStateAsync(LocalizedText activeState);
+    CompletableFuture<StatusCode> writeActiveStateAsync(LocalizedText activeState);
 
     /**
      * Get the ActiveState {@link TwoStateVariableType} Node, or {@code null} if it does not exist.
@@ -131,9 +131,9 @@ public interface NonExclusiveLimitAlarmType extends LimitAlarmType {
      * An asynchronous implementation of {@link #writeHighHighState(LocalizedText)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeHighHighStateAsync(LocalizedText highHighState);
+    CompletableFuture<StatusCode> writeHighHighStateAsync(LocalizedText highHighState);
 
     /**
      * Get the HighHighState {@link TwoStateVariableType} Node, or {@code null} if it does not exist.
@@ -204,9 +204,9 @@ public interface NonExclusiveLimitAlarmType extends LimitAlarmType {
      * An asynchronous implementation of {@link #writeHighState(LocalizedText)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeHighStateAsync(LocalizedText highState);
+    CompletableFuture<StatusCode> writeHighStateAsync(LocalizedText highState);
 
     /**
      * Get the HighState {@link TwoStateVariableType} Node, or {@code null} if it does not exist.
@@ -277,9 +277,9 @@ public interface NonExclusiveLimitAlarmType extends LimitAlarmType {
      * An asynchronous implementation of {@link #writeLowState(LocalizedText)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeLowStateAsync(LocalizedText lowState);
+    CompletableFuture<StatusCode> writeLowStateAsync(LocalizedText lowState);
 
     /**
      * Get the LowState {@link TwoStateVariableType} Node, or {@code null} if it does not exist.
@@ -350,9 +350,9 @@ public interface NonExclusiveLimitAlarmType extends LimitAlarmType {
      * An asynchronous implementation of {@link #writeLowLowState(LocalizedText)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeLowLowStateAsync(LocalizedText lowLowState);
+    CompletableFuture<StatusCode> writeLowLowStateAsync(LocalizedText lowLowState);
 
     /**
      * Get the LowLowState {@link TwoStateVariableType} Node, or {@code null} if it does not exist.

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/NonTransparentNetworkRedundancyType.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/NonTransparentNetworkRedundancyType.java
@@ -7,8 +7,8 @@ import org.eclipse.milo.opcua.sdk.core.QualifiedProperty;
 import org.eclipse.milo.opcua.sdk.core.ValueRanks;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.structured.NetworkGroupDataType;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public interface NonTransparentNetworkRedundancyType extends NonTransparentRedundancyType {
     QualifiedProperty<NetworkGroupDataType[]> SERVER_NETWORK_GROUPS = new QualifiedProperty<>(
@@ -69,9 +69,10 @@ public interface NonTransparentNetworkRedundancyType extends NonTransparentRedun
      * An asynchronous implementation of {@link #writeServerNetworkGroups(NetworkGroupDataType[])}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeServerNetworkGroupsAsync(NetworkGroupDataType[] serverNetworkGroups);
+    CompletableFuture<StatusCode> writeServerNetworkGroupsAsync(
+        NetworkGroupDataType[] serverNetworkGroups);
 
     /**
      * Get the ServerNetworkGroups {@link PropertyType} Node, or {@code null} if it does not exist.

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/NonTransparentRedundancyType.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/NonTransparentRedundancyType.java
@@ -7,7 +7,7 @@ import org.eclipse.milo.opcua.sdk.core.QualifiedProperty;
 import org.eclipse.milo.opcua.sdk.core.ValueRanks;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 
 public interface NonTransparentRedundancyType extends ServerRedundancyType {
     QualifiedProperty<String[]> SERVER_URI_ARRAY = new QualifiedProperty<>(
@@ -68,9 +68,9 @@ public interface NonTransparentRedundancyType extends ServerRedundancyType {
      * An asynchronous implementation of {@link #writeServerUriArray(String[])}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeServerUriArrayAsync(String[] serverUriArray);
+    CompletableFuture<StatusCode> writeServerUriArrayAsync(String[] serverUriArray);
 
     /**
      * Get the ServerUriArray {@link PropertyType} Node, or {@code null} if it does not exist.

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/OffNormalAlarmType.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/OffNormalAlarmType.java
@@ -8,7 +8,7 @@ import org.eclipse.milo.opcua.sdk.core.ValueRanks;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 
 public interface OffNormalAlarmType extends DiscreteAlarmType {
     QualifiedProperty<NodeId> NORMAL_STATE = new QualifiedProperty<>(
@@ -69,9 +69,9 @@ public interface OffNormalAlarmType extends DiscreteAlarmType {
      * An asynchronous implementation of {@link #writeNormalState(NodeId)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeNormalStateAsync(NodeId normalState);
+    CompletableFuture<StatusCode> writeNormalStateAsync(NodeId normalState);
 
     /**
      * Get the NormalState {@link PropertyType} Node, or {@code null} if it does not exist.

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/OperationLimitsType.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/OperationLimitsType.java
@@ -7,8 +7,8 @@ import org.eclipse.milo.opcua.sdk.core.QualifiedProperty;
 import org.eclipse.milo.opcua.sdk.core.ValueRanks;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public interface OperationLimitsType extends FolderType {
     QualifiedProperty<UInteger> MAX_NODES_PER_READ = new QualifiedProperty<>(
@@ -157,9 +157,9 @@ public interface OperationLimitsType extends FolderType {
      * An asynchronous implementation of {@link #writeMaxNodesPerRead(UInteger)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeMaxNodesPerReadAsync(UInteger maxNodesPerRead);
+    CompletableFuture<StatusCode> writeMaxNodesPerReadAsync(UInteger maxNodesPerRead);
 
     /**
      * Get the MaxNodesPerRead {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -230,9 +230,10 @@ public interface OperationLimitsType extends FolderType {
      * An asynchronous implementation of {@link #writeMaxNodesPerHistoryReadData(UInteger)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeMaxNodesPerHistoryReadDataAsync(UInteger maxNodesPerHistoryReadData);
+    CompletableFuture<StatusCode> writeMaxNodesPerHistoryReadDataAsync(
+        UInteger maxNodesPerHistoryReadData);
 
     /**
      * Get the MaxNodesPerHistoryReadData {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -303,9 +304,9 @@ public interface OperationLimitsType extends FolderType {
      * An asynchronous implementation of {@link #writeMaxNodesPerHistoryReadEvents(UInteger)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeMaxNodesPerHistoryReadEventsAsync(
+    CompletableFuture<StatusCode> writeMaxNodesPerHistoryReadEventsAsync(
         UInteger maxNodesPerHistoryReadEvents);
 
     /**
@@ -377,9 +378,9 @@ public interface OperationLimitsType extends FolderType {
      * An asynchronous implementation of {@link #writeMaxNodesPerWrite(UInteger)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeMaxNodesPerWriteAsync(UInteger maxNodesPerWrite);
+    CompletableFuture<StatusCode> writeMaxNodesPerWriteAsync(UInteger maxNodesPerWrite);
 
     /**
      * Get the MaxNodesPerWrite {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -450,9 +451,9 @@ public interface OperationLimitsType extends FolderType {
      * An asynchronous implementation of {@link #writeMaxNodesPerHistoryUpdateData(UInteger)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeMaxNodesPerHistoryUpdateDataAsync(
+    CompletableFuture<StatusCode> writeMaxNodesPerHistoryUpdateDataAsync(
         UInteger maxNodesPerHistoryUpdateData);
 
     /**
@@ -526,9 +527,9 @@ public interface OperationLimitsType extends FolderType {
      * An asynchronous implementation of {@link #writeMaxNodesPerHistoryUpdateEvents(UInteger)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeMaxNodesPerHistoryUpdateEventsAsync(
+    CompletableFuture<StatusCode> writeMaxNodesPerHistoryUpdateEventsAsync(
         UInteger maxNodesPerHistoryUpdateEvents);
 
     /**
@@ -600,9 +601,9 @@ public interface OperationLimitsType extends FolderType {
      * An asynchronous implementation of {@link #writeMaxNodesPerMethodCall(UInteger)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeMaxNodesPerMethodCallAsync(UInteger maxNodesPerMethodCall);
+    CompletableFuture<StatusCode> writeMaxNodesPerMethodCallAsync(UInteger maxNodesPerMethodCall);
 
     /**
      * Get the MaxNodesPerMethodCall {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -673,9 +674,9 @@ public interface OperationLimitsType extends FolderType {
      * An asynchronous implementation of {@link #writeMaxNodesPerBrowse(UInteger)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeMaxNodesPerBrowseAsync(UInteger maxNodesPerBrowse);
+    CompletableFuture<StatusCode> writeMaxNodesPerBrowseAsync(UInteger maxNodesPerBrowse);
 
     /**
      * Get the MaxNodesPerBrowse {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -746,9 +747,10 @@ public interface OperationLimitsType extends FolderType {
      * An asynchronous implementation of {@link #writeMaxNodesPerRegisterNodes(UInteger)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeMaxNodesPerRegisterNodesAsync(UInteger maxNodesPerRegisterNodes);
+    CompletableFuture<StatusCode> writeMaxNodesPerRegisterNodesAsync(
+        UInteger maxNodesPerRegisterNodes);
 
     /**
      * Get the MaxNodesPerRegisterNodes {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -821,9 +823,9 @@ public interface OperationLimitsType extends FolderType {
      * An asynchronous implementation of {@link #writeMaxNodesPerTranslateBrowsePathsToNodeIds(UInteger)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeMaxNodesPerTranslateBrowsePathsToNodeIdsAsync(
+    CompletableFuture<StatusCode> writeMaxNodesPerTranslateBrowsePathsToNodeIdsAsync(
         UInteger maxNodesPerTranslateBrowsePathsToNodeIds);
 
     /**
@@ -895,9 +897,10 @@ public interface OperationLimitsType extends FolderType {
      * An asynchronous implementation of {@link #writeMaxNodesPerNodeManagement(UInteger)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeMaxNodesPerNodeManagementAsync(UInteger maxNodesPerNodeManagement);
+    CompletableFuture<StatusCode> writeMaxNodesPerNodeManagementAsync(
+        UInteger maxNodesPerNodeManagement);
 
     /**
      * Get the MaxNodesPerNodeManagement {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -968,9 +971,10 @@ public interface OperationLimitsType extends FolderType {
      * An asynchronous implementation of {@link #writeMaxMonitoredItemsPerCall(UInteger)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeMaxMonitoredItemsPerCallAsync(UInteger maxMonitoredItemsPerCall);
+    CompletableFuture<StatusCode> writeMaxMonitoredItemsPerCallAsync(
+        UInteger maxMonitoredItemsPerCall);
 
     /**
      * Get the MaxMonitoredItemsPerCall {@link PropertyType} Node, or {@code null} if it does not exist.

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/ProgramStateMachineType.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/ProgramStateMachineType.java
@@ -11,9 +11,9 @@ import org.eclipse.milo.opcua.sdk.core.ValueRanks;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.structured.ProgramDiagnosticDataType;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public interface ProgramStateMachineType extends FiniteStateMachineType {
     QualifiedProperty<Boolean> CREATABLE = new QualifiedProperty<>(
@@ -122,9 +122,9 @@ public interface ProgramStateMachineType extends FiniteStateMachineType {
      * An asynchronous implementation of {@link #writeCreatable(Boolean)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeCreatableAsync(Boolean creatable);
+    CompletableFuture<StatusCode> writeCreatableAsync(Boolean creatable);
 
     /**
      * Get the Creatable {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -195,9 +195,9 @@ public interface ProgramStateMachineType extends FiniteStateMachineType {
      * An asynchronous implementation of {@link #writeDeletable(Boolean)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeDeletableAsync(Boolean deletable);
+    CompletableFuture<StatusCode> writeDeletableAsync(Boolean deletable);
 
     /**
      * Get the Deletable {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -268,9 +268,9 @@ public interface ProgramStateMachineType extends FiniteStateMachineType {
      * An asynchronous implementation of {@link #writeAutoDelete(Boolean)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeAutoDeleteAsync(Boolean autoDelete);
+    CompletableFuture<StatusCode> writeAutoDeleteAsync(Boolean autoDelete);
 
     /**
      * Get the AutoDelete {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -341,9 +341,9 @@ public interface ProgramStateMachineType extends FiniteStateMachineType {
      * An asynchronous implementation of {@link #writeRecycleCount(Integer)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeRecycleCountAsync(Integer recycleCount);
+    CompletableFuture<StatusCode> writeRecycleCountAsync(Integer recycleCount);
 
     /**
      * Get the RecycleCount {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -414,9 +414,9 @@ public interface ProgramStateMachineType extends FiniteStateMachineType {
      * An asynchronous implementation of {@link #writeInstanceCount(UInteger)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeInstanceCountAsync(UInteger instanceCount);
+    CompletableFuture<StatusCode> writeInstanceCountAsync(UInteger instanceCount);
 
     /**
      * Get the InstanceCount {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -487,9 +487,9 @@ public interface ProgramStateMachineType extends FiniteStateMachineType {
      * An asynchronous implementation of {@link #writeMaxInstanceCount(UInteger)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeMaxInstanceCountAsync(UInteger maxInstanceCount);
+    CompletableFuture<StatusCode> writeMaxInstanceCountAsync(UInteger maxInstanceCount);
 
     /**
      * Get the MaxInstanceCount {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -560,9 +560,9 @@ public interface ProgramStateMachineType extends FiniteStateMachineType {
      * An asynchronous implementation of {@link #writeMaxRecycleCount(UInteger)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeMaxRecycleCountAsync(UInteger maxRecycleCount);
+    CompletableFuture<StatusCode> writeMaxRecycleCountAsync(UInteger maxRecycleCount);
 
     /**
      * Get the MaxRecycleCount {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -633,9 +633,9 @@ public interface ProgramStateMachineType extends FiniteStateMachineType {
      * An asynchronous implementation of {@link #writeCurrentState(LocalizedText)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeCurrentStateAsync(LocalizedText currentState);
+    CompletableFuture<StatusCode> writeCurrentStateAsync(LocalizedText currentState);
 
     /**
      * Get the CurrentState {@link FiniteStateVariableType} Node, or {@code null} if it does not exist.
@@ -706,9 +706,9 @@ public interface ProgramStateMachineType extends FiniteStateMachineType {
      * An asynchronous implementation of {@link #writeLastTransition(LocalizedText)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeLastTransitionAsync(LocalizedText lastTransition);
+    CompletableFuture<StatusCode> writeLastTransitionAsync(LocalizedText lastTransition);
 
     /**
      * Get the LastTransition {@link FiniteTransitionVariableType} Node, or {@code null} if it does not exist.
@@ -779,9 +779,9 @@ public interface ProgramStateMachineType extends FiniteStateMachineType {
      * An asynchronous implementation of {@link #writeProgramDiagnostics(ProgramDiagnosticDataType)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeProgramDiagnosticsAsync(
+    CompletableFuture<StatusCode> writeProgramDiagnosticsAsync(
         ProgramDiagnosticDataType programDiagnostics);
 
     /**

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/ProgramTransitionAuditEventType.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/ProgramTransitionAuditEventType.java
@@ -5,7 +5,7 @@ import java.util.concurrent.CompletableFuture;
 import org.eclipse.milo.opcua.sdk.client.model.types.variables.FiniteTransitionVariableType;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 
 public interface ProgramTransitionAuditEventType extends AuditUpdateStateEventType {
     /**
@@ -58,9 +58,9 @@ public interface ProgramTransitionAuditEventType extends AuditUpdateStateEventTy
      * An asynchronous implementation of {@link #writeTransition(LocalizedText)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeTransitionAsync(LocalizedText transition);
+    CompletableFuture<StatusCode> writeTransitionAsync(LocalizedText transition);
 
     /**
      * Get the Transition {@link FiniteTransitionVariableType} Node, or {@code null} if it does not exist.

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/ProgramTransitionEventType.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/ProgramTransitionEventType.java
@@ -7,7 +7,7 @@ import org.eclipse.milo.opcua.sdk.core.QualifiedProperty;
 import org.eclipse.milo.opcua.sdk.core.ValueRanks;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 
 public interface ProgramTransitionEventType extends TransitionEventType {
     QualifiedProperty<Object> INTERMEDIATE_RESULT = new QualifiedProperty<>(
@@ -68,9 +68,9 @@ public interface ProgramTransitionEventType extends TransitionEventType {
      * An asynchronous implementation of {@link #writeIntermediateResult(Object)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeIntermediateResultAsync(Object intermediateResult);
+    CompletableFuture<StatusCode> writeIntermediateResultAsync(Object intermediateResult);
 
     /**
      * Get the IntermediateResult {@link PropertyType} Node, or {@code null} if it does not exist.

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/ProgressEventType.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/ProgressEventType.java
@@ -7,8 +7,8 @@ import org.eclipse.milo.opcua.sdk.core.QualifiedProperty;
 import org.eclipse.milo.opcua.sdk.core.ValueRanks;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UShort;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public interface ProgressEventType extends BaseEventType {
     QualifiedProperty<Object> CONTEXT = new QualifiedProperty<>(
@@ -77,9 +77,9 @@ public interface ProgressEventType extends BaseEventType {
      * An asynchronous implementation of {@link #writeContext(Object)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeContextAsync(Object context);
+    CompletableFuture<StatusCode> writeContextAsync(Object context);
 
     /**
      * Get the Context {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -150,9 +150,9 @@ public interface ProgressEventType extends BaseEventType {
      * An asynchronous implementation of {@link #writeProgress(UShort)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeProgressAsync(UShort progress);
+    CompletableFuture<StatusCode> writeProgressAsync(UShort progress);
 
     /**
      * Get the Progress {@link PropertyType} Node, or {@code null} if it does not exist.

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/SemanticChangeEventType.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/SemanticChangeEventType.java
@@ -7,8 +7,8 @@ import org.eclipse.milo.opcua.sdk.core.QualifiedProperty;
 import org.eclipse.milo.opcua.sdk.core.ValueRanks;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.structured.SemanticChangeStructureDataType;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public interface SemanticChangeEventType extends BaseModelChangeEventType {
     QualifiedProperty<SemanticChangeStructureDataType[]> CHANGES = new QualifiedProperty<>(
@@ -69,9 +69,9 @@ public interface SemanticChangeEventType extends BaseModelChangeEventType {
      * An asynchronous implementation of {@link #writeChanges(SemanticChangeStructureDataType[])}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeChangesAsync(SemanticChangeStructureDataType[] changes);
+    CompletableFuture<StatusCode> writeChangesAsync(SemanticChangeStructureDataType[] changes);
 
     /**
      * Get the Changes {@link PropertyType} Node, or {@code null} if it does not exist.

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/ServerCapabilitiesType.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/ServerCapabilitiesType.java
@@ -7,10 +7,10 @@ import org.eclipse.milo.opcua.sdk.core.QualifiedProperty;
 import org.eclipse.milo.opcua.sdk.core.ValueRanks;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UShort;
 import org.eclipse.milo.opcua.stack.core.types.structured.SignedSoftwareCertificate;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public interface ServerCapabilitiesType extends BaseObjectType {
     QualifiedProperty<String[]> SERVER_PROFILE_ARRAY = new QualifiedProperty<>(
@@ -143,9 +143,9 @@ public interface ServerCapabilitiesType extends BaseObjectType {
      * An asynchronous implementation of {@link #writeServerProfileArray(String[])}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeServerProfileArrayAsync(String[] serverProfileArray);
+    CompletableFuture<StatusCode> writeServerProfileArrayAsync(String[] serverProfileArray);
 
     /**
      * Get the ServerProfileArray {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -216,9 +216,9 @@ public interface ServerCapabilitiesType extends BaseObjectType {
      * An asynchronous implementation of {@link #writeLocaleIdArray(String[])}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeLocaleIdArrayAsync(String[] localeIdArray);
+    CompletableFuture<StatusCode> writeLocaleIdArrayAsync(String[] localeIdArray);
 
     /**
      * Get the LocaleIdArray {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -289,9 +289,9 @@ public interface ServerCapabilitiesType extends BaseObjectType {
      * An asynchronous implementation of {@link #writeMinSupportedSampleRate(Double)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeMinSupportedSampleRateAsync(Double minSupportedSampleRate);
+    CompletableFuture<StatusCode> writeMinSupportedSampleRateAsync(Double minSupportedSampleRate);
 
     /**
      * Get the MinSupportedSampleRate {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -362,9 +362,10 @@ public interface ServerCapabilitiesType extends BaseObjectType {
      * An asynchronous implementation of {@link #writeMaxBrowseContinuationPoints(UShort)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeMaxBrowseContinuationPointsAsync(UShort maxBrowseContinuationPoints);
+    CompletableFuture<StatusCode> writeMaxBrowseContinuationPointsAsync(
+        UShort maxBrowseContinuationPoints);
 
     /**
      * Get the MaxBrowseContinuationPoints {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -435,9 +436,10 @@ public interface ServerCapabilitiesType extends BaseObjectType {
      * An asynchronous implementation of {@link #writeMaxQueryContinuationPoints(UShort)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeMaxQueryContinuationPointsAsync(UShort maxQueryContinuationPoints);
+    CompletableFuture<StatusCode> writeMaxQueryContinuationPointsAsync(
+        UShort maxQueryContinuationPoints);
 
     /**
      * Get the MaxQueryContinuationPoints {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -508,9 +510,9 @@ public interface ServerCapabilitiesType extends BaseObjectType {
      * An asynchronous implementation of {@link #writeMaxHistoryContinuationPoints(UShort)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeMaxHistoryContinuationPointsAsync(
+    CompletableFuture<StatusCode> writeMaxHistoryContinuationPointsAsync(
         UShort maxHistoryContinuationPoints);
 
     /**
@@ -583,9 +585,9 @@ public interface ServerCapabilitiesType extends BaseObjectType {
      * An asynchronous implementation of {@link #writeSoftwareCertificates(SignedSoftwareCertificate[])}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeSoftwareCertificatesAsync(
+    CompletableFuture<StatusCode> writeSoftwareCertificatesAsync(
         SignedSoftwareCertificate[] softwareCertificates);
 
     /**
@@ -657,9 +659,9 @@ public interface ServerCapabilitiesType extends BaseObjectType {
      * An asynchronous implementation of {@link #writeMaxArrayLength(UInteger)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeMaxArrayLengthAsync(UInteger maxArrayLength);
+    CompletableFuture<StatusCode> writeMaxArrayLengthAsync(UInteger maxArrayLength);
 
     /**
      * Get the MaxArrayLength {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -730,9 +732,9 @@ public interface ServerCapabilitiesType extends BaseObjectType {
      * An asynchronous implementation of {@link #writeMaxStringLength(UInteger)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeMaxStringLengthAsync(UInteger maxStringLength);
+    CompletableFuture<StatusCode> writeMaxStringLengthAsync(UInteger maxStringLength);
 
     /**
      * Get the MaxStringLength {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -803,9 +805,9 @@ public interface ServerCapabilitiesType extends BaseObjectType {
      * An asynchronous implementation of {@link #writeMaxByteStringLength(UInteger)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeMaxByteStringLengthAsync(UInteger maxByteStringLength);
+    CompletableFuture<StatusCode> writeMaxByteStringLengthAsync(UInteger maxByteStringLength);
 
     /**
      * Get the MaxByteStringLength {@link PropertyType} Node, or {@code null} if it does not exist.

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/ServerConfigurationType.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/ServerConfigurationType.java
@@ -7,8 +7,8 @@ import org.eclipse.milo.opcua.sdk.core.QualifiedProperty;
 import org.eclipse.milo.opcua.sdk.core.ValueRanks;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public interface ServerConfigurationType extends BaseObjectType {
     QualifiedProperty<String[]> SERVER_CAPABILITIES = new QualifiedProperty<>(
@@ -93,9 +93,9 @@ public interface ServerConfigurationType extends BaseObjectType {
      * An asynchronous implementation of {@link #writeServerCapabilities(String[])}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeServerCapabilitiesAsync(String[] serverCapabilities);
+    CompletableFuture<StatusCode> writeServerCapabilitiesAsync(String[] serverCapabilities);
 
     /**
      * Get the ServerCapabilities {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -166,9 +166,10 @@ public interface ServerConfigurationType extends BaseObjectType {
      * An asynchronous implementation of {@link #writeSupportedPrivateKeyFormats(String[])}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeSupportedPrivateKeyFormatsAsync(String[] supportedPrivateKeyFormats);
+    CompletableFuture<StatusCode> writeSupportedPrivateKeyFormatsAsync(
+        String[] supportedPrivateKeyFormats);
 
     /**
      * Get the SupportedPrivateKeyFormats {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -239,9 +240,9 @@ public interface ServerConfigurationType extends BaseObjectType {
      * An asynchronous implementation of {@link #writeMaxTrustListSize(UInteger)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeMaxTrustListSizeAsync(UInteger maxTrustListSize);
+    CompletableFuture<StatusCode> writeMaxTrustListSizeAsync(UInteger maxTrustListSize);
 
     /**
      * Get the MaxTrustListSize {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -312,9 +313,9 @@ public interface ServerConfigurationType extends BaseObjectType {
      * An asynchronous implementation of {@link #writeMulticastDnsEnabled(Boolean)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeMulticastDnsEnabledAsync(Boolean multicastDnsEnabled);
+    CompletableFuture<StatusCode> writeMulticastDnsEnabledAsync(Boolean multicastDnsEnabled);
 
     /**
      * Get the MulticastDnsEnabled {@link PropertyType} Node, or {@code null} if it does not exist.

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/ServerDiagnosticsType.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/ServerDiagnosticsType.java
@@ -10,10 +10,10 @@ import org.eclipse.milo.opcua.sdk.core.QualifiedProperty;
 import org.eclipse.milo.opcua.sdk.core.ValueRanks;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.structured.SamplingIntervalDiagnosticsDataType;
 import org.eclipse.milo.opcua.stack.core.types.structured.ServerDiagnosticsSummaryDataType;
 import org.eclipse.milo.opcua.stack.core.types.structured.SubscriptionDiagnosticsDataType;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public interface ServerDiagnosticsType extends BaseObjectType {
     QualifiedProperty<Boolean> ENABLED_FLAG = new QualifiedProperty<>(
@@ -74,9 +74,9 @@ public interface ServerDiagnosticsType extends BaseObjectType {
      * An asynchronous implementation of {@link #writeEnabledFlag(Boolean)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeEnabledFlagAsync(Boolean enabledFlag);
+    CompletableFuture<StatusCode> writeEnabledFlagAsync(Boolean enabledFlag);
 
     /**
      * Get the EnabledFlag {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -149,9 +149,9 @@ public interface ServerDiagnosticsType extends BaseObjectType {
      * An asynchronous implementation of {@link #writeServerDiagnosticsSummary(ServerDiagnosticsSummaryDataType)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeServerDiagnosticsSummaryAsync(
+    CompletableFuture<StatusCode> writeServerDiagnosticsSummaryAsync(
         ServerDiagnosticsSummaryDataType serverDiagnosticsSummary);
 
     /**
@@ -226,9 +226,9 @@ public interface ServerDiagnosticsType extends BaseObjectType {
      * An asynchronous implementation of {@link #writeSamplingIntervalDiagnosticsArray(SamplingIntervalDiagnosticsDataType[])}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeSamplingIntervalDiagnosticsArrayAsync(
+    CompletableFuture<StatusCode> writeSamplingIntervalDiagnosticsArrayAsync(
         SamplingIntervalDiagnosticsDataType[] samplingIntervalDiagnosticsArray);
 
     /**
@@ -304,9 +304,9 @@ public interface ServerDiagnosticsType extends BaseObjectType {
      * An asynchronous implementation of {@link #writeSubscriptionDiagnosticsArray(SubscriptionDiagnosticsDataType[])}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeSubscriptionDiagnosticsArrayAsync(
+    CompletableFuture<StatusCode> writeSubscriptionDiagnosticsArrayAsync(
         SubscriptionDiagnosticsDataType[] subscriptionDiagnosticsArray);
 
     /**

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/ServerRedundancyType.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/ServerRedundancyType.java
@@ -7,8 +7,8 @@ import org.eclipse.milo.opcua.sdk.core.QualifiedProperty;
 import org.eclipse.milo.opcua.sdk.core.ValueRanks;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.RedundancySupport;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public interface ServerRedundancyType extends BaseObjectType {
     QualifiedProperty<RedundancySupport> REDUNDANCY_SUPPORT = new QualifiedProperty<>(
@@ -69,9 +69,9 @@ public interface ServerRedundancyType extends BaseObjectType {
      * An asynchronous implementation of {@link #writeRedundancySupport(RedundancySupport)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeRedundancySupportAsync(RedundancySupport redundancySupport);
+    CompletableFuture<StatusCode> writeRedundancySupportAsync(RedundancySupport redundancySupport);
 
     /**
      * Get the RedundancySupport {@link PropertyType} Node, or {@code null} if it does not exist.

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/ServerType.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/ServerType.java
@@ -9,9 +9,9 @@ import org.eclipse.milo.opcua.sdk.core.ValueRanks;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.structured.ServerStatusDataType;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public interface ServerType extends BaseObjectType {
     QualifiedProperty<String[]> SERVER_ARRAY = new QualifiedProperty<>(
@@ -104,9 +104,9 @@ public interface ServerType extends BaseObjectType {
      * An asynchronous implementation of {@link #writeServerArray(String[])}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeServerArrayAsync(String[] serverArray);
+    CompletableFuture<StatusCode> writeServerArrayAsync(String[] serverArray);
 
     /**
      * Get the ServerArray {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -177,9 +177,9 @@ public interface ServerType extends BaseObjectType {
      * An asynchronous implementation of {@link #writeNamespaceArray(String[])}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeNamespaceArrayAsync(String[] namespaceArray);
+    CompletableFuture<StatusCode> writeNamespaceArrayAsync(String[] namespaceArray);
 
     /**
      * Get the NamespaceArray {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -250,9 +250,9 @@ public interface ServerType extends BaseObjectType {
      * An asynchronous implementation of {@link #writeServiceLevel(UByte)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeServiceLevelAsync(UByte serviceLevel);
+    CompletableFuture<StatusCode> writeServiceLevelAsync(UByte serviceLevel);
 
     /**
      * Get the ServiceLevel {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -323,9 +323,9 @@ public interface ServerType extends BaseObjectType {
      * An asynchronous implementation of {@link #writeAuditing(Boolean)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeAuditingAsync(Boolean auditing);
+    CompletableFuture<StatusCode> writeAuditingAsync(Boolean auditing);
 
     /**
      * Get the Auditing {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -396,9 +396,9 @@ public interface ServerType extends BaseObjectType {
      * An asynchronous implementation of {@link #writeEstimatedReturnTime(DateTime)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeEstimatedReturnTimeAsync(DateTime estimatedReturnTime);
+    CompletableFuture<StatusCode> writeEstimatedReturnTimeAsync(DateTime estimatedReturnTime);
 
     /**
      * Get the EstimatedReturnTime {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -469,9 +469,9 @@ public interface ServerType extends BaseObjectType {
      * An asynchronous implementation of {@link #writeServerStatus(ServerStatusDataType)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeServerStatusAsync(ServerStatusDataType serverStatus);
+    CompletableFuture<StatusCode> writeServerStatusAsync(ServerStatusDataType serverStatus);
 
     /**
      * Get the ServerStatus {@link ServerStatusType} Node, or {@code null} if it does not exist.

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/SessionDiagnosticsObjectType.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/SessionDiagnosticsObjectType.java
@@ -6,10 +6,10 @@ import org.eclipse.milo.opcua.sdk.client.model.types.variables.SessionDiagnostic
 import org.eclipse.milo.opcua.sdk.client.model.types.variables.SessionSecurityDiagnosticsType;
 import org.eclipse.milo.opcua.sdk.client.model.types.variables.SubscriptionDiagnosticsArrayType;
 import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.structured.SessionDiagnosticsDataType;
 import org.eclipse.milo.opcua.stack.core.types.structured.SessionSecurityDiagnosticsDataType;
 import org.eclipse.milo.opcua.stack.core.types.structured.SubscriptionDiagnosticsDataType;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public interface SessionDiagnosticsObjectType extends BaseObjectType {
     /**
@@ -62,9 +62,9 @@ public interface SessionDiagnosticsObjectType extends BaseObjectType {
      * An asynchronous implementation of {@link #writeSessionDiagnostics(SessionDiagnosticsDataType)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeSessionDiagnosticsAsync(
+    CompletableFuture<StatusCode> writeSessionDiagnosticsAsync(
         SessionDiagnosticsDataType sessionDiagnostics);
 
     /**
@@ -139,9 +139,9 @@ public interface SessionDiagnosticsObjectType extends BaseObjectType {
      * An asynchronous implementation of {@link #writeSessionSecurityDiagnostics(SessionSecurityDiagnosticsDataType)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeSessionSecurityDiagnosticsAsync(
+    CompletableFuture<StatusCode> writeSessionSecurityDiagnosticsAsync(
         SessionSecurityDiagnosticsDataType sessionSecurityDiagnostics);
 
     /**
@@ -217,9 +217,9 @@ public interface SessionDiagnosticsObjectType extends BaseObjectType {
      * An asynchronous implementation of {@link #writeSubscriptionDiagnosticsArray(SubscriptionDiagnosticsDataType[])}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeSubscriptionDiagnosticsArrayAsync(
+    CompletableFuture<StatusCode> writeSubscriptionDiagnosticsArrayAsync(
         SubscriptionDiagnosticsDataType[] subscriptionDiagnosticsArray);
 
     /**

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/SessionsDiagnosticsSummaryType.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/SessionsDiagnosticsSummaryType.java
@@ -5,9 +5,9 @@ import java.util.concurrent.CompletableFuture;
 import org.eclipse.milo.opcua.sdk.client.model.types.variables.SessionDiagnosticsArrayType;
 import org.eclipse.milo.opcua.sdk.client.model.types.variables.SessionSecurityDiagnosticsArrayType;
 import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.structured.SessionDiagnosticsDataType;
 import org.eclipse.milo.opcua.stack.core.types.structured.SessionSecurityDiagnosticsDataType;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public interface SessionsDiagnosticsSummaryType extends BaseObjectType {
     /**
@@ -62,9 +62,9 @@ public interface SessionsDiagnosticsSummaryType extends BaseObjectType {
      * An asynchronous implementation of {@link #writeSessionDiagnosticsArray(SessionDiagnosticsDataType[])}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeSessionDiagnosticsArrayAsync(
+    CompletableFuture<StatusCode> writeSessionDiagnosticsArrayAsync(
         SessionDiagnosticsDataType[] sessionDiagnosticsArray);
 
     /**
@@ -139,9 +139,9 @@ public interface SessionsDiagnosticsSummaryType extends BaseObjectType {
      * An asynchronous implementation of {@link #writeSessionSecurityDiagnosticsArray(SessionSecurityDiagnosticsDataType[])}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeSessionSecurityDiagnosticsArrayAsync(
+    CompletableFuture<StatusCode> writeSessionSecurityDiagnosticsArrayAsync(
         SessionSecurityDiagnosticsDataType[] sessionSecurityDiagnosticsArray);
 
     /**

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/ShelvedStateMachineType.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/ShelvedStateMachineType.java
@@ -7,7 +7,7 @@ import org.eclipse.milo.opcua.sdk.core.QualifiedProperty;
 import org.eclipse.milo.opcua.sdk.core.ValueRanks;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 
 public interface ShelvedStateMachineType extends FiniteStateMachineType {
     QualifiedProperty<Double> UNSHELVE_TIME = new QualifiedProperty<>(
@@ -68,9 +68,9 @@ public interface ShelvedStateMachineType extends FiniteStateMachineType {
      * An asynchronous implementation of {@link #writeUnshelveTime(Double)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeUnshelveTimeAsync(Double unshelveTime);
+    CompletableFuture<StatusCode> writeUnshelveTimeAsync(Double unshelveTime);
 
     /**
      * Get the UnshelveTime {@link PropertyType} Node, or {@code null} if it does not exist.

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/StateMachineType.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/StateMachineType.java
@@ -6,7 +6,7 @@ import org.eclipse.milo.opcua.sdk.client.model.types.variables.StateVariableType
 import org.eclipse.milo.opcua.sdk.client.model.types.variables.TransitionVariableType;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 
 public interface StateMachineType extends BaseObjectType {
     /**
@@ -59,9 +59,9 @@ public interface StateMachineType extends BaseObjectType {
      * An asynchronous implementation of {@link #writeCurrentState(LocalizedText)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeCurrentStateAsync(LocalizedText currentState);
+    CompletableFuture<StatusCode> writeCurrentStateAsync(LocalizedText currentState);
 
     /**
      * Get the CurrentState {@link StateVariableType} Node, or {@code null} if it does not exist.
@@ -132,9 +132,9 @@ public interface StateMachineType extends BaseObjectType {
      * An asynchronous implementation of {@link #writeLastTransition(LocalizedText)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeLastTransitionAsync(LocalizedText lastTransition);
+    CompletableFuture<StatusCode> writeLastTransitionAsync(LocalizedText lastTransition);
 
     /**
      * Get the LastTransition {@link TransitionVariableType} Node, or {@code null} if it does not exist.

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/StateType.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/StateType.java
@@ -7,8 +7,8 @@ import org.eclipse.milo.opcua.sdk.core.QualifiedProperty;
 import org.eclipse.milo.opcua.sdk.core.ValueRanks;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public interface StateType extends BaseObjectType {
     QualifiedProperty<UInteger> STATE_NUMBER = new QualifiedProperty<>(
@@ -69,9 +69,9 @@ public interface StateType extends BaseObjectType {
      * An asynchronous implementation of {@link #writeStateNumber(UInteger)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeStateNumberAsync(UInteger stateNumber);
+    CompletableFuture<StatusCode> writeStateNumberAsync(UInteger stateNumber);
 
     /**
      * Get the StateNumber {@link PropertyType} Node, or {@code null} if it does not exist.

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/SystemStatusChangeEventType.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/SystemStatusChangeEventType.java
@@ -7,8 +7,8 @@ import org.eclipse.milo.opcua.sdk.core.QualifiedProperty;
 import org.eclipse.milo.opcua.sdk.core.ValueRanks;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.ServerState;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public interface SystemStatusChangeEventType extends SystemEventType {
     QualifiedProperty<ServerState> SYSTEM_STATE = new QualifiedProperty<>(
@@ -69,9 +69,9 @@ public interface SystemStatusChangeEventType extends SystemEventType {
      * An asynchronous implementation of {@link #writeSystemState(ServerState)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeSystemStateAsync(ServerState systemState);
+    CompletableFuture<StatusCode> writeSystemStateAsync(ServerState systemState);
 
     /**
      * Get the SystemState {@link PropertyType} Node, or {@code null} if it does not exist.

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/TransitionEventType.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/TransitionEventType.java
@@ -6,7 +6,7 @@ import org.eclipse.milo.opcua.sdk.client.model.types.variables.StateVariableType
 import org.eclipse.milo.opcua.sdk.client.model.types.variables.TransitionVariableType;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 
 public interface TransitionEventType extends BaseEventType {
     /**
@@ -59,9 +59,9 @@ public interface TransitionEventType extends BaseEventType {
      * An asynchronous implementation of {@link #writeTransition(LocalizedText)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeTransitionAsync(LocalizedText transition);
+    CompletableFuture<StatusCode> writeTransitionAsync(LocalizedText transition);
 
     /**
      * Get the Transition {@link TransitionVariableType} Node, or {@code null} if it does not exist.
@@ -132,9 +132,9 @@ public interface TransitionEventType extends BaseEventType {
      * An asynchronous implementation of {@link #writeFromState(LocalizedText)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeFromStateAsync(LocalizedText fromState);
+    CompletableFuture<StatusCode> writeFromStateAsync(LocalizedText fromState);
 
     /**
      * Get the FromState {@link StateVariableType} Node, or {@code null} if it does not exist.
@@ -205,9 +205,9 @@ public interface TransitionEventType extends BaseEventType {
      * An asynchronous implementation of {@link #writeToState(LocalizedText)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeToStateAsync(LocalizedText toState);
+    CompletableFuture<StatusCode> writeToStateAsync(LocalizedText toState);
 
     /**
      * Get the ToState {@link StateVariableType} Node, or {@code null} if it does not exist.

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/TransitionType.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/TransitionType.java
@@ -7,8 +7,8 @@ import org.eclipse.milo.opcua.sdk.core.QualifiedProperty;
 import org.eclipse.milo.opcua.sdk.core.ValueRanks;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public interface TransitionType extends BaseObjectType {
     QualifiedProperty<UInteger> TRANSITION_NUMBER = new QualifiedProperty<>(
@@ -69,9 +69,9 @@ public interface TransitionType extends BaseObjectType {
      * An asynchronous implementation of {@link #writeTransitionNumber(UInteger)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeTransitionNumberAsync(UInteger transitionNumber);
+    CompletableFuture<StatusCode> writeTransitionNumberAsync(UInteger transitionNumber);
 
     /**
      * Get the TransitionNumber {@link PropertyType} Node, or {@code null} if it does not exist.

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/TransparentRedundancyType.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/TransparentRedundancyType.java
@@ -7,8 +7,8 @@ import org.eclipse.milo.opcua.sdk.core.QualifiedProperty;
 import org.eclipse.milo.opcua.sdk.core.ValueRanks;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.structured.RedundantServerDataType;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public interface TransparentRedundancyType extends ServerRedundancyType {
     QualifiedProperty<String> CURRENT_SERVER_ID = new QualifiedProperty<>(
@@ -77,9 +77,9 @@ public interface TransparentRedundancyType extends ServerRedundancyType {
      * An asynchronous implementation of {@link #writeCurrentServerId(String)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeCurrentServerIdAsync(String currentServerId);
+    CompletableFuture<StatusCode> writeCurrentServerIdAsync(String currentServerId);
 
     /**
      * Get the CurrentServerId {@link PropertyType} Node, or {@code null} if it does not exist.
@@ -150,9 +150,9 @@ public interface TransparentRedundancyType extends ServerRedundancyType {
      * An asynchronous implementation of {@link #writeRedundantServerArray(RedundantServerDataType[])}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeRedundantServerArrayAsync(
+    CompletableFuture<StatusCode> writeRedundantServerArrayAsync(
         RedundantServerDataType[] redundantServerArray);
 
     /**

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/TrustListType.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/types/objects/TrustListType.java
@@ -8,7 +8,7 @@ import org.eclipse.milo.opcua.sdk.core.ValueRanks;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
-import org.eclipse.milo.opcua.stack.core.util.Unit;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 
 public interface TrustListType extends FileType {
     QualifiedProperty<DateTime> LAST_UPDATE_TIME = new QualifiedProperty<>(
@@ -69,9 +69,9 @@ public interface TrustListType extends FileType {
      * An asynchronous implementation of {@link #writeLastUpdateTime(DateTime)}.
      *
      * @return a CompletableFuture that completes successfully with the operation result or
-     * completes exceptionally if an operation- or service-level error occurs.
+     * completes exceptionally if a service-level error occurs.
      */
-    CompletableFuture<Unit> writeLastUpdateTimeAsync(DateTime lastUpdateTime);
+    CompletableFuture<StatusCode> writeLastUpdateTimeAsync(DateTime lastUpdateTime);
 
     /**
      * Get the LastUpdateTime {@link PropertyType} Node, or {@code null} if it does not exist.


### PR DESCRIPTION
New nodes have two changes:
1. read/get methods now handle enum and enum array values
2. object write methods return StatusCode instead of Unit, like variables

fixes #703
