### PR TITLE
fix(sec): upgrade ch.qos.logback:logback-classic to 1.2.0

### DIFF
--- a/milo-examples/client-examples/pom.xml
+++ b/milo-examples/client-examples/pom.xml
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.1.7</version>
+            <version>1.2.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>

--- a/milo-examples/server-examples/pom.xml
+++ b/milo-examples/server-examples/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.1.7</version>
+            <version>1.2.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in ch.qos.logback:logback-classic 1.1.7
- [CVE-2017-5929](https://www.oscs1024.com/hd/CVE-2017-5929)


### What did I do？
Upgrade ch.qos.logback:logback-classic from 1.1.7 to 1.2.0 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS