### PR TITLE
Generate self-signed certs with pathLenConstraint=0

### DIFF
--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/util/SelfSignedCertificateGenerator.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/util/SelfSignedCertificateGenerator.java
@@ -128,7 +128,8 @@ public class SelfSignedCertificateGenerator {
             subjectPublicKeyInfo
         );
 
-        BasicConstraints basicConstraints = new BasicConstraints(true);
+        // Explicitly set path length constraint to 0. This constructor also sets cA=true.
+        BasicConstraints basicConstraints = new BasicConstraints(0);
 
         // Authority Key Identifier
         addAuthorityKeyIdentifier(certificateBuilder, keyPair);


### PR DESCRIPTION
This allows some amount of compatibility with OPC UA 1.05, where it is preferred to have cA=false instead, but there is a backwards-compatibility concession that allows cA=true if `pathLenConstraint` is present and set to 0.

fixes #1110