### PR TITLE
Notify subscription transfer failed after *any* failure

### DIFF
--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/session/SessionFsmFactory.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/session/SessionFsmFactory.java
@@ -1003,26 +1003,36 @@ public class SessionFsmFactory {
                         .map(UaException::getStatusCode)
                         .orElse(StatusCode.BAD);
 
-                    // Bad_ServiceUnsupported is the correct response when transfers aren't supported but
-                    // server implementations tend to interpret the spec in their own unique way...
+                    LOGGER.debug("[{}] TransferSubscriptions not supported: {}", ctx.getInstanceId(), statusCode);
+
+                    client.getConfig().getExecutor().execute(() -> {
+                        // transferFailed() will remove the subscription, but that is okay
+                        // because the list from getSubscriptions() above is a copy.
+                        for (UaSubscription subscription : subscriptions) {
+                            subscriptionManager.transferFailed(
+                                subscription.getSubscriptionId(), statusCode);
+                        }
+                    });
+
+                    // Bad_ServiceUnsupported is the correct response when transfers aren't
+                    // supported but server implementations interpret the spec differently.
                     if (statusCode.getValue() == StatusCodes.Bad_NotImplemented ||
                         statusCode.getValue() == StatusCodes.Bad_NotSupported ||
                         statusCode.getValue() == StatusCodes.Bad_OutOfService ||
                         statusCode.getValue() == StatusCodes.Bad_ServiceUnsupported) {
 
-                        LOGGER.debug("[{}] TransferSubscriptions not supported: {}", ctx.getInstanceId(), statusCode);
-
-                        client.getConfig().getExecutor().execute(() -> {
-                            // transferFailed() will remove the subscription, but that is okay
-                            // because the list from getSubscriptions() above is a copy.
-                            for (UaSubscription subscription : subscriptions) {
-                                subscriptionManager.transferFailed(
-                                    subscription.getSubscriptionId(), statusCode);
-                            }
-                        });
+                        // One of the expected responses; continue moving through the FSM.
 
                         transferFuture.complete(Unit.VALUE);
                     } else {
+                        // An unexpected response; complete exceptionally and start over.
+                        // Subsequent runs through the FSM will not attempt transfer because
+                        // transferFailed() has been called for all the existing subscriptions.
+                        // This will prevent us from getting stuck in a "loop" attempting to
+                        // reconnect to a defective server that responds with a channel-level
+                        // Error message to subscription transfer requests instead of an
+                        // application-level ServiceFault.
+
                         transferFuture.completeExceptionally(ex);
                     }
                 }


### PR DESCRIPTION
This prevents the FSM from getting stuck in a reconnect "loop" when a
defective server doesn't respond with one of the expected StatusCodes or
doesn't respond with a ServiceFault at all, e.g. responding instead with
a channel layer Error message instead.

The main consequence of this is that subscription transfer will only be
attempted once after re-establishing a session, leaving a small possibility
that some legitimate type of failure, such as a connection interruption,
occurring as the subscriptions are being transferred results in the
subscriptions being subsequently re-created when it may have been possible
to transfer them.

fixes #722
