### PR TITLE
feat(ci): Adds basic build and test ci workflow

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,33 @@
+---
+# This workflow will build a Java project with Maven, and cache/restore any dependencies to improve the workflow execution time
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+
+name: Java CI with Maven
+
+on:
+  push:
+    branches:
+  pull_request:
+    branches: [ master, develop ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        java: [ '8', '11' ]
+      fail-fast: false
+    name: Java ${{ matrix.java }} build
+
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up JDK ${{ matrix.java }}
+      uses: actions/setup-java@v3
+      with:
+        java-version: ${{ matrix.java }}
+        distribution: 'temurin'
+        cache: maven
+    - name: Build with Maven
+      run: mvn clean install -DskipTests=false


### PR DESCRIPTION
This pull request adds a basic CI for building and testing milo.
As public open source projects benefit from free quota of gh-actions minutes this does not result in additional costs for the Eclipse Foundation.

Currently Java 8 and 11 is enabled as well as `temurin` for the OpenJDK flavor.

Signed-off-by: Götz Görisch <g.goerisch@vdw.de>

Before you submit a pull request please acknowledge the following:
- [X] You have signed an Eclipse Contributor Agreement and are committing using the same email address
- [X] Your code contains any tests relevant to the problem you are solving
- [X] All new and existing tests passed
- [X] Code follows the style guidelines and Checkstyle passes

See [CONTRIBUTING](https://github.com/eclipse/milo/blob/master/CONTRIBUTING.md) for more information.
