### PR TITLE
Transition to CreatingWait state when connection is lost

### DIFF
--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/session/Event.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/session/Event.java
@@ -199,4 +199,11 @@ interface Event {
         }
     }
 
+    class ConnectionLost implements Event {
+        @Override
+        public String toString() {
+            return getClass().getSimpleName();
+        }
+    }
+
 }

--- a/opc-ua-stack/stack-client/src/main/java/org/eclipse/milo/opcua/stack/client/UaStackClient.java
+++ b/opc-ua-stack/stack-client/src/main/java/org/eclipse/milo/opcua/stack/client/UaStackClient.java
@@ -153,6 +153,15 @@ public class UaStackClient {
     }
 
     /**
+     * Get the {@link UaTransport} used by this client.
+     *
+     * @return the {@link UaTransport} used by this client.
+     */
+    public UaTransport getTransport() {
+        return transport;
+    }
+
+    /**
      * Get the client {@link NamespaceTable}.
      *
      * @return the client {@link NamespaceTable}.

--- a/opc-ua-stack/stack-client/src/main/java/org/eclipse/milo/opcua/stack/client/transport/tcp/OpcTcpTransport.java
+++ b/opc-ua-stack/stack-client/src/main/java/org/eclipse/milo/opcua/stack/client/transport/tcp/OpcTcpTransport.java
@@ -56,4 +56,11 @@ public class OpcTcpTransport extends AbstractTransport implements UaTransport {
         return channelFsm.getChannel();
     }
 
+    /**
+     * @return the {@link ChannelFsm} used by this transport.
+     */
+    public ChannelFsm channelFsm() {
+        return channelFsm;
+    }
+
 }


### PR DESCRIPTION
If the transport allows it, listen for connection loss and immediately 
transition to the `CreatingWait` state when it happens. This will speed up 
recovery of the session and reduce the chance requests are sent using the old 
Session, before a new one is activated, when the underlying connection is 
re-established.

fixes #1011
