### PR TITLE
Use configured session locale ids when activating a session

### DIFF
--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/session/SessionFsmFactory.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/session/SessionFsmFactory.java
@@ -895,7 +895,7 @@ public class SessionFsmFactory {
                 client.newRequestHeader(csr.getAuthenticationToken()),
                 buildClientSignature(client.getConfig(), csrNonce),
                 new SignedSoftwareCertificate[0],
-                new String[0],
+                client.getConfig().getSessionLocaleIds(),
                 ExtensionObject.encode(client.getStaticSerializationContext(), userIdentityToken),
                 userTokenSignature
             );


### PR DESCRIPTION
fixes #970
