### PR TITLE
Remove check preventing Variant construction with DataValue

### DIFF
--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/builtin/Variant.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/builtin/Variant.java
@@ -44,7 +44,6 @@ public final class Variant {
                 ArrayUtil.getType(value) : value.getClass();
 
             checkArgument(clazzIsArray || !Variant.class.equals(componentClazz), "Variant cannot contain Variant");
-            checkArgument(!DataValue.class.equals(componentClazz), "Variant cannot contain DataValue");
             checkArgument(!DiagnosticInfo.class.equals(componentClazz), "Variant cannot contain DiagnosticInfo");
         }
 

--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/types/builtin/VariantTest.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/types/builtin/VariantTest.java
@@ -15,18 +15,18 @@ import org.testng.annotations.Test;
 public class VariantTest {
 
     @Test
-    public void testVariantCanContainVariantArray() {
-        new Variant(new Variant[] {new Variant(0), new Variant(1), new Variant(2)});
+    public void variantCanContainDataValue() {
+        new Variant(new DataValue(Variant.NULL_VALUE));
+    }
+
+    @Test
+    public void variantCanContainVariantArray() {
+        new Variant(new Variant[]{new Variant(0), new Variant(1), new Variant(2)});
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void variantCannotContainVariant() {
         new Variant(new Variant(null));
-    }
-
-    @Test(expectedExceptions = IllegalArgumentException.class)
-    public void variantCannotContainDataValue() {
-        new Variant(new DataValue(Variant.NULL_VALUE));
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)


### PR DESCRIPTION
OPC UA 1.04 further clarifies that it is legal to construct a Variant
containing a DataValue for use in e.g. method arguments or PubSub but it is
not legal for a DataValue to contain such a Variant. Without knowledge of
where the Variant will be used it does not make sense to restrict construction
of such a Variant.

fixes #805