### PR TITLE
Fix NPEs on transition to CreatingWait state

### DIFF
--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/session/SessionFsmFactory.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/session/SessionFsmFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 the Eclipse Milo Authors
+ * Copyright (c) 2021 the Eclipse Milo Authors
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -255,7 +255,7 @@ public class SessionFsmFactory {
         fb.when(State.Creating)
             .on(Event.CreateSessionFailure.class)
             .transitionTo(State.CreatingWait)
-            .execute(ctx -> {
+            .executeFirst(ctx -> {
                 Event.CreateSessionFailure e = (Event.CreateSessionFailure) ctx.event();
 
                 handleFailureToOpenSession(client, ctx, e.failure);
@@ -331,7 +331,7 @@ public class SessionFsmFactory {
         fb.when(State.Activating)
             .on(Event.ActivateSessionFailure.class)
             .transitionTo(State.CreatingWait)
-            .execute(ctx -> {
+            .executeFirst(ctx -> {
                 Event.ActivateSessionFailure e = (Event.ActivateSessionFailure) ctx.event();
 
                 handleFailureToOpenSession(client, ctx, e.failure);
@@ -385,7 +385,7 @@ public class SessionFsmFactory {
         fb.when(State.Transferring)
             .on(Event.TransferSubscriptionsFailure.class)
             .transitionTo(State.CreatingWait)
-            .execute(ctx -> {
+            .executeFirst(ctx -> {
                 Event.TransferSubscriptionsFailure e = (Event.TransferSubscriptionsFailure) ctx.event();
 
                 handleFailureToOpenSession(client, ctx, e.failure);
@@ -441,7 +441,7 @@ public class SessionFsmFactory {
         fb.when(State.Initializing)
             .on(Event.InitializeFailure.class)
             .transitionTo(State.CreatingWait)
-            .execute(ctx -> {
+            .executeFirst(ctx -> {
                 Event.InitializeFailure e = (Event.InitializeFailure) ctx.event();
 
                 handleFailureToOpenSession(client, ctx, e.failure);
@@ -541,7 +541,7 @@ public class SessionFsmFactory {
             .to(s -> s == State.Closing || s == State.CreatingWait)
             .viaAny()
             .execute(ctx -> {
-                ScheduledFuture scheduledFuture =
+                ScheduledFuture<?> scheduledFuture =
                     KEY_KEEP_ALIVE_SCHEDULED_FUTURE.remove(ctx);
 
                 if (scheduledFuture != null) {
@@ -1062,7 +1062,7 @@ public class SessionFsmFactory {
         } else {
             UaStackClient stackClient = client.getStackClient();
 
-            CompletableFuture[] futures = initializers.stream()
+            CompletableFuture<?>[] futures = initializers.stream()
                 .map(i -> i.initialize(stackClient, session))
                 .toArray(CompletableFuture[]::new);
 

--- a/opc-ua-stack/stack-client/pom.xml
+++ b/opc-ua-stack/stack-client/pom.xml
@@ -1,4 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2021 the Eclipse Milo Authors
+  ~
+  ~ This program and the accompanying materials are made
+  ~ available under the terms of the Eclipse Public License 2.0
+  ~ which is available at https://www.eclipse.org/legal/epl-2.0/
+  ~
+  ~ SPDX-License-Identifier: EPL-2.0
+  -->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -23,6 +33,17 @@
         <dependency>
             <groupId>com.digitalpetri.netty</groupId>
             <artifactId>netty-channel-fsm</artifactId>
+            <version>0.5</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.digitalpetri.fsm</groupId>
+                    <artifactId>strict-machine</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.digitalpetri.fsm</groupId>
+            <artifactId>strict-machine</artifactId>
             <version>0.5</version>
         </dependency>
         <dependency>

--- a/opc-ua-stack/stack-client/pom.xml
+++ b/opc-ua-stack/stack-client/pom.xml
@@ -1,14 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-  ~ Copyright (c) 2021 the Eclipse Milo Authors
-  ~
-  ~ This program and the accompanying materials are made
-  ~ available under the terms of the Eclipse Public License 2.0
-  ~ which is available at https://www.eclipse.org/legal/epl-2.0/
-  ~
-  ~ SPDX-License-Identifier: EPL-2.0
-  -->
-
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
Ensure that handleFailureToOpenSession is the first transition action
to run when transitioning to CreatingWait state.

fixes #807
