### PR TITLE
Update jaxb-runtime and jakarta.activation dependencies

### DIFF
--- a/opc-ua-stack/bsd-core/pom.xml
+++ b/opc-ua-stack/bsd-core/pom.xml
@@ -24,13 +24,13 @@
         <dependency>
             <groupId>com.sun.activation</groupId>
             <artifactId>jakarta.activation</artifactId>
-            <version>1.2.1</version>
+            <version>1.2.2</version>
         </dependency>
 
         <dependency>
             <groupId>org.glassfish.jaxb</groupId>
             <artifactId>jaxb-runtime</artifactId>
-            <version>2.3.2</version>
+            <version>2.3.6</version>
         </dependency>
     </dependencies>
 

--- a/opc-ua-stack/bsd-parser/pom.xml
+++ b/opc-ua-stack/bsd-parser/pom.xml
@@ -24,13 +24,13 @@
         <dependency>
             <groupId>com.sun.activation</groupId>
             <artifactId>jakarta.activation</artifactId>
-            <version>1.2.1</version>
+            <version>1.2.2</version>
         </dependency>
 
         <dependency>
             <groupId>org.glassfish.jaxb</groupId>
             <artifactId>jaxb-runtime</artifactId>
-            <version>2.3.3</version>
+            <version>2.3.6</version>
         </dependency>
 
         <dependency>

--- a/opc-ua-stack/stack-core/pom.xml
+++ b/opc-ua-stack/stack-core/pom.xml
@@ -74,7 +74,7 @@
         <dependency>
             <groupId>org.glassfish.jaxb</groupId>
             <artifactId>jaxb-runtime</artifactId>
-            <version>2.3.3</version>
+            <version>2.3.6</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
This should fix an error using DataTypeDictionaryGenerator on JDK 17.

fixes #962
