### PR TITLE
Fix missing callback invocations in ManagedSubscription.StatusListener 

### DIFF
--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/api/subscriptions/UaSubscription.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/api/subscriptions/UaSubscription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 the Eclipse Milo Authors
+ * Copyright (c) 2021 the Eclipse Milo Authors
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -15,6 +15,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
 import com.google.common.collect.ImmutableList;
+import org.eclipse.milo.opcua.sdk.client.api.UaSession;
 import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
 import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
 import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
@@ -296,6 +297,27 @@ public interface UaSubscription {
          * @param status       the new subscription status.
          */
         default void onStatusChangedNotification(UaSubscription subscription, StatusCode status) {}
+
+        /**
+         * Attempts to recover missed notification data have failed.
+         * <p>
+         * When a notification is missed a series of Republish requests are initiated to recover the missing data. If
+         * republishing fails, or any of the notifications are no longer available, this callback will be invoked.
+         *
+         * @param subscription the subscription that missed notification data.
+         */
+        default void onNotificationDataLost(UaSubscription subscription) {}
+
+        /**
+         * A new {@link UaSession} was established, and upon attempting to transfer an existing subscription to this
+         * new session, a failure occurred.
+         * <p>
+         * This subscription will be removed from {@link UaSubscriptionManager}'s bookkeeping. It must be re-created.
+         *
+         * @param subscription the {@link UaSubscription} that could not be transferred.
+         * @param statusCode   the {@link StatusCode} for the transfer failure.
+         */
+        default void onSubscriptionTransferFailed(UaSubscription subscription, StatusCode statusCode) {}
 
     }
 

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/subscriptions/ManagedSubscription.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/subscriptions/ManagedSubscription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 the Eclipse Milo Authors
+ * Copyright (c) 2021 the Eclipse Milo Authors
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -25,7 +25,6 @@ import java.util.stream.Collectors;
 import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
 import org.eclipse.milo.opcua.sdk.client.api.subscriptions.UaMonitoredItem;
 import org.eclipse.milo.opcua.sdk.client.api.subscriptions.UaSubscription;
-import org.eclipse.milo.opcua.sdk.client.api.subscriptions.UaSubscriptionManager;
 import org.eclipse.milo.opcua.sdk.client.subscriptions.ManagedDataItem.DataValueListener;
 import org.eclipse.milo.opcua.stack.core.AttributeId;
 import org.eclipse.milo.opcua.stack.core.Identifiers;
@@ -1216,8 +1215,7 @@ public class ManagedSubscription {
      * A {@link UaSubscription.NotificationListener} used internally by {@link ManagedSubscription} to notify its
      * {@link ChangeListener}s and {@link StatusListener}s.
      */
-    private class ManagedSubscriptionNotificationListener implements
-        UaSubscriptionManager.SubscriptionListener, UaSubscription.NotificationListener {
+    private class ManagedSubscriptionNotificationListener implements UaSubscription.NotificationListener {
 
         private final ExecutionQueue executionQueue = new ExecutionQueue(client.getConfig().getExecutor());
 
@@ -1290,39 +1288,25 @@ public class ManagedSubscription {
             );
         }
 
-        //endregion
-
-        //region UaSubscriptionManager.SubscriptionListener
-
-        // These callbacks need to be filtered to see if they are for the
-        // UaSubscription backing this ManagedSubscription instance before
-        // doing notification.
-
         @Override
         public void onNotificationDataLost(UaSubscription subscription) {
-            if (ManagedSubscription.this.subscription.getSubscriptionId().equals(subscription.getSubscriptionId())) {
-                executionQueue.submit(() ->
-                    statusListeners.forEach(
-                        statusListener ->
-                            statusListener.onNotificationDataLost(ManagedSubscription.this)
-                    )
-                );
-            }
+            executionQueue.submit(() ->
+                statusListeners.forEach(
+                    statusListener ->
+                        statusListener.onNotificationDataLost(ManagedSubscription.this)
+                )
+            );
         }
 
         @Override
         public void onSubscriptionTransferFailed(UaSubscription subscription, StatusCode statusCode) {
-            if (ManagedSubscription.this.subscription.getSubscriptionId().equals(subscription.getSubscriptionId())) {
-                executionQueue.submit(() ->
-                    statusListeners.forEach(
-                        statusListener ->
-                            statusListener.onSubscriptionTransferFailed(ManagedSubscription.this, statusCode)
-                    )
-                );
-            }
+            executionQueue.submit(() ->
+                statusListeners.forEach(
+                    statusListener ->
+                        statusListener.onSubscriptionTransferFailed(ManagedSubscription.this, statusCode)
+                )
+            );
         }
-
-        //endregion
 
     }
 

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/subscriptions/OpcUaSubscriptionManager.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/subscriptions/OpcUaSubscriptionManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 the Eclipse Milo Authors
+ * Copyright (c) 2021 the Eclipse Milo Authors
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -363,6 +363,11 @@ public class OpcUaSubscriptionManager implements UaSubscriptionManager {
 
         if (subscription != null) {
             subscriptionListeners.forEach(l -> l.onSubscriptionTransferFailed(subscription, statusCode));
+
+            subscription.getNotificationListeners().forEach(
+                l ->
+                    l.onSubscriptionTransferFailed(subscription, statusCode)
+            );
         }
     }
 
@@ -528,10 +533,12 @@ public class OpcUaSubscriptionManager implements UaSubscriptionManager {
                     logger.debug("Republish failed: {}", ex.getMessage(), ex);
 
                     subscriptionListeners.forEach(l -> l.onNotificationDataLost(subscription));
+                    subscription.getNotificationListeners().forEach(l -> l.onNotificationDataLost(subscription));
                 } else {
                     // Republish succeeded, possibly with some data loss, resume processing.
                     if (dataLost) {
                         subscriptionListeners.forEach(l -> l.onNotificationDataLost(subscription));
+                        subscription.getNotificationListeners().forEach(l -> l.onNotificationDataLost(subscription));
                     }
                 }
 


### PR DESCRIPTION
Use new callbacks from UaSubscription.NotificationListener to ensure we
receive notification that data was lost or a subscription transfer failed.

fixes #865