### PR TITLE
Update netty-channel-fsm to version 0.5

### DIFF
--- a/opc-ua-stack/stack-client/pom.xml
+++ b/opc-ua-stack/stack-client/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>com.digitalpetri.netty</groupId>
             <artifactId>netty-channel-fsm</artifactId>
-            <version>0.3</version>
+            <version>0.5</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>


### PR DESCRIPTION
This version and its transitive dependency strict-machine 0.4 both include
Automatic-Module-Name entries in their MANIFEST.MF files.
