### PR TITLE
Update netty-channel-fsm to version 0.8

### DIFF
--- a/opc-ua-sdk/dictionary-reader/pom.xml
+++ b/opc-ua-sdk/dictionary-reader/pom.xml
@@ -25,6 +25,12 @@
             <artifactId>bsd-parser</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.jetbrains</groupId>
+            <artifactId>annotations</artifactId>
+            <version>${annotations.version}</version>
+            <scope>provided</scope>
+        </dependency>
 
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/opc-ua-stack/stack-client/pom.xml
+++ b/opc-ua-stack/stack-client/pom.xml
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>com.digitalpetri.netty</groupId>
             <artifactId>netty-channel-fsm</artifactId>
-            <version>0.7</version>
+            <version>0.8</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>


### PR DESCRIPTION
This version does not include an unintentional dependency on Kotlin.

fixes #972
