### PR TITLE
allow all-zero nonces when no nonce is required

### DIFF
--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/util/NonceUtil.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/util/NonceUtil.java
@@ -232,7 +232,7 @@ public class NonceUtil {
             );
         }
 
-        if (bs.length > 0 && Arrays.areAllZeroes(bs, 0, bs.length)) {
+        if (minimumLength > 0 && bs.length > 0 && Arrays.areAllZeroes(bs, 0, bs.length)) {
             throw new UaException(StatusCodes.Bad_NonceInvalid, "nonce must be non-zero");
         }
     }


### PR DESCRIPTION
See https://github.com/locka99/opcua/issues/182

Rust's [opcua-server](https://crates.io/crates/opcua-server) v0.9.0 sends an all-zero nonce for security policies where no nonce is required.
There is no reason to throw an error in this case, since the nonce is not used anyway.