### PR TITLE
Enable security by default in the client examples

### DIFF
--- a/milo-examples/client-examples/src/main/java/org/eclipse/milo/examples/client/ClientExample.java
+++ b/milo-examples/client-examples/src/main/java/org/eclipse/milo/examples/client/ClientExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 the Eclipse Milo Authors
+ * Copyright (c) 2021 the Eclipse Milo Authors
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -27,11 +27,11 @@ public interface ClientExample {
     }
 
     default Predicate<EndpointDescription> endpointFilter() {
-        return e -> true;
+        return e -> getSecurityPolicy().getUri().equals(e.getSecurityPolicyUri());
     }
 
     default SecurityPolicy getSecurityPolicy() {
-        return SecurityPolicy.None;
+        return SecurityPolicy.Basic256Sha256;
     }
 
     default IdentityProvider getIdentityProvider() {

--- a/milo-examples/client-examples/src/main/java/org/eclipse/milo/examples/client/ClientExampleRunner.java
+++ b/milo-examples/client-examples/src/main/java/org/eclipse/milo/examples/client/ClientExampleRunner.java
@@ -64,20 +64,22 @@ public class ClientExampleRunner {
     }
 
     private OpcUaClient createClient() throws Exception {
-        Path securityTempDir = Paths.get(System.getProperty("java.io.tmpdir"), "client-example", "security");
+        Path securityTempDir = Paths.get(System.getProperty("java.io.tmpdir"), "client", "security");
         Files.createDirectories(securityTempDir);
         if (!Files.exists(securityTempDir)) {
             throw new Exception("unable to create security dir: " + securityTempDir);
         }
 
+        File pkiDir = securityTempDir.resolve("pki").toFile();
+
         LoggerFactory.getLogger(getClass())
-            .info("security temp dir: {}", securityTempDir.toAbsolutePath());
+            .info("security dir: {}", securityTempDir.toAbsolutePath());
+        LoggerFactory.getLogger(getClass())
+            .info("security pki dir: {}", pkiDir.getAbsolutePath());
 
         KeyStoreLoader loader = new KeyStoreLoader().load(securityTempDir);
 
-        File pkiDir = securityTempDir.resolve("pki").toFile();
         trustListManager = new DefaultTrustListManager(pkiDir);
-        LoggerFactory.getLogger(getClass()).info("pki dir: {}", pkiDir.getAbsolutePath());
 
         DefaultClientCertificateValidator certificateValidator =
             new DefaultClientCertificateValidator(trustListManager);
@@ -112,13 +114,13 @@ public class ClientExampleRunner {
             // will need to be moved from the security "pki/rejected" directory to the
             // "pki/trusted/certs" directory.
 
-            // Make the example client trust the example server certificate by default.
+            // Make the example server trust the example client certificate by default.
             client.getConfig().getCertificate().ifPresent(
                 certificate ->
                     exampleServer.getServer().getConfig().getTrustListManager().addTrustedCertificate(certificate)
             );
 
-            // Make the example server trust the example client certificate by default.
+            // Make the example client trust the example server certificate by default.
             exampleServer.getServer().getConfig().getCertificateManager().getCertificates().forEach(
                 certificate ->
                     trustListManager.addTrustedCertificate(certificate)

--- a/milo-examples/server-examples/src/main/java/org/eclipse/milo/examples/server/ExampleServer.java
+++ b/milo-examples/server-examples/src/main/java/org/eclipse/milo/examples/server/ExampleServer.java
@@ -11,6 +11,9 @@
 package org.eclipse.milo.examples.server;
 
 import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.security.KeyPair;
 import java.security.Security;
 import java.security.cert.X509Certificate;
@@ -85,11 +88,14 @@ public class ExampleServer {
     private final ExampleNamespace exampleNamespace;
 
     public ExampleServer() throws Exception {
-        File securityTempDir = new File(System.getProperty("java.io.tmpdir"), "security");
-        if (!securityTempDir.exists() && !securityTempDir.mkdirs()) {
+        Path securityTempDir = Paths.get(System.getProperty("java.io.tmpdir"), "server-example", "security");
+        Files.createDirectories(securityTempDir);
+        if (!Files.exists(securityTempDir)) {
             throw new Exception("unable to create security temp dir: " + securityTempDir);
         }
-        LoggerFactory.getLogger(getClass()).info("security temp dir: {}", securityTempDir.getAbsolutePath());
+
+        LoggerFactory.getLogger(getClass())
+            .info("security temp dir: {}", securityTempDir.toAbsolutePath());
 
         KeyStoreLoader loader = new KeyStoreLoader().load(securityTempDir);
 
@@ -98,7 +104,7 @@ public class ExampleServer {
             loader.getServerCertificateChain()
         );
 
-        File pkiDir = securityTempDir.toPath().resolve("pki").toFile();
+        File pkiDir = securityTempDir.resolve("pki").toFile();
         DefaultTrustListManager trustListManager = new DefaultTrustListManager(pkiDir);
         LoggerFactory.getLogger(getClass()).info("pki dir: {}", pkiDir.getAbsolutePath());
 

--- a/milo-examples/server-examples/src/main/java/org/eclipse/milo/examples/server/ExampleServer.java
+++ b/milo-examples/server-examples/src/main/java/org/eclipse/milo/examples/server/ExampleServer.java
@@ -88,14 +88,18 @@ public class ExampleServer {
     private final ExampleNamespace exampleNamespace;
 
     public ExampleServer() throws Exception {
-        Path securityTempDir = Paths.get(System.getProperty("java.io.tmpdir"), "server-example", "security");
+        Path securityTempDir = Paths.get(System.getProperty("java.io.tmpdir"), "server", "security");
         Files.createDirectories(securityTempDir);
         if (!Files.exists(securityTempDir)) {
             throw new Exception("unable to create security temp dir: " + securityTempDir);
         }
 
+        File pkiDir = securityTempDir.resolve("pki").toFile();
+
         LoggerFactory.getLogger(getClass())
-            .info("security temp dir: {}", securityTempDir.toAbsolutePath());
+            .info("security dir: {}", securityTempDir.toAbsolutePath());
+        LoggerFactory.getLogger(getClass())
+            .info("security pki dir: {}", pkiDir.getAbsolutePath());
 
         KeyStoreLoader loader = new KeyStoreLoader().load(securityTempDir);
 
@@ -104,9 +108,7 @@ public class ExampleServer {
             loader.getServerCertificateChain()
         );
 
-        File pkiDir = securityTempDir.resolve("pki").toFile();
         DefaultTrustListManager trustListManager = new DefaultTrustListManager(pkiDir);
-        LoggerFactory.getLogger(getClass()).info("pki dir: {}", pkiDir.getAbsolutePath());
 
         DefaultServerCertificateValidator certificateValidator =
             new DefaultServerCertificateValidator(trustListManager);

--- a/milo-examples/server-examples/src/main/java/org/eclipse/milo/examples/server/KeyStoreLoader.java
+++ b/milo-examples/server-examples/src/main/java/org/eclipse/milo/examples/server/KeyStoreLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 the Eclipse Milo Authors
+ * Copyright (c) 2021 the Eclipse Milo Authors
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -13,6 +13,7 @@ package org.eclipse.milo.examples.server;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
+import java.nio.file.Path;
 import java.security.Key;
 import java.security.KeyPair;
 import java.security.KeyStore;
@@ -45,10 +46,10 @@ class KeyStoreLoader {
     private X509Certificate serverCertificate;
     private KeyPair serverKeyPair;
 
-    KeyStoreLoader load(File baseDir) throws Exception {
+    KeyStoreLoader load(Path baseDir) throws Exception {
         KeyStore keyStore = KeyStore.getInstance("PKCS12");
 
-        File serverKeyStore = baseDir.toPath().resolve("example-server.pfx").toFile();
+        File serverKeyStore = baseDir.resolve("example-server.pfx").toFile();
 
         logger.info("Loading KeyStore at {}", serverKeyStore);
 


### PR DESCRIPTION
Demonstrate and enable by default secure connections and certificate validation against the trust list in the client examples.