### PR TITLE
Implement ExpandedNodeId.parse without NodeId.parse

### DIFF
--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/types/builtin/ExpandedNodeIdTest.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/types/builtin/ExpandedNodeIdTest.java
@@ -180,6 +180,16 @@ public class ExpandedNodeIdTest {
     }
 
     @Test
+    public void parseIdentifierContainingSemiColons() {
+        ExpandedNodeId xni = ExpandedNodeId.parse(
+            "nsu=http://foo.com/bar;s=O=::/#pc;B=::/#pc;S=pc;"
+        );
+
+        assertEquals(xni.getNamespaceUri(), "http://foo.com/bar");
+        assertEquals(xni.getIdentifier(), "O=::/#pc;B=::/#pc;S=pc;");
+    }
+
+    @Test
     public void reindex() {
         NamespaceTable namespaceTable = new NamespaceTable();
         namespaceTable.addUri("test1");

--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/types/builtin/NodeIdTest.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/types/builtin/NodeIdTest.java
@@ -183,4 +183,12 @@ public class NodeIdTest {
         assertEquals(xni.getNamespaceUri(), "urn:test");
     }
 
+    @Test
+    public void parseIdentifierContainingSemiColons() {
+        NodeId nodeId = NodeId.parse("ns=14;s=O=::/#pc;B=::/#pc;S=pc;");
+
+        assertEquals(nodeId.getNamespaceIndex(), ushort(14));
+        assertEquals(nodeId.getIdentifier(), "O=::/#pc;B=::/#pc;S=pc;");
+    }
+
 }


### PR DESCRIPTION
This new implementation also fixes a bug when parsing a String identifier that
contains additional semicolons.

fixes #976
