### PR TITLE
Return Bad_UserAccessDenied if subscription belongs to another session

### DIFF
--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/namespaces/OpcUaNamespace.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/namespaces/OpcUaNamespace.java
@@ -436,7 +436,13 @@ public class OpcUaNamespace extends ManagedNamespaceWithLifecycle {
                 Subscription subscription = session.getSubscriptionManager().getSubscription(subscriptionId);
 
                 if (subscription == null) {
-                    throw new UaException(StatusCodes.Bad_SubscriptionIdInvalid);
+                    if (session.getServer().getSubscriptions().containsKey(subscriptionId)) {
+                        // Exists but belongs to another session
+                        throw new UaException(StatusCodes.Bad_UserAccessDenied);
+                    } else {
+                        // Doesn't exist in any session
+                        throw new UaException(StatusCodes.Bad_SubscriptionIdInvalid);
+                    }
                 } else {
                     subscription.getMonitoredItems().values().stream()
                         .filter(item -> item instanceof MonitoredDataItem)


### PR DESCRIPTION
In the ResendData Method implementation, only return Bad_SubscriptionIdInvalid when the subscription doesn't exist at all.

fixes #984
