### PR TITLE
Get certificate bytes from endpoint when constructing signature data

### DIFF
--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/AbstractX509IdentityValidator.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/AbstractX509IdentityValidator.java
@@ -104,8 +104,8 @@ public abstract class AbstractX509IdentityValidator<T> extends AbstractIdentityV
     ) throws UaException {
 
         ByteString serverCertificateBs = session
-            .getSecurityConfiguration()
-            .getServerCertificateBytes();
+            .getEndpoint()
+            .getServerCertificate();
 
         ByteString lastNonceBs = session.getLastNonce();
 


### PR DESCRIPTION
When SecurityPolicy.None is being used the certificate bytes from SecurityConfiguration will be
empty, causing the signature validation to fail because the client will have constructed the data
using the certificate bytes from the EndpointDescription.

fixes #770
