### PR TITLE
Fix Bad_NotFound calling methods with no InputArguments or OutputArguments

### DIFF
--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/AddressSpaceTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/AddressSpaceTest.java
@@ -84,7 +84,7 @@ public class AddressSpaceTest extends AbstractClientServerTest {
 
             List<? extends UaNode> nodes = addressSpace.browseNodes(objectsFolderNode, browseOptions);
 
-            assertEquals(5, nodes.size());
+            assertEquals(6, nodes.size());
             assertTrue(nodes.stream().anyMatch(n -> n.getNodeId().equals(Identifiers.RootFolder)));
             assertTrue(nodes.stream().anyMatch(n -> n.getNodeId().equals(Identifiers.Server)));
         }

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/methods/UaMethodTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/methods/UaMethodTest.java
@@ -142,4 +142,18 @@ public class UaMethodTest extends AbstractClientServerTest {
         assertEquals(4.0, outputs[0].getValue());
     }
 
+    @Test
+    public void callMethodWithNoInputsOrOutputs() throws UaException {
+        AddressSpace addressSpace = client.getAddressSpace();
+
+        UaObjectNode objectsNode = addressSpace.getObjectNode(Identifiers.ObjectsFolder);
+
+        Variant[] outputs = objectsNode.callMethod(
+            new QualifiedName(2, "hasNoInputsOrOutputs()"),
+            new Variant[0]
+        );
+
+        assertEquals(0, outputs.length);
+    }
+
 }

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/test/TestNamespace.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/test/TestNamespace.java
@@ -22,6 +22,7 @@ import org.eclipse.milo.opcua.sdk.server.UaNodeManager;
 import org.eclipse.milo.opcua.sdk.server.api.DataItem;
 import org.eclipse.milo.opcua.sdk.server.api.ManagedNamespaceWithLifecycle;
 import org.eclipse.milo.opcua.sdk.server.api.MonitoredItem;
+import org.eclipse.milo.opcua.sdk.server.api.methods.AbstractMethodInvocationHandler;
 import org.eclipse.milo.opcua.sdk.server.model.nodes.objects.BaseEventTypeNode;
 import org.eclipse.milo.opcua.sdk.server.model.nodes.objects.ServerTypeNode;
 import org.eclipse.milo.opcua.sdk.server.model.nodes.variables.AnalogItemTypeNode;
@@ -39,6 +40,7 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
+import org.eclipse.milo.opcua.stack.core.types.structured.Argument;
 import org.eclipse.milo.opcua.stack.core.types.structured.Range;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -166,6 +168,40 @@ public class TestNamespace extends ManagedNamespaceWithLifecycle {
                 methodNode.setInputArguments(sqrtMethod.getInputArguments());
                 methodNode.setOutputArguments(sqrtMethod.getOutputArguments());
                 methodNode.setInvocationHandler(sqrtMethod);
+
+                return methodNode;
+            });
+
+            UaMethodNode.build(getNodeContext(), b -> {
+                b.setNodeId(newNodeId("hasNoInputsOrOutputs()"));
+                b.setBrowseName(newQualifiedName("hasNoInputsOrOutputs()"));
+                b.setDisplayName(LocalizedText.english("hasNoInputsOrOutputs()"));
+
+                b.addReference(new Reference(
+                    b.getNodeId(),
+                    Identifiers.HasOrderedComponent,
+                    Identifiers.ObjectsFolder.expanded(),
+                    Reference.Direction.INVERSE
+                ));
+
+                UaMethodNode methodNode = b.buildAndAdd();
+
+                methodNode.setInvocationHandler(new AbstractMethodInvocationHandler(methodNode) {
+                    @Override
+                    public Argument[] getInputArguments() {
+                        return new Argument[0];
+                    }
+
+                    @Override
+                    public Argument[] getOutputArguments() {
+                        return new Argument[0];
+                    }
+
+                    @Override
+                    protected Variant[] invoke(InvocationContext invocationContext, Variant[] inputValues) throws UaException {
+                        return new Variant[0];
+                    }
+                });
 
                 return methodNode;
             });

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/nodes/UaMethodNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/nodes/UaMethodNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 the Eclipse Milo Authors
+ * Copyright (c) 2021 the Eclipse Milo Authors
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -209,7 +209,7 @@ public class UaMethodNode extends UaNode implements MethodNode {
      * @return the value of the InputArguments Property, if it exists.
      * @see MethodNodeProperties
      */
-    public CompletableFuture<? extends Argument[]> readInputArgumentsAsync() {
+    public CompletableFuture<Argument[]> readInputArgumentsAsync() {
         return getProperty(MethodNodeProperties.InputArguments);
     }
 
@@ -224,7 +224,7 @@ public class UaMethodNode extends UaNode implements MethodNode {
      * @return the value of the OutputArguments Property, if it exists.
      * @see MethodNodeProperties
      */
-    public CompletableFuture<? extends Argument[]> readOutputArgumentsAsync() {
+    public CompletableFuture<Argument[]> readOutputArgumentsAsync() {
         return getProperty(MethodNodeProperties.OutputArguments);
     }
 

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/nodes/UaObjectNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/nodes/UaObjectNode.java
@@ -40,6 +40,7 @@ import org.eclipse.milo.opcua.stack.core.types.enumerated.BrowseDirection;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.BrowseResultMask;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.NamingRuleType;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
+import org.eclipse.milo.opcua.stack.core.types.structured.Argument;
 import org.eclipse.milo.opcua.stack.core.types.structured.BrowseDescription;
 import org.eclipse.milo.opcua.stack.core.types.structured.BrowseResult;
 import org.eclipse.milo.opcua.stack.core.types.structured.ReferenceDescription;
@@ -286,8 +287,16 @@ public class UaObjectNode extends UaNode implements ObjectNode {
                                 addressSpace.getNodeAsync(nodeId).thenCompose(node -> {
                                     UaMethodNode methodNode = (UaMethodNode) node;
 
-                                    return methodNode.readInputArgumentsAsync().thenCombine(
-                                        methodNode.readOutputArgumentsAsync(),
+                                    CompletableFuture<Argument[]> inputArguments =
+                                        methodNode.readInputArgumentsAsync()
+                                            .exceptionally(t -> new Argument[0]);
+
+                                    CompletableFuture<Argument[]> outputArguments =
+                                        methodNode.readOutputArgumentsAsync()
+                                            .exceptionally(t -> new Argument[0]);
+
+                                    return inputArguments.thenCombine(
+                                        outputArguments,
                                         (in, out) -> new UaMethod(client, this, methodNode, in, out)
                                     );
                                 })


### PR DESCRIPTION
MethodNodes are allowed to omit the InputArguments and OutputArguments
PropertyNodes all together rather than using Nodes with empty values.

fixes #815
