### PR TITLE
Return Bad_SessionClosed for remaining PublishRequests

### DIFF
--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/subscriptions/SubscriptionManager.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/subscriptions/SubscriptionManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 the Eclipse Milo Authors
+ * Copyright (c) 2021 the Eclipse Milo Authors
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -1221,6 +1221,15 @@ public class SubscriptionManager {
             }
 
             iterator.remove();
+        }
+
+        if (deleteSubscriptions) {
+            while (publishQueue.isNotEmpty()) {
+                ServiceRequest publishService = publishQueue.poll();
+                if (publishService != null) {
+                    publishService.setServiceFault(StatusCodes.Bad_SessionClosed);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
When the Session is closed and the delete subscriptions flag is set de-queue
any remaining PublishRequests and return a ServiceFault with Bad_SessionClosed.

fixes #846
