### PR TITLE
Fix NPE generating struct with enum field

### DIFF
--- a/milo-examples/client-examples/src/main/java/org/eclipse/milo/examples/client/ReadWriteCustomDataTypeNodeExample.java
+++ b/milo-examples/client-examples/src/main/java/org/eclipse/milo/examples/client/ReadWriteCustomDataTypeNodeExample.java
@@ -12,6 +12,7 @@ package org.eclipse.milo.examples.client;
 
 import java.util.concurrent.CompletableFuture;
 
+import org.eclipse.milo.examples.server.types.CustomEnumType;
 import org.eclipse.milo.examples.server.types.CustomStructType;
 import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
 import org.eclipse.milo.opcua.sdk.client.nodes.UaVariableNode;
@@ -66,7 +67,8 @@ public class ReadWriteCustomDataTypeNodeExample implements ClientExample {
         CustomStructType modified = new CustomStructType(
             decoded.getFoo() + "bar",
             uint(decoded.getBar().intValue() + 1),
-            !decoded.isBaz()
+            !decoded.isBaz(),
+            CustomEnumType.Field1
         );
         ExtensionObject modifiedXo = ExtensionObject.encode(
             client.getStaticSerializationContext(),

--- a/milo-examples/server-examples/src/main/java/org/eclipse/milo/examples/server/ExampleNamespace.java
+++ b/milo-examples/server-examples/src/main/java/org/eclipse/milo/examples/server/ExampleNamespace.java
@@ -848,6 +848,16 @@ public class ExampleNamespace extends ManagedNamespaceWithLifecycle {
                 null,
                 uint(0),
                 false
+            ),
+            new StructureField(
+                "customEnumType",
+                LocalizedText.NULL_VALUE,
+                CustomEnumType.TYPE_ID
+                    .toNodeIdOrThrow(getServer().getNamespaceTable()),
+                ValueRanks.Scalar,
+                null,
+                uint(0),
+                false
             )
         };
 
@@ -959,7 +969,8 @@ public class ExampleNamespace extends ManagedNamespaceWithLifecycle {
         CustomStructType value = new CustomStructType(
             "foo",
             uint(42),
-            true
+            true,
+            CustomEnumType.Field0
         );
 
         ExtensionObject xo = ExtensionObject.encodeDefaultBinary(

--- a/milo-examples/server-examples/src/main/java/org/eclipse/milo/examples/server/types/CustomStructType.java
+++ b/milo-examples/server-examples/src/main/java/org/eclipse/milo/examples/server/types/CustomStructType.java
@@ -42,14 +42,17 @@ public class CustomStructType implements UaStructure {
     private final UInteger bar;
     private final boolean baz;
 
+    private final CustomEnumType customEnumType;
+
     public CustomStructType() {
-        this(null, uint(0), false);
+        this(null, uint(0), false, CustomEnumType.Field0);
     }
 
-    public CustomStructType(String foo, UInteger bar, boolean baz) {
+    public CustomStructType(String foo, UInteger bar, boolean baz, CustomEnumType customEnumType) {
         this.foo = foo;
         this.bar = bar;
         this.baz = baz;
+        this.customEnumType = customEnumType;
     }
 
     public String getFoo() {
@@ -62,6 +65,10 @@ public class CustomStructType implements UaStructure {
 
     public boolean isBaz() {
         return baz;
+    }
+
+    public CustomEnumType getCustomEnumType() {
+        return customEnumType;
     }
 
     @Override
@@ -87,12 +94,13 @@ public class CustomStructType implements UaStructure {
         CustomStructType that = (CustomStructType) o;
         return baz == that.baz &&
             Objects.equal(foo, that.foo) &&
-            Objects.equal(bar, that.bar);
+            Objects.equal(bar, that.bar) &&
+            customEnumType == that.customEnumType;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(foo, bar, baz);
+        return Objects.hashCode(foo, bar, baz, customEnumType);
     }
 
     @Override
@@ -101,6 +109,7 @@ public class CustomStructType implements UaStructure {
             .add("foo", foo)
             .add("bar", bar)
             .add("baz", baz)
+            .add("customEnumType", customEnumType)
             .toString();
     }
 
@@ -113,23 +122,27 @@ public class CustomStructType implements UaStructure {
         @Override
         public CustomStructType decode(
             SerializationContext context,
-            UaDecoder decoder) throws UaSerializationException {
+            UaDecoder decoder
+        ) throws UaSerializationException {
 
             String foo = decoder.readString("Foo");
             UInteger bar = decoder.readUInt32("Bar");
             boolean baz = decoder.readBoolean("Baz");
+            CustomEnumType customEnumType = decoder.readEnum("CustomEnumType", CustomEnumType.class);
 
-            return new CustomStructType(foo, bar, baz);
+            return new CustomStructType(foo, bar, baz, customEnumType);
         }
 
         @Override
         public void encode(
             SerializationContext context,
-            UaEncoder encoder, CustomStructType value) throws UaSerializationException {
+            UaEncoder encoder, CustomStructType value
+        ) throws UaSerializationException {
 
             encoder.writeString("Foo", value.foo);
             encoder.writeUInt32("Bar", value.bar);
             encoder.writeBoolean("Baz", value.baz);
+            encoder.writeEnum("CustomEnumType", value.customEnumType);
         }
     }
 

--- a/opc-ua-sdk/dictionary-manager/src/main/java/org/eclipse/milo/opcua/sdk/server/dtd/DataTypeDictionaryManager.java
+++ b/opc-ua-sdk/dictionary-manager/src/main/java/org/eclipse/milo/opcua/sdk/server/dtd/DataTypeDictionaryManager.java
@@ -483,7 +483,8 @@ public class DataTypeDictionaryManager implements Lifecycle {
 
             checkNotNull(dictionaryNode, "dictionaryNode for dataTypeId=" + dataTypeId);
 
-            String dictionaryNamespaceUri = dictionaryNode.getProperty(DataTypeDictionaryType.NAMESPACE_URI).orElse(null);
+            String dictionaryNamespaceUri = dictionaryNode.getProperty(DataTypeDictionaryType.NAMESPACE_URI)
+                .orElse(null);
 
             checkNotNull(dictionaryNamespaceUri, "dictionaryNamespaceUri for dataTypeId=" + dataTypeId);
 

--- a/opc-ua-sdk/dictionary-manager/src/main/java/org/eclipse/milo/opcua/sdk/server/dtd/DataTypeDictionaryManager.java
+++ b/opc-ua-sdk/dictionary-manager/src/main/java/org/eclipse/milo/opcua/sdk/server/dtd/DataTypeDictionaryManager.java
@@ -431,8 +431,6 @@ public class DataTypeDictionaryManager implements Lifecycle {
     ) {
 
         Function<NodeId, DataTypeLocation> dataTypeLookup = dataTypeId -> {
-            String dataTypeName;
-            String dictionaryNamespaceUri;
 
             UaNode dataTypeNode = addressSpaceManager.getManagedNode(dataTypeId).orElse(null);
 
@@ -442,6 +440,18 @@ public class DataTypeDictionaryManager implements Lifecycle {
                 long id = ((UInteger) dataTypeId.getIdentifier()).longValue();
                 String uri = id <= 15L ? Namespaces.OPC_UA_BSD : Namespaces.OPC_UA;
                 return new DataTypeLocation(dataTypeNode.getBrowseName().getName(), uri);
+            }
+
+            QualifiedName parentTypeName = dataTypeNode.getReferences()
+                .stream()
+                .filter(Reference.SUBTYPE_OF)
+                .flatMap(r -> opt2stream(addressSpaceManager.getManagedNode(r.getTargetNodeId())))
+                .findFirst()
+                .map(UaNode::getBrowseName)
+                .orElse(QualifiedName.NULL_VALUE);
+
+            if (parentTypeName.equals(new QualifiedName(0, "Enumeration"))) {
+                return new DataTypeLocation(dataTypeNode.getBrowseName().getName(), "");
             }
 
             UaNode dataTypeEncodingNode = dataTypeNode.getReferences()
@@ -463,7 +473,7 @@ public class DataTypeDictionaryManager implements Lifecycle {
 
             checkNotNull(dataTypeDescriptionNode, "dataTypeDescriptionNode for dataTypeId=" + dataTypeId);
 
-            dataTypeName = dataTypeDescriptionNode.getBrowseName().getName();
+            String dataTypeName = dataTypeDescriptionNode.getBrowseName().getName();
 
             UaNode dictionaryNode = dataTypeDescriptionNode.getReferences().stream()
                 .filter(Reference.COMPONENT_OF_PREDICATE)
@@ -473,7 +483,7 @@ public class DataTypeDictionaryManager implements Lifecycle {
 
             checkNotNull(dictionaryNode, "dictionaryNode for dataTypeId=" + dataTypeId);
 
-            dictionaryNamespaceUri = dictionaryNode.getProperty(DataTypeDictionaryType.NAMESPACE_URI).orElse(null);
+            String dictionaryNamespaceUri = dictionaryNode.getProperty(DataTypeDictionaryType.NAMESPACE_URI).orElse(null);
 
             checkNotNull(dictionaryNamespaceUri, "dictionaryNamespaceUri for dataTypeId=" + dataTypeId);
 

--- a/opc-ua-stack/bsd-generator/src/main/java/org/eclipse/milo/opcua/binaryschema/generator/DataTypeDictionaryGenerator.java
+++ b/opc-ua-stack/bsd-generator/src/main/java/org/eclipse/milo/opcua/binaryschema/generator/DataTypeDictionaryGenerator.java
@@ -230,11 +230,17 @@ public class DataTypeDictionaryGenerator {
             String dataTypeName = dataTypeLocation.dataTypeName;
             String dictionaryNamespaceUri = dataTypeLocation.dictionaryNamespaceUri;
 
-            namespaces.add(dictionaryNamespaceUri);
+            if (!dictionaryNamespaceUri.isEmpty()) {
+                namespaces.add(dictionaryNamespaceUri);
+            }
 
             FieldType fieldType = new FieldType();
             fieldType.setName(fieldName);
-            fieldType.setTypeName(new QName(dictionaryNamespaceUri, dataTypeName));
+            if (dictionaryNamespaceUri.isEmpty()) {
+                fieldType.setTypeName(new QName(namespaceUri, dataTypeName));
+            } else {
+                fieldType.setTypeName(new QName(dictionaryNamespaceUri, dataTypeName));
+            }
 
             if (structureType == StructureType.StructureWithOptionalFields) {
                 if (field.getIsOptional()) {


### PR DESCRIPTION
When generating the BSD XML for a struct that has an enum type field
assume the namespace URI is that of the current dictionary. Enumerations
are not currently defined with enough extra information to look up the
namespace URI; consequently a struct definition may not reference an
enum type defined in another dictionary.

fixes #964