### PR TITLE
Refactor `IdentityValidator` and introduce `Identity`

### DIFF
--- a/milo-examples/server-examples/src/main/java/org/eclipse/milo/examples/server/ExampleNamespace.java
+++ b/milo-examples/server-examples/src/main/java/org/eclipse/milo/examples/server/ExampleNamespace.java
@@ -29,6 +29,7 @@ import org.eclipse.milo.opcua.sdk.server.Lifecycle;
 import org.eclipse.milo.opcua.sdk.server.ManagedNamespaceWithLifecycle;
 import org.eclipse.milo.opcua.sdk.server.OpcUaServer;
 import org.eclipse.milo.opcua.sdk.server.dtd.BinaryDataTypeDictionaryManager;
+import org.eclipse.milo.opcua.sdk.server.identity.Identity;
 import org.eclipse.milo.opcua.sdk.server.items.DataItem;
 import org.eclipse.milo.opcua.sdk.server.items.MonitoredItem;
 import org.eclipse.milo.opcua.sdk.server.model.objects.BaseEventTypeNode;
@@ -415,8 +416,14 @@ public class ExampleNamespace extends ManagedNamespaceWithLifecycle {
         node.setValue(new DataValue(new Variant("shh... don't tell the lusers")));
 
         node.getFilterChain().addLast(new RestrictedAccessFilter(identity -> {
-            if ("admin".equals(identity)) {
-                return AccessLevel.READ_WRITE;
+            if (identity instanceof Identity.UsernameIdentity) {
+                Identity.UsernameIdentity usernameIdentity = (Identity.UsernameIdentity) identity;
+
+                if (usernameIdentity.getUsername().equals("admin")) {
+                    return AccessLevel.READ_WRITE;
+                } else {
+                    return AccessLevel.NONE;
+                }
             } else {
                 return AccessLevel.NONE;
             }
@@ -450,10 +457,16 @@ public class ExampleNamespace extends ManagedNamespaceWithLifecycle {
         node.setValue(new DataValue(new Variant("admin was here")));
 
         node.getFilterChain().addLast(new RestrictedAccessFilter(identity -> {
-            if ("admin".equals(identity)) {
-                return AccessLevel.READ_WRITE;
+            if (identity instanceof Identity.UsernameIdentity) {
+                Identity.UsernameIdentity usernameIdentity = (Identity.UsernameIdentity) identity;
+
+                if (usernameIdentity.getUsername().equals("admin")) {
+                    return AccessLevel.READ_WRITE;
+                } else {
+                    return AccessLevel.NONE;
+                }
             } else {
-                return AccessLevel.READ_ONLY;
+                return AccessLevel.NONE;
             }
         }));
 

--- a/milo-examples/server-examples/src/main/java/org/eclipse/milo/examples/server/RestrictedAccessFilter.java
+++ b/milo-examples/server-examples/src/main/java/org/eclipse/milo/examples/server/RestrictedAccessFilter.java
@@ -16,6 +16,7 @@ import java.util.function.Function;
 
 import org.eclipse.milo.opcua.sdk.core.AccessLevel;
 import org.eclipse.milo.opcua.sdk.server.Session;
+import org.eclipse.milo.opcua.sdk.server.identity.Identity;
 import org.eclipse.milo.opcua.sdk.server.nodes.filters.AttributeFilter;
 import org.eclipse.milo.opcua.sdk.server.nodes.filters.AttributeFilterContext.GetAttributeContext;
 import org.eclipse.milo.opcua.stack.core.AttributeId;
@@ -24,16 +25,16 @@ public class RestrictedAccessFilter implements AttributeFilter {
 
     private static final Set<AccessLevel> INTERNAL_ACCESS = AccessLevel.READ_WRITE;
 
-    private final Function<Object, Set<AccessLevel>> accessLevelsFn;
+    private final Function<Identity, Set<AccessLevel>> accessLevelsFn;
 
-    public RestrictedAccessFilter(Function<Object, Set<AccessLevel>> accessLevelsFn) {
+    public RestrictedAccessFilter(Function<Identity, Set<AccessLevel>> accessLevelsFn) {
         this.accessLevelsFn = accessLevelsFn;
     }
 
     @Override
     public Object getAttribute(GetAttributeContext ctx, AttributeId attributeId) {
         if (attributeId == AttributeId.UserAccessLevel) {
-            Optional<Object> identity = ctx.getSession().map(Session::getIdentityObject);
+            Optional<Identity> identity = ctx.getSession().map(Session::getIdentity);
 
             Set<AccessLevel> accessLevels = identity.map(accessLevelsFn).orElse(INTERNAL_ACCESS);
 

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/OpcUaServerConfigBuilder.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/OpcUaServerConfigBuilder.java
@@ -44,7 +44,7 @@ public class OpcUaServerConfigBuilder {
         DateTime.MIN_VALUE
     );
 
-    private IdentityValidator<?> identityValidator = AnonymousIdentityValidator.INSTANCE;
+    private IdentityValidator identityValidator = AnonymousIdentityValidator.INSTANCE;
 
     private EncodingLimits encodingLimits = EncodingLimits.DEFAULT;
 
@@ -91,7 +91,7 @@ public class OpcUaServerConfigBuilder {
         return this;
     }
 
-    public OpcUaServerConfigBuilder setIdentityValidator(IdentityValidator<?> identityValidator) {
+    public OpcUaServerConfigBuilder setIdentityValidator(IdentityValidator identityValidator) {
         this.identityValidator = identityValidator;
         return this;
     }
@@ -142,7 +142,7 @@ public class OpcUaServerConfigBuilder {
         private final String applicationUri;
         private final String productUri;
         private final BuildInfo buildInfo;
-        private final IdentityValidator<?> identityValidator;
+        private final IdentityValidator identityValidator;
         private final EncodingLimits encodingLimits;
         private final OpcUaServerConfigLimits limits;
         private final CertificateManager certificateManager;
@@ -155,7 +155,7 @@ public class OpcUaServerConfigBuilder {
             String applicationUri,
             String productUri,
             BuildInfo buildInfo,
-            IdentityValidator<?> identityValidator,
+            IdentityValidator identityValidator,
             EncodingLimits encodingLimits,
             OpcUaServerConfigLimits limits,
             CertificateManager certificateManager,
@@ -177,7 +177,7 @@ public class OpcUaServerConfigBuilder {
         }
 
         @Override
-        public IdentityValidator<?> getIdentityValidator() {
+        public IdentityValidator getIdentityValidator() {
             return identityValidator;
         }
 

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/Session.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/Session.java
@@ -25,6 +25,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.eclipse.milo.opcua.sdk.server.diagnostics.SessionDiagnostics;
 import org.eclipse.milo.opcua.sdk.server.diagnostics.SessionSecurityDiagnostics;
+import org.eclipse.milo.opcua.sdk.server.identity.Identity;
 import org.eclipse.milo.opcua.sdk.server.servicesets.impl.helpers.BrowseHelper.BrowseContinuationPoint;
 import org.eclipse.milo.opcua.sdk.server.subscriptions.SubscriptionManager;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
@@ -63,8 +64,8 @@ public class Session {
 
     private final Semaphore callSemaphore = new Semaphore(CONCURRENT_CALL_LIMIT, true);
 
-    private volatile Object identityObject;
     private volatile UserIdentityToken identityToken;
+    private volatile Identity identity;
 
     private volatile ByteString lastNonce = ByteString.NULL_VALUE;
 
@@ -139,9 +140,8 @@ public class Session {
         return endpoint;
     }
 
-    @Nullable
-    public Object getIdentityObject() {
-        return identityObject;
+    public @Nullable Identity getIdentity() {
+        return identity;
     }
 
     @Nullable
@@ -179,7 +179,7 @@ public class Session {
 
     /**
      * @return a list containing the (possibly abbreviated) history of client user ids. This list may contain null
-     * entries.
+     *     entries.
      * @see #getClientUserId()
      */
     public List<String> getClientUserIdHistory() {
@@ -196,8 +196,8 @@ public class Session {
         this.secureChannelId = secureChannelId;
     }
 
-    public void setIdentityObject(Object identityObject, UserIdentityToken identityToken) {
-        this.identityObject = identityObject;
+    public void setIdentity(Identity identity, UserIdentityToken identityToken) {
+        this.identity = identity;
         this.identityToken = identityToken;
 
         synchronized (clientUserIdHistory) {

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/SessionManager.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/SessionManager.java
@@ -28,6 +28,7 @@ import java.util.stream.Stream;
 import com.google.common.base.Objects;
 import com.google.common.math.DoubleMath;
 import com.google.common.primitives.Bytes;
+import org.eclipse.milo.opcua.sdk.server.identity.Identity;
 import org.eclipse.milo.opcua.sdk.server.identity.IdentityValidator;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.UaException;
@@ -472,7 +473,7 @@ public class SessionManager {
                         session.getEndpoint().getUserIdentityTokens()
                     );
 
-                    Object identityObject = validateIdentityToken(
+                    Identity identity = validateIdentityToken(
                         session,
                         identityToken,
                         request.getUserTokenSignature()
@@ -484,7 +485,7 @@ public class SessionManager {
                     ByteString serverNonce = NonceUtil.generateNonce(32);
 
                     session.setClientAddress(context.clientAddress());
-                    session.setIdentityObject(identityObject, identityToken);
+                    session.setIdentity(identity, identityToken);
                     session.setLastNonce(serverNonce);
                     session.setLocaleIds(request.getLocaleIds());
 
@@ -505,16 +506,13 @@ public class SessionManager {
                         session.getEndpoint().getUserIdentityTokens()
                     );
 
-                    Object identityObject = validateIdentityToken(
+                    Identity identity = validateIdentityToken(
                         session,
                         identityToken,
                         request.getUserTokenSignature()
                     );
 
-                    boolean sameIdentity = Objects.equal(
-                        identityObject,
-                        session.getIdentityObject()
-                    );
+                    boolean sameIdentity = Objects.equal(identity, session.getIdentity());
 
                     boolean sameCertificate = Objects.equal(
                         clientCertificateBytes,
@@ -567,7 +565,7 @@ public class SessionManager {
                 session.getEndpoint().getUserIdentityTokens()
             );
 
-            Object identityObject = validateIdentityToken(
+            Identity identity = validateIdentityToken(
                 session,
                 identityToken,
                 request.getUserTokenSignature()
@@ -582,7 +580,7 @@ public class SessionManager {
             ByteString serverNonce = NonceUtil.generateNonce(32);
 
             session.setClientAddress(context.clientAddress());
-            session.setIdentityObject(identityObject, identityToken);
+            session.setIdentity(identity, identityToken);
             session.setLocaleIds(request.getLocaleIds());
             session.setLastNonce(serverNonce);
 
@@ -723,10 +721,11 @@ public class SessionManager {
         return new AnonymousIdentityToken(policyId);
     }
 
-    private Object validateIdentityToken(
+    private Identity validateIdentityToken(
         Session session,
         Object tokenObject,
-        SignatureData tokenSignature) throws UaException {
+        SignatureData tokenSignature
+    ) throws UaException {
 
         IdentityValidator identityValidator = server.getConfig().getIdentityValidator();
         UserTokenPolicy tokenPolicy = validatePolicyId(session, tokenObject);

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/AbstractIdentity.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/AbstractIdentity.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2023 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.identity;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.jetbrains.annotations.Nullable;
+
+public abstract class AbstractIdentity implements Identity {
+
+    protected final AtomicReference<Object> userDataRef = new AtomicReference<>();
+
+    @Override
+    public void setUserData(Object userData) {
+        userDataRef.set(userData);
+    }
+
+    @Override
+    public @Nullable Object getUserData() {
+        return userDataRef.get();
+    }
+
+}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/AbstractIdentity.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/AbstractIdentity.java
@@ -14,6 +14,9 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.jetbrains.annotations.Nullable;
 
+/**
+ * A base class for {@link Identity} implementations that manages the user data.
+ */
 public abstract class AbstractIdentity implements Identity {
 
     protected final AtomicReference<Object> userDataRef = new AtomicReference<>();

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/AbstractIdentityValidator.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/AbstractIdentityValidator.java
@@ -34,41 +34,41 @@ import org.eclipse.milo.opcua.stack.core.types.structured.X509IdentityToken;
 import org.eclipse.milo.opcua.stack.core.util.CertificateUtil;
 import org.eclipse.milo.opcua.stack.core.util.DigestUtil;
 
-public abstract class AbstractIdentityValidator<T> implements IdentityValidator<T> {
+public abstract class AbstractIdentityValidator implements IdentityValidator {
 
     @Override
-    public T validateIdentityToken(
+    public Identity validateIdentityToken(
         Session session,
         UserIdentityToken token,
-        UserTokenPolicy tokenPolicy,
-        SignatureData tokenSignature) throws UaException {
+        UserTokenPolicy policy,
+        SignatureData signature) throws UaException {
 
-        switch (tokenPolicy.getTokenType()) {
+        switch (policy.getTokenType()) {
             case Anonymous: {
                 if (token instanceof AnonymousIdentityToken) {
                     return validateAnonymousToken(
-                        session, (AnonymousIdentityToken) token, tokenPolicy, tokenSignature);
+                        session, (AnonymousIdentityToken) token, policy, signature);
                 }
                 break;
             }
             case UserName: {
                 if (token instanceof UserNameIdentityToken) {
                     return validateUsernameToken(
-                        session, (UserNameIdentityToken) token, tokenPolicy, tokenSignature);
+                        session, (UserNameIdentityToken) token, policy, signature);
                 }
                 break;
             }
             case Certificate: {
                 if (token instanceof X509IdentityToken) {
                     return validateX509Token(
-                        session, (X509IdentityToken) token, tokenPolicy, tokenSignature);
+                        session, (X509IdentityToken) token, policy, signature);
                 }
                 break;
             }
             case IssuedToken: {
                 if (token instanceof IssuedIdentityToken) {
                     return validateIssuedIdentityToken(
-                        session, (IssuedIdentityToken) token, tokenPolicy, tokenSignature);
+                        session, (IssuedIdentityToken) token, policy, signature);
                 }
                 break;
             }
@@ -85,18 +85,19 @@ public abstract class AbstractIdentityValidator<T> implements IdentityValidator<
      * This Object should implement equality in such a way that a subsequent identity validation for the same user
      * yields a comparable Object.
      *
-     * @param session        the {@link Session} the request is arriving on.
-     * @param token          the {@link AnonymousIdentityToken}.
-     * @param tokenPolicy    the {@link UserTokenPolicy} specified by the policyId in {@code token}.
+     * @param session the {@link Session} the request is arriving on.
+     * @param token the {@link AnonymousIdentityToken}.
+     * @param tokenPolicy the {@link UserTokenPolicy} specified by the policyId in {@code token}.
      * @param tokenSignature the {@link SignatureData} sent in the {@link ActivateSessionRequest}.
      * @return an identity Object that represents the user.
      * @throws UaException if the token is invalid, rejected, or user access is denied.
      */
-    protected T validateAnonymousToken(
+    protected Identity validateAnonymousToken(
         Session session,
         AnonymousIdentityToken token,
         UserTokenPolicy tokenPolicy,
-        SignatureData tokenSignature) throws UaException {
+        SignatureData tokenSignature
+    ) throws UaException {
 
         throw new UaException(StatusCodes.Bad_IdentityTokenInvalid);
     }
@@ -107,18 +108,19 @@ public abstract class AbstractIdentityValidator<T> implements IdentityValidator<
      * This Object should implement equality in such a way that a subsequent identity validation for the same user
      * yields a comparable Object.
      *
-     * @param session        the {@link Session} the request is arriving on.
-     * @param token          the {@link UserNameIdentityToken}.
-     * @param tokenPolicy    the {@link UserTokenPolicy} specified by the policyId in {@code token}.
+     * @param session the {@link Session} the request is arriving on.
+     * @param token the {@link UserNameIdentityToken}.
+     * @param tokenPolicy the {@link UserTokenPolicy} specified by the policyId in {@code token}.
      * @param tokenSignature the {@link SignatureData} sent in the {@link ActivateSessionRequest}.
      * @return an identity Object that represents the user.
      * @throws UaException if the token is invalid, rejected, or user access is denied.
      */
-    protected T validateUsernameToken(
+    protected Identity validateUsernameToken(
         Session session,
         UserNameIdentityToken token,
         UserTokenPolicy tokenPolicy,
-        SignatureData tokenSignature) throws UaException {
+        SignatureData tokenSignature
+    ) throws UaException {
 
         throw new UaException(StatusCodes.Bad_IdentityTokenInvalid);
     }
@@ -129,18 +131,19 @@ public abstract class AbstractIdentityValidator<T> implements IdentityValidator<
      * This Object should implement equality in such a way that a subsequent identity validation for the same user
      * yields a comparable Object.
      *
-     * @param session        the {@link Session} the request is arriving on.
-     * @param token          the {@link X509IdentityToken}.
-     * @param tokenPolicy    the {@link UserTokenPolicy} specified by the policyId in {@code token}.
+     * @param session the {@link Session} the request is arriving on.
+     * @param token the {@link X509IdentityToken}.
+     * @param tokenPolicy the {@link UserTokenPolicy} specified by the policyId in {@code token}.
      * @param tokenSignature the {@link SignatureData} sent in the {@link ActivateSessionRequest}.
      * @return an identity Object that represents the user.
      * @throws UaException if the token is invalid, rejected, or user access is denied.
      */
-    protected T validateX509Token(
+    protected Identity validateX509Token(
         Session session,
         X509IdentityToken token,
         UserTokenPolicy tokenPolicy,
-        SignatureData tokenSignature) throws UaException {
+        SignatureData tokenSignature
+    ) throws UaException {
 
         throw new UaException(StatusCodes.Bad_IdentityTokenInvalid);
     }
@@ -151,18 +154,19 @@ public abstract class AbstractIdentityValidator<T> implements IdentityValidator<
      * This Object should implement equality in such a way that a subsequent identity validation for the same user
      * yields a comparable Object.
      *
-     * @param session        the {@link Session} the request is arriving on.
-     * @param token          the {@link IssuedIdentityToken}.
-     * @param tokenPolicy    the {@link UserTokenPolicy} specified by the policyId in {@code token}.
+     * @param session the {@link Session} the request is arriving on.
+     * @param token the {@link IssuedIdentityToken}.
+     * @param tokenPolicy the {@link UserTokenPolicy} specified by the policyId in {@code token}.
      * @param tokenSignature the {@link SignatureData} sent in the {@link ActivateSessionRequest}.
      * @return an identity Object that represents the user.
      * @throws UaException if the token is invalid, rejected, or user access is denied.
      */
-    protected T validateIssuedIdentityToken(
+    protected Identity validateIssuedIdentityToken(
         Session session,
         IssuedIdentityToken token,
         UserTokenPolicy tokenPolicy,
-        SignatureData tokenSignature) throws UaException {
+        SignatureData tokenSignature
+    ) throws UaException {
 
         throw new UaException(StatusCodes.Bad_IdentityTokenInvalid);
     }
@@ -172,7 +176,7 @@ public abstract class AbstractIdentityValidator<T> implements IdentityValidator<
      * <p>
      * See {@link UserNameIdentityToken#getPassword()} and {@link IssuedIdentityToken#getTokenData()}.
      *
-     * @param session   the current {@link Session}.
+     * @param session the current {@link Session}.
      * @param dataBytes the encrypted data.
      * @return the decrypted data.
      * @throws UaException if decryption fails.

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/AbstractIdentityValidator.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/AbstractIdentityValidator.java
@@ -85,8 +85,8 @@ public abstract class AbstractIdentityValidator implements IdentityValidator {
     }
 
     /**
-     * Validate an {@link AnonymousIdentityToken} and return an {@link Identity} that represents
-     * the user.
+     * Validate an {@link AnonymousIdentityToken} and return an {@link AnonymousIdentity} that
+     * represents the user.
      * <p>
      * This Identity should implement equality in such a way that different instances representing
      * the same user are comparable.
@@ -109,8 +109,8 @@ public abstract class AbstractIdentityValidator implements IdentityValidator {
     }
 
     /**
-     * Validate an {@link UserNameIdentityToken} and return an {@link Identity} that represents
-     * the user.
+     * Validate an {@link UserNameIdentityToken} and return a {@link UsernameIdentity} that
+     * represents the user.
      * <p>
      * This Identity should implement equality in such a way that different instances representing
      * the same user are comparable.
@@ -133,8 +133,8 @@ public abstract class AbstractIdentityValidator implements IdentityValidator {
     }
 
     /**
-     * Validate an {@link X509IdentityToken} and return an {@link X509UserIdentity} that represents
-     * the user.
+     * Validate an {@link X509IdentityToken} and return an {@link X509UserIdentity} that
+     * represents the user.
      * <p>
      * This Identity should implement equality in such a way that different instances representing
      * the same user are comparable.
@@ -157,8 +157,8 @@ public abstract class AbstractIdentityValidator implements IdentityValidator {
     }
 
     /**
-     * Validate an {@link IssuedIdentityToken} and return an {@link IssuedIdentity} that represents
-     * the user.
+     * Validate an {@link IssuedIdentityToken} and return an {@link IssuedIdentity} that
+     * represents the user.
      * <p>
      * This Identity should implement equality in such a way that different instances representing
      * the same user are comparable.

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/AbstractIdentityValidator.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/AbstractIdentityValidator.java
@@ -18,6 +18,10 @@ import java.security.cert.X509Certificate;
 import javax.crypto.Cipher;
 
 import org.eclipse.milo.opcua.sdk.server.Session;
+import org.eclipse.milo.opcua.sdk.server.identity.Identity.AnonymousIdentity;
+import org.eclipse.milo.opcua.sdk.server.identity.Identity.IssuedIdentity;
+import org.eclipse.milo.opcua.sdk.server.identity.Identity.UsernameIdentity;
+import org.eclipse.milo.opcua.sdk.server.identity.Identity.X509UserIdentity;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.channel.SecureChannel;
@@ -91,10 +95,10 @@ public abstract class AbstractIdentityValidator implements IdentityValidator {
      * @param token the {@link AnonymousIdentityToken}.
      * @param policy the {@link UserTokenPolicy} specified by the policyId in {@code token}.
      * @param signature the {@link SignatureData} sent in the {@link ActivateSessionRequest}.
-     * @return an {@link Identity} that represents the user.
+     * @return an {@link AnonymousIdentity} that represents the user identity.
      * @throws UaException if the token is invalid, rejected, or user access is denied.
      */
-    protected Identity validateAnonymousToken(
+    protected AnonymousIdentity validateAnonymousToken(
         Session session,
         AnonymousIdentityToken token,
         UserTokenPolicy policy,
@@ -115,10 +119,10 @@ public abstract class AbstractIdentityValidator implements IdentityValidator {
      * @param token the {@link UserNameIdentityToken}.
      * @param policy the {@link UserTokenPolicy} specified by the policyId in {@code token}.
      * @param signature the {@link SignatureData} sent in the {@link ActivateSessionRequest}.
-     * @return an {@link Identity} that represents the user.
+     * @return a {@link UsernameIdentity} that represents the user identity.
      * @throws UaException if the token is invalid, rejected, or user access is denied.
      */
-    protected Identity validateUsernameToken(
+    protected UsernameIdentity validateUsernameToken(
         Session session,
         UserNameIdentityToken token,
         UserTokenPolicy policy,
@@ -129,7 +133,7 @@ public abstract class AbstractIdentityValidator implements IdentityValidator {
     }
 
     /**
-     * Validate an {@link X509IdentityToken} and return an {@link Identity} that represents
+     * Validate an {@link X509IdentityToken} and return an {@link X509UserIdentity} that represents
      * the user.
      * <p>
      * This Identity should implement equality in such a way that different instances representing
@@ -139,10 +143,10 @@ public abstract class AbstractIdentityValidator implements IdentityValidator {
      * @param token the {@link X509IdentityToken}.
      * @param policy the {@link UserTokenPolicy} specified by the policyId in {@code token}.
      * @param signature the {@link SignatureData} sent in the {@link ActivateSessionRequest}.
-     * @return an {@link Identity} that represents the user.
+     * @return an {@link X509UserIdentity} that represents the user identity.
      * @throws UaException if the token is invalid, rejected, or user access is denied.
      */
-    protected Identity validateX509Token(
+    protected X509UserIdentity validateX509Token(
         Session session,
         X509IdentityToken token,
         UserTokenPolicy policy,
@@ -153,7 +157,7 @@ public abstract class AbstractIdentityValidator implements IdentityValidator {
     }
 
     /**
-     * Validate an {@link IssuedIdentityToken} and return an {@link Identity} that represents
+     * Validate an {@link IssuedIdentityToken} and return an {@link IssuedIdentity} that represents
      * the user.
      * <p>
      * This Identity should implement equality in such a way that different instances representing
@@ -163,10 +167,10 @@ public abstract class AbstractIdentityValidator implements IdentityValidator {
      * @param token the {@link IssuedIdentityToken}.
      * @param policy the {@link UserTokenPolicy} specified by the policyId in {@code token}.
      * @param signature the {@link SignatureData} sent in the {@link ActivateSessionRequest}.
-     * @return an {@link Identity} that represents the user.
+     * @return an {@link IssuedIdentity} that represents the user identity.
      * @throws UaException if the token is invalid, rejected, or user access is denied.
      */
-    protected Identity validateIssuedIdentityToken(
+    protected IssuedIdentity validateIssuedIdentityToken(
         Session session,
         IssuedIdentityToken token,
         UserTokenPolicy policy,

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/AbstractIdentityValidator.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/AbstractIdentityValidator.java
@@ -41,7 +41,8 @@ public abstract class AbstractIdentityValidator implements IdentityValidator {
         Session session,
         UserIdentityToken token,
         UserTokenPolicy policy,
-        SignatureData signature) throws UaException {
+        SignatureData signature
+    ) throws UaException {
 
         switch (policy.getTokenType()) {
             case Anonymous: {
@@ -80,110 +81,117 @@ public abstract class AbstractIdentityValidator implements IdentityValidator {
     }
 
     /**
-     * Validate an {@link AnonymousIdentityToken} and return an identity Object that represents the user.
+     * Validate an {@link AnonymousIdentityToken} and return an {@link Identity} that represents
+     * the user.
      * <p>
-     * This Object should implement equality in such a way that a subsequent identity validation for the same user
-     * yields a comparable Object.
+     * This Identity should implement equality in such a way that different instances representing
+     * the same user are comparable.
      *
-     * @param session the {@link Session} the request is arriving on.
+     * @param session the {@link Session} making the request.
      * @param token the {@link AnonymousIdentityToken}.
-     * @param tokenPolicy the {@link UserTokenPolicy} specified by the policyId in {@code token}.
-     * @param tokenSignature the {@link SignatureData} sent in the {@link ActivateSessionRequest}.
-     * @return an identity Object that represents the user.
+     * @param policy the {@link UserTokenPolicy} specified by the policyId in {@code token}.
+     * @param signature the {@link SignatureData} sent in the {@link ActivateSessionRequest}.
+     * @return an {@link Identity} that represents the user.
      * @throws UaException if the token is invalid, rejected, or user access is denied.
      */
     protected Identity validateAnonymousToken(
         Session session,
         AnonymousIdentityToken token,
-        UserTokenPolicy tokenPolicy,
-        SignatureData tokenSignature
+        UserTokenPolicy policy,
+        SignatureData signature
     ) throws UaException {
 
         throw new UaException(StatusCodes.Bad_IdentityTokenInvalid);
     }
 
     /**
-     * Validate a {@link UserNameIdentityToken} and return an identity Object that represents the user.
+     * Validate an {@link UserNameIdentityToken} and return an {@link Identity} that represents
+     * the user.
      * <p>
-     * This Object should implement equality in such a way that a subsequent identity validation for the same user
-     * yields a comparable Object.
+     * This Identity should implement equality in such a way that different instances representing
+     * the same user are comparable.
      *
-     * @param session the {@link Session} the request is arriving on.
+     * @param session the {@link Session} making the request.
      * @param token the {@link UserNameIdentityToken}.
-     * @param tokenPolicy the {@link UserTokenPolicy} specified by the policyId in {@code token}.
-     * @param tokenSignature the {@link SignatureData} sent in the {@link ActivateSessionRequest}.
-     * @return an identity Object that represents the user.
+     * @param policy the {@link UserTokenPolicy} specified by the policyId in {@code token}.
+     * @param signature the {@link SignatureData} sent in the {@link ActivateSessionRequest}.
+     * @return an {@link Identity} that represents the user.
      * @throws UaException if the token is invalid, rejected, or user access is denied.
      */
     protected Identity validateUsernameToken(
         Session session,
         UserNameIdentityToken token,
-        UserTokenPolicy tokenPolicy,
-        SignatureData tokenSignature
+        UserTokenPolicy policy,
+        SignatureData signature
     ) throws UaException {
 
         throw new UaException(StatusCodes.Bad_IdentityTokenInvalid);
     }
 
     /**
-     * Validate an {@link X509IdentityToken} and return an identity Object that represents the user.
+     * Validate an {@link X509IdentityToken} and return an {@link Identity} that represents
+     * the user.
      * <p>
-     * This Object should implement equality in such a way that a subsequent identity validation for the same user
-     * yields a comparable Object.
+     * This Identity should implement equality in such a way that different instances representing
+     * the same user are comparable.
      *
-     * @param session the {@link Session} the request is arriving on.
+     * @param session the {@link Session} making the request.
      * @param token the {@link X509IdentityToken}.
-     * @param tokenPolicy the {@link UserTokenPolicy} specified by the policyId in {@code token}.
-     * @param tokenSignature the {@link SignatureData} sent in the {@link ActivateSessionRequest}.
-     * @return an identity Object that represents the user.
+     * @param policy the {@link UserTokenPolicy} specified by the policyId in {@code token}.
+     * @param signature the {@link SignatureData} sent in the {@link ActivateSessionRequest}.
+     * @return an {@link Identity} that represents the user.
      * @throws UaException if the token is invalid, rejected, or user access is denied.
      */
     protected Identity validateX509Token(
         Session session,
         X509IdentityToken token,
-        UserTokenPolicy tokenPolicy,
-        SignatureData tokenSignature
+        UserTokenPolicy policy,
+        SignatureData signature
     ) throws UaException {
 
         throw new UaException(StatusCodes.Bad_IdentityTokenInvalid);
     }
 
     /**
-     * Validate an {@link IssuedIdentityToken} and return an identity Object that represents the user.
+     * Validate an {@link IssuedIdentityToken} and return an {@link Identity} that represents
+     * the user.
      * <p>
-     * This Object should implement equality in such a way that a subsequent identity validation for the same user
-     * yields a comparable Object.
+     * This Identity should implement equality in such a way that different instances representing
+     * the same user are comparable.
      *
-     * @param session the {@link Session} the request is arriving on.
+     * @param session the {@link Session} making the request.
      * @param token the {@link IssuedIdentityToken}.
-     * @param tokenPolicy the {@link UserTokenPolicy} specified by the policyId in {@code token}.
-     * @param tokenSignature the {@link SignatureData} sent in the {@link ActivateSessionRequest}.
-     * @return an identity Object that represents the user.
+     * @param policy the {@link UserTokenPolicy} specified by the policyId in {@code token}.
+     * @param signature the {@link SignatureData} sent in the {@link ActivateSessionRequest}.
+     * @return an {@link Identity} that represents the user.
      * @throws UaException if the token is invalid, rejected, or user access is denied.
      */
     protected Identity validateIssuedIdentityToken(
         Session session,
         IssuedIdentityToken token,
-        UserTokenPolicy tokenPolicy,
-        SignatureData tokenSignature
+        UserTokenPolicy policy,
+        SignatureData signature
     ) throws UaException {
 
         throw new UaException(StatusCodes.Bad_IdentityTokenInvalid);
     }
 
     /**
-     * Decrypt the data contained in a {@link UserNameIdentityToken} or {@link IssuedIdentityToken}.
-     * <p>
-     * See {@link UserNameIdentityToken#getPassword()} and {@link IssuedIdentityToken#getTokenData()}.
+     * Decrypt the data contained in a {@link UserNameIdentityToken} or
+     * {@link IssuedIdentityToken}.
      *
      * @param session the current {@link Session}.
      * @param dataBytes the encrypted data.
      * @return the decrypted data.
      * @throws UaException if decryption fails.
+     * @see IssuedIdentityToken#getTokenData()
+     * @see UserNameIdentityToken#getPassword()
      */
-    protected byte[] decryptTokenData(Session session,
-                                      SecurityAlgorithm algorithm,
-                                      byte[] dataBytes) throws UaException {
+    protected byte[] decryptTokenData(
+        Session session,
+        SecurityAlgorithm algorithm,
+        byte[] dataBytes
+    ) throws UaException {
 
         X509Certificate certificate = CertificateUtil.decodeCertificate(
             session.getEndpoint()

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/AbstractUsernameIdentityValidator.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/AbstractUsernameIdentityValidator.java
@@ -148,7 +148,8 @@ public abstract class AbstractUsernameIdentityValidator extends AbstractIdentity
     }
 
     /**
-     * Create and return an identity object for an anonymous user.
+     * Create and return an {@link AnonymousIdentity} for the anonymous user, or {@code null} if
+     * anonymous authentication is not allowed.
      *
      * @param session the {@link Session} being activated.
      * @return an {@link AnonymousIdentity}, or {@code null} if anonymous authentication is not

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/AbstractUsernameIdentityValidator.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/AbstractUsernameIdentityValidator.java
@@ -25,10 +25,10 @@ import org.eclipse.milo.opcua.stack.core.types.structured.UserNameIdentityToken;
 import org.eclipse.milo.opcua.stack.core.types.structured.UserTokenPolicy;
 import org.jetbrains.annotations.Nullable;
 
-public abstract class AbstractUsernameIdentityValidator<T> extends AbstractIdentityValidator<T> {
+public abstract class AbstractUsernameIdentityValidator extends AbstractIdentityValidator {
 
     @Override
-    protected T validateAnonymousToken(
+    protected Identity validateAnonymousToken(
         Session session,
         AnonymousIdentityToken token,
         UserTokenPolicy tokenPolicy,
@@ -39,7 +39,7 @@ public abstract class AbstractUsernameIdentityValidator<T> extends AbstractIdent
     }
 
     @Override
-    protected T validateUsernameToken(
+    protected Identity validateUsernameToken(
         Session session,
         UserNameIdentityToken token,
         UserTokenPolicy tokenPolicy,
@@ -125,21 +125,21 @@ public abstract class AbstractUsernameIdentityValidator<T> extends AbstractIdent
         }
     }
 
-    private T authenticateAnonymousOrThrow(Session session) throws UaException {
-        T identityObject = authenticateAnonymous(session);
+    private Identity.AnonymousIdentity authenticateAnonymousOrThrow(Session session) throws UaException {
+        Identity.AnonymousIdentity identity = authenticateAnonymous(session);
 
-        if (identityObject != null) {
-            return identityObject;
+        if (identity != null) {
+            return identity;
         } else {
             throw new UaException(StatusCodes.Bad_UserAccessDenied);
         }
     }
 
-    private T authenticateUsernameOrThrow(Session session, String username, String password) throws UaException {
-        T identityObject = authenticateUsernamePassword(session, username, password);
+    private Identity.UsernameIdentity authenticateUsernameOrThrow(Session session, String username, String password) throws UaException {
+        Identity.UsernameIdentity identity = authenticateUsernamePassword(session, username, password);
 
-        if (identityObject != null) {
-            return identityObject;
+        if (identity != null) {
+            return identity;
         } else {
             throw new UaException(StatusCodes.Bad_UserAccessDenied);
         }
@@ -150,21 +150,23 @@ public abstract class AbstractUsernameIdentityValidator<T> extends AbstractIdent
      *
      * @param session the {@link Session} being activated.
      * @return an identity object of type {@code T} representig an anonymous user, or {@code null} if anonymous
-     * authentication is not allowed.
+     *     authentication is not allowed.
      */
-    @Nullable
-    protected abstract T authenticateAnonymous(Session session);
+    protected abstract @Nullable Identity.AnonymousIdentity authenticateAnonymous(Session session);
 
     /**
      * Authenticate {@code username} with {@code password}, returning an identity object of type {@code T} if the
      * authentication succeeded, or {@code null} if the authentication failed.
      *
-     * @param session  the {@link Session} being activated.
+     * @param session the {@link Session} being activated.
      * @param username the username to authenticate.
      * @param password the password to authenticate the user with.
      * @return an identity object of type {@code T} if the authentication succeeded, or {@code null} if it failed.
      */
-    @Nullable
-    protected abstract T authenticateUsernamePassword(Session session, String username, String password);
+    protected abstract @Nullable Identity.UsernameIdentity authenticateUsernamePassword(
+        Session session,
+        String username,
+        String password
+    );
 
 }

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/AbstractUsernameIdentityValidator.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/AbstractUsernameIdentityValidator.java
@@ -14,6 +14,8 @@ import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 
 import org.eclipse.milo.opcua.sdk.server.Session;
+import org.eclipse.milo.opcua.sdk.server.identity.Identity.AnonymousIdentity;
+import org.eclipse.milo.opcua.sdk.server.identity.Identity.UsernameIdentity;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.security.SecurityAlgorithm;
@@ -28,7 +30,7 @@ import org.jetbrains.annotations.Nullable;
 public abstract class AbstractUsernameIdentityValidator extends AbstractIdentityValidator {
 
     @Override
-    protected Identity validateAnonymousToken(
+    protected AnonymousIdentity validateAnonymousToken(
         Session session,
         AnonymousIdentityToken token,
         UserTokenPolicy policy,
@@ -39,7 +41,7 @@ public abstract class AbstractUsernameIdentityValidator extends AbstractIdentity
     }
 
     @Override
-    protected Identity validateUsernameToken(
+    protected UsernameIdentity validateUsernameToken(
         Session session,
         UserNameIdentityToken token,
         UserTokenPolicy policy,
@@ -125,8 +127,8 @@ public abstract class AbstractUsernameIdentityValidator extends AbstractIdentity
         }
     }
 
-    private Identity.AnonymousIdentity authenticateAnonymousOrThrow(Session session) throws UaException {
-        Identity.AnonymousIdentity identity = authenticateAnonymous(session);
+    private AnonymousIdentity authenticateAnonymousOrThrow(Session session) throws UaException {
+        AnonymousIdentity identity = authenticateAnonymous(session);
 
         if (identity != null) {
             return identity;
@@ -135,8 +137,8 @@ public abstract class AbstractUsernameIdentityValidator extends AbstractIdentity
         }
     }
 
-    private Identity.UsernameIdentity authenticateUsernameOrThrow(Session session, String username, String password) throws UaException {
-        Identity.UsernameIdentity identity = authenticateUsernamePassword(session, username, password);
+    private UsernameIdentity authenticateUsernameOrThrow(Session session, String username, String password) throws UaException {
+        UsernameIdentity identity = authenticateUsernamePassword(session, username, password);
 
         if (identity != null) {
             return identity;
@@ -149,21 +151,22 @@ public abstract class AbstractUsernameIdentityValidator extends AbstractIdentity
      * Create and return an identity object for an anonymous user.
      *
      * @param session the {@link Session} being activated.
-     * @return an identity object of type {@code T} representig an anonymous user, or {@code null} if anonymous
-     *     authentication is not allowed.
+     * @return an {@link AnonymousIdentity}, or {@code null} if anonymous authentication is not
+     *     allowed.
      */
-    protected abstract @Nullable Identity.AnonymousIdentity authenticateAnonymous(Session session);
+    protected abstract @Nullable AnonymousIdentity authenticateAnonymous(Session session);
 
     /**
-     * Authenticate {@code username} with {@code password}, returning an identity object of type {@code T} if the
-     * authentication succeeded, or {@code null} if the authentication failed.
+     * Authenticate {@code username} with {@code password}, returning a {@link UsernameIdentity}
+     * if authentication succeeded, or {@code null} if the authentication failed.
      *
      * @param session the {@link Session} being activated.
      * @param username the username to authenticate.
      * @param password the password to authenticate the user with.
-     * @return an identity object of type {@code T} if the authentication succeeded, or {@code null} if it failed.
+     * @return a {@link UsernameIdentity} if the authentication succeeded, or {@code null} if it
+     *     failed.
      */
-    protected abstract @Nullable Identity.UsernameIdentity authenticateUsernamePassword(
+    protected abstract @Nullable UsernameIdentity authenticateUsernamePassword(
         Session session,
         String username,
         String password

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/AbstractUsernameIdentityValidator.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/AbstractUsernameIdentityValidator.java
@@ -31,8 +31,8 @@ public abstract class AbstractUsernameIdentityValidator extends AbstractIdentity
     protected Identity validateAnonymousToken(
         Session session,
         AnonymousIdentityToken token,
-        UserTokenPolicy tokenPolicy,
-        SignatureData tokenSignature
+        UserTokenPolicy policy,
+        SignatureData signature
     ) throws UaException {
 
         return authenticateAnonymousOrThrow(session);
@@ -42,8 +42,8 @@ public abstract class AbstractUsernameIdentityValidator extends AbstractIdentity
     protected Identity validateUsernameToken(
         Session session,
         UserNameIdentityToken token,
-        UserTokenPolicy tokenPolicy,
-        SignatureData tokenSignature
+        UserTokenPolicy policy,
+        SignatureData signature
     ) throws UaException {
 
         String username = token.getUserName();

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/AbstractX509IdentityValidator.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/AbstractX509IdentityValidator.java
@@ -29,7 +29,7 @@ import org.jetbrains.annotations.Nullable;
 public abstract class AbstractX509IdentityValidator extends AbstractIdentityValidator {
 
     @Override
-    protected Identity validateX509Token(
+    protected Identity.X509UserIdentity validateX509Token(
         Session session,
         X509IdentityToken token,
         UserTokenPolicy policy,
@@ -70,12 +70,12 @@ public abstract class AbstractX509IdentityValidator extends AbstractIdentityVali
         return authenticateIdentityCertificateOrThrow(session, identityCertificate);
     }
 
-    private Identity authenticateIdentityCertificateOrThrow(
+    private Identity.X509UserIdentity authenticateIdentityCertificateOrThrow(
         Session session,
         X509Certificate identityCertificate
     ) throws UaException {
 
-        Identity identity = authenticateIdentityCertificate(session, identityCertificate);
+        Identity.X509UserIdentity identity = authenticateIdentityCertificate(session, identityCertificate);
 
         if (identity != null) {
             return identity;
@@ -87,13 +87,15 @@ public abstract class AbstractX509IdentityValidator extends AbstractIdentityVali
     /**
      * Create and return an identity object for the user identified by {@code identityCertificate}.
      * <p>
-     * Possession of the private key associated with this certificate has been verified prior to this call.
+     * Possession of the private key associated with this certificate has been verified prior to
+     * this call.
      *
      * @param session the {@link Session} being activated.
      * @param identityCertificate the {@link X509Certificate} identifying the user.
-     * @return an identity object of type {@code T} if the authentication succeeded, or {@code null} if it failed.
+     * @return an {@link Identity.X509UserIdentity} if the authentication succeeded, or
+     *     {@code null} if it failed.
      */
-    protected abstract @Nullable Identity authenticateIdentityCertificate(
+    protected abstract @Nullable Identity.X509UserIdentity authenticateIdentityCertificate(
         Session session,
         X509Certificate identityCertificate
     );

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/AbstractX509IdentityValidator.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/AbstractX509IdentityValidator.java
@@ -32,36 +32,36 @@ public abstract class AbstractX509IdentityValidator extends AbstractIdentityVali
     protected Identity validateX509Token(
         Session session,
         X509IdentityToken token,
-        UserTokenPolicy tokenPolicy,
-        SignatureData tokenSignature
+        UserTokenPolicy policy,
+        SignatureData signature
     ) throws UaException {
 
         ByteString clientCertificateBs = token.getCertificateData();
         X509Certificate identityCertificate = CertificateUtil.decodeCertificate(clientCertificateBs.bytesOrEmpty());
 
         // verify the algorithm matches the one specified by the tokenPolicy or else the channel itself
-        if (tokenPolicy.getSecurityPolicyUri() != null) {
-            SecurityPolicy securityPolicy = SecurityPolicy.fromUri(tokenPolicy.getSecurityPolicyUri());
+        if (policy.getSecurityPolicyUri() != null) {
+            SecurityPolicy securityPolicy = SecurityPolicy.fromUri(policy.getSecurityPolicyUri());
 
-            if (!securityPolicy.getAsymmetricSignatureAlgorithm().getUri().equals(tokenSignature.getAlgorithm())) {
+            if (!securityPolicy.getAsymmetricSignatureAlgorithm().getUri().equals(signature.getAlgorithm())) {
                 throw new UaException(StatusCodes.Bad_SecurityChecksFailed,
                     "algorithm in token signature did not match algorithm specified by token policy");
             }
         } else {
             SecurityPolicy securityPolicy = session.getSecurityConfiguration().getSecurityPolicy();
 
-            if (!securityPolicy.getAsymmetricSignatureAlgorithm().getUri().equals(tokenSignature.getAlgorithm())) {
+            if (!securityPolicy.getAsymmetricSignatureAlgorithm().getUri().equals(signature.getAlgorithm())) {
                 throw new UaException(StatusCodes.Bad_SecurityChecksFailed,
                     "algorithm in token signature did not match algorithm specified by secure channel");
             }
         }
 
-        SecurityAlgorithm algorithm = SecurityAlgorithm.fromUri(tokenSignature.getAlgorithm());
+        SecurityAlgorithm algorithm = SecurityAlgorithm.fromUri(signature.getAlgorithm());
 
         if (algorithm != SecurityAlgorithm.None) {
             verifySignature(
                 session,
-                tokenSignature,
+                signature,
                 identityCertificate,
                 algorithm
             );

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/AbstractX509IdentityValidator.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/AbstractX509IdentityValidator.java
@@ -14,6 +14,7 @@ import java.security.cert.X509Certificate;
 
 import com.google.common.primitives.Bytes;
 import org.eclipse.milo.opcua.sdk.server.Session;
+import org.eclipse.milo.opcua.sdk.server.identity.Identity.X509UserIdentity;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.security.SecurityAlgorithm;
@@ -29,7 +30,7 @@ import org.jetbrains.annotations.Nullable;
 public abstract class AbstractX509IdentityValidator extends AbstractIdentityValidator {
 
     @Override
-    protected Identity.X509UserIdentity validateX509Token(
+    protected X509UserIdentity validateX509Token(
         Session session,
         X509IdentityToken token,
         UserTokenPolicy policy,
@@ -70,12 +71,12 @@ public abstract class AbstractX509IdentityValidator extends AbstractIdentityVali
         return authenticateCertificateOrThrow(session, certificate);
     }
 
-    private Identity.X509UserIdentity authenticateCertificateOrThrow(
+    private X509UserIdentity authenticateCertificateOrThrow(
         Session session,
         X509Certificate certificate
     ) throws UaException {
 
-        Identity.X509UserIdentity identity = authenticateCertificate(session, certificate);
+        X509UserIdentity identity = authenticateCertificate(session, certificate);
 
         if (identity != null) {
             return identity;
@@ -85,17 +86,17 @@ public abstract class AbstractX509IdentityValidator extends AbstractIdentityVali
     }
 
     /**
-     * Create and return an identity object for the user identified by {@code certificate}.
+     * Create and return an {@link X509UserIdentity} for the user identified by {@code certificate}.
      * <p>
      * Possession of the private key associated with this certificate has been verified prior to
      * this call.
      *
      * @param session the {@link Session} being activated.
      * @param certificate the {@link X509Certificate} identifying the user.
-     * @return an {@link Identity.X509UserIdentity} if the authentication succeeded, or
-     *     {@code null} if it failed.
+     * @return an {@link X509UserIdentity} if the authentication succeeded, or {@code null} if it
+     *     failed.
      */
-    protected abstract @Nullable Identity.X509UserIdentity authenticateCertificate(
+    protected abstract @Nullable X509UserIdentity authenticateCertificate(
         Session session,
         X509Certificate certificate
     );

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/AbstractX509IdentityValidator.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/AbstractX509IdentityValidator.java
@@ -37,7 +37,7 @@ public abstract class AbstractX509IdentityValidator extends AbstractIdentityVali
     ) throws UaException {
 
         ByteString clientCertificateBs = token.getCertificateData();
-        X509Certificate identityCertificate = CertificateUtil.decodeCertificate(clientCertificateBs.bytesOrEmpty());
+        X509Certificate certificate = CertificateUtil.decodeCertificate(clientCertificateBs.bytesOrEmpty());
 
         // verify the algorithm matches the one specified by the tokenPolicy or else the channel itself
         if (policy.getSecurityPolicyUri() != null) {
@@ -62,20 +62,20 @@ public abstract class AbstractX509IdentityValidator extends AbstractIdentityVali
             verifySignature(
                 session,
                 signature,
-                identityCertificate,
+                certificate,
                 algorithm
             );
         }
 
-        return authenticateIdentityCertificateOrThrow(session, identityCertificate);
+        return authenticateCertificateOrThrow(session, certificate);
     }
 
-    private Identity.X509UserIdentity authenticateIdentityCertificateOrThrow(
+    private Identity.X509UserIdentity authenticateCertificateOrThrow(
         Session session,
-        X509Certificate identityCertificate
+        X509Certificate certificate
     ) throws UaException {
 
-        Identity.X509UserIdentity identity = authenticateIdentityCertificate(session, identityCertificate);
+        Identity.X509UserIdentity identity = authenticateCertificate(session, certificate);
 
         if (identity != null) {
             return identity;
@@ -85,25 +85,25 @@ public abstract class AbstractX509IdentityValidator extends AbstractIdentityVali
     }
 
     /**
-     * Create and return an identity object for the user identified by {@code identityCertificate}.
+     * Create and return an identity object for the user identified by {@code certificate}.
      * <p>
      * Possession of the private key associated with this certificate has been verified prior to
      * this call.
      *
      * @param session the {@link Session} being activated.
-     * @param identityCertificate the {@link X509Certificate} identifying the user.
+     * @param certificate the {@link X509Certificate} identifying the user.
      * @return an {@link Identity.X509UserIdentity} if the authentication succeeded, or
      *     {@code null} if it failed.
      */
-    protected abstract @Nullable Identity.X509UserIdentity authenticateIdentityCertificate(
+    protected abstract @Nullable Identity.X509UserIdentity authenticateCertificate(
         Session session,
-        X509Certificate identityCertificate
+        X509Certificate certificate
     );
 
     private static void verifySignature(
         Session session,
         SignatureData tokenSignature,
-        X509Certificate identityCertificate,
+        X509Certificate certificate,
         SecurityAlgorithm algorithm
     ) throws UaException {
 
@@ -119,7 +119,7 @@ public abstract class AbstractX509IdentityValidator extends AbstractIdentityVali
 
             SignatureUtil.verify(
                 algorithm,
-                identityCertificate,
+                certificate,
                 dataBytes,
                 signatureBytes
             );
@@ -138,7 +138,7 @@ public abstract class AbstractX509IdentityValidator extends AbstractIdentityVali
 
                 SignatureUtil.verify(
                     algorithm,
-                    identityCertificate,
+                    certificate,
                     dataBytes,
                     signatureBytes
                 );

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/AbstractX509IdentityValidator.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/AbstractX509IdentityValidator.java
@@ -26,10 +26,10 @@ import org.eclipse.milo.opcua.stack.core.util.CertificateUtil;
 import org.eclipse.milo.opcua.stack.core.util.SignatureUtil;
 import org.jetbrains.annotations.Nullable;
 
-public abstract class AbstractX509IdentityValidator<T> extends AbstractIdentityValidator<T> {
+public abstract class AbstractX509IdentityValidator extends AbstractIdentityValidator {
 
     @Override
-    protected T validateX509Token(
+    protected Identity validateX509Token(
         Session session,
         X509IdentityToken token,
         UserTokenPolicy tokenPolicy,
@@ -70,15 +70,15 @@ public abstract class AbstractX509IdentityValidator<T> extends AbstractIdentityV
         return authenticateIdentityCertificateOrThrow(session, identityCertificate);
     }
 
-    private T authenticateIdentityCertificateOrThrow(
+    private Identity authenticateIdentityCertificateOrThrow(
         Session session,
         X509Certificate identityCertificate
     ) throws UaException {
 
-        T identityObject = authenticateIdentityCertificate(session, identityCertificate);
+        Identity identity = authenticateIdentityCertificate(session, identityCertificate);
 
-        if (identityObject != null) {
-            return identityObject;
+        if (identity != null) {
+            return identity;
         } else {
             throw new UaException(StatusCodes.Bad_UserAccessDenied);
         }
@@ -89,12 +89,14 @@ public abstract class AbstractX509IdentityValidator<T> extends AbstractIdentityV
      * <p>
      * Possession of the private key associated with this certificate has been verified prior to this call.
      *
-     * @param session             the {@link Session} being activated.
+     * @param session the {@link Session} being activated.
      * @param identityCertificate the {@link X509Certificate} identifying the user.
      * @return an identity object of type {@code T} if the authentication succeeded, or {@code null} if it failed.
      */
-    @Nullable
-    protected abstract T authenticateIdentityCertificate(Session session, X509Certificate identityCertificate);
+    protected abstract @Nullable Identity authenticateIdentityCertificate(
+        Session session,
+        X509Certificate identityCertificate
+    );
 
     private static void verifySignature(
         Session session,

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/AnonymousIdentityValidator.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/AnonymousIdentityValidator.java
@@ -15,25 +15,22 @@ import org.eclipse.milo.opcua.stack.core.types.structured.AnonymousIdentityToken
 import org.eclipse.milo.opcua.stack.core.types.structured.SignatureData;
 import org.eclipse.milo.opcua.stack.core.types.structured.UserTokenPolicy;
 
-public final class AnonymousIdentityValidator extends AbstractIdentityValidator<String> {
+public final class AnonymousIdentityValidator extends AbstractIdentityValidator {
 
     /**
      * A static instance implementing AnonymousIdentityValidator
      */
-    public static final IdentityValidator<String> INSTANCE = new AnonymousIdentityValidator();
+    public static final AnonymousIdentityValidator INSTANCE = new AnonymousIdentityValidator();
 
     @Override
-    public String validateAnonymousToken(
+    public Identity.AnonymousIdentity validateAnonymousToken(
         Session session,
         AnonymousIdentityToken token,
         UserTokenPolicy tokenPolicy,
         SignatureData tokenSignature
     ) {
 
-        return String.format("anonymous_%s_%s",
-            session.getSessionName(),
-            session.getSessionId().toParseableString()
-        );
+        return new DefaultAnonymousIdentity();
     }
 
 }

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/AnonymousIdentityValidator.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/AnonymousIdentityValidator.java
@@ -26,8 +26,8 @@ public final class AnonymousIdentityValidator extends AbstractIdentityValidator 
     public Identity.AnonymousIdentity validateAnonymousToken(
         Session session,
         AnonymousIdentityToken token,
-        UserTokenPolicy tokenPolicy,
-        SignatureData tokenSignature
+        UserTokenPolicy policy,
+        SignatureData signature
     ) {
 
         return new DefaultAnonymousIdentity();

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/CompositeValidator.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/CompositeValidator.java
@@ -33,7 +33,7 @@ public class CompositeValidator implements IdentityValidator {
     private final List<IdentityValidator> validators;
 
     public CompositeValidator(IdentityValidator... validators) {
-        this.validators = List.of(validators);
+        this(List.of(validators));
     }
 
     public CompositeValidator(List<IdentityValidator> validators) {

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/CompositeValidator.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/CompositeValidator.java
@@ -23,36 +23,38 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * A composite {@link IdentityValidator} that tries its component {@link IdentityValidator}s in the order provided.
+ * A composite {@link IdentityValidator} that tries its component {@link IdentityValidator}s in
+ * the order provided.
  */
-public class CompositeValidator<T> implements IdentityValidator<T> {
+public class CompositeValidator implements IdentityValidator {
 
     private final Logger logger = LoggerFactory.getLogger(getClass());
 
-    private final List<IdentityValidator<T>> validators;
+    private final List<IdentityValidator> validators;
 
-    public CompositeValidator(IdentityValidator<T>... validators) {
+    public CompositeValidator(IdentityValidator... validators) {
         this.validators = List.of(validators);
     }
 
-    public CompositeValidator(List<IdentityValidator<T>> validators) {
+    public CompositeValidator(List<IdentityValidator> validators) {
         this.validators = List.copyOf(validators);
     }
 
     @Override
-    public T validateIdentityToken(
+    public Identity validateIdentityToken(
         Session session,
         UserIdentityToken token,
-        UserTokenPolicy tokenPolicy,
-        SignatureData tokenSignature) throws UaException {
+        UserTokenPolicy policy,
+        SignatureData signature
+    ) throws UaException {
 
-        Iterator<IdentityValidator<T>> iterator = validators.iterator();
+        Iterator<IdentityValidator> iterator = validators.iterator();
 
         while (iterator.hasNext()) {
-            IdentityValidator<T> validator = iterator.next();
+            IdentityValidator validator = iterator.next();
 
             try {
-                return validator.validateIdentityToken(session, token, tokenPolicy, tokenSignature);
+                return validator.validateIdentityToken(session, token, policy, signature);
             } catch (Exception e) {
                 if (!iterator.hasNext()) {
                     throw e;

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/DefaultAnonymousIdentity.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/DefaultAnonymousIdentity.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2023 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.identity;
+
+import org.eclipse.milo.opcua.stack.core.types.enumerated.UserTokenType;
+
+public class DefaultAnonymousIdentity extends AbstractIdentity implements Identity.AnonymousIdentity {
+
+    @Override
+    public UserTokenType getUserTokenType() {
+        return UserTokenType.Anonymous;
+    }
+
+}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/DefaultIssuedIdentity.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/DefaultIssuedIdentity.java
@@ -10,26 +10,25 @@
 
 package org.eclipse.milo.opcua.sdk.server.identity;
 
-import java.security.cert.X509Certificate;
-
+import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.UserTokenType;
 
-public class DefaultX509UserIdentity extends AbstractIdentity implements Identity.X509UserIdentity {
+public class DefaultIssuedIdentity extends AbstractIdentity implements Identity.IssuedIdentity {
 
-    private final X509Certificate certificate;
+    private final ByteString tokenData;
 
-    public DefaultX509UserIdentity(X509Certificate certificate) {
-        this.certificate = certificate;
+    public DefaultIssuedIdentity(ByteString tokenData) {
+        this.tokenData = tokenData;
     }
 
     @Override
     public UserTokenType getUserTokenType() {
-        return UserTokenType.Certificate;
+        return UserTokenType.IssuedToken;
     }
 
     @Override
-    public X509Certificate getCertificate() {
-        return certificate;
+    public ByteString getTokenData() {
+        return tokenData;
     }
 
 }

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/DefaultUsernameIdentity.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/DefaultUsernameIdentity.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2023 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.identity;
+
+import org.eclipse.milo.opcua.stack.core.types.enumerated.UserTokenType;
+
+public class DefaultUsernameIdentity extends AbstractIdentity implements Identity.UsernameIdentity {
+
+    private final String username;
+
+    public DefaultUsernameIdentity(String username) {
+        this.username = username;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    @Override
+    public UserTokenType getUserTokenType() {
+        return UserTokenType.UserName;
+    }
+
+}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/DefaultUsernameIdentity.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/DefaultUsernameIdentity.java
@@ -20,13 +20,14 @@ public class DefaultUsernameIdentity extends AbstractIdentity implements Identit
         this.username = username;
     }
 
-    public String getUsername() {
-        return username;
-    }
-
     @Override
     public UserTokenType getUserTokenType() {
         return UserTokenType.UserName;
+    }
+
+    @Override
+    public String getUsername() {
+        return username;
     }
 
 }

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/DefaultX509UserIdentity.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/DefaultX509UserIdentity.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2023 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.identity;
+
+import java.security.cert.X509Certificate;
+
+import org.eclipse.milo.opcua.stack.core.types.enumerated.UserTokenType;
+
+public class DefaultX509UserIdentity extends AbstractIdentity implements Identity.X509UserIdentity {
+
+    private final X509Certificate certificate;
+
+    public DefaultX509UserIdentity(X509Certificate certificate) {
+        this.certificate = certificate;
+    }
+
+    public X509Certificate getCertificate() {
+        return certificate;
+    }
+
+    @Override
+    public UserTokenType getUserTokenType() {
+        return UserTokenType.Certificate;
+    }
+
+}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/Identity.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/Identity.java
@@ -37,7 +37,7 @@ public interface Identity {
      *
      * @param userData the user data object.
      */
-    void setUserData(Object userData);
+    void setUserData(@Nullable Object userData);
 
     /**
      * An {@link Identity} derived from validation of an {@link AnonymousIdentityToken}.

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/Identity.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/Identity.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2023 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.identity;
+
+import java.security.cert.X509Certificate;
+
+import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.UserTokenType;
+import org.jetbrains.annotations.Nullable;
+
+public interface Identity {
+
+    /**
+     * @return the {@link UserTokenType} for this identity.
+     */
+    UserTokenType getUserTokenType();
+
+    /**
+     * @return the user data object associated with this identity.
+     */
+    @Nullable Object getUserData();
+
+    /**
+     * Associate an arbitrary user data object on this identity.
+     *
+     * @param userData the user data object.
+     */
+    void setUserData(Object userData);
+
+    interface AnonymousIdentity extends Identity {
+
+    }
+
+    interface UsernameIdentity extends Identity {
+
+
+        /**
+         * @return the username for this identity.
+         */
+        String getUsername();
+
+    }
+
+    interface X509UserIdentity extends Identity {
+
+
+        /**
+         * @return the {@link X509Certificate} for this identity.
+         */
+        X509Certificate getCertificate();
+
+    }
+
+    interface IssuedUserIdentity extends Identity {
+
+        /**
+         * @return a {@link ByteString} containing opaque issued token data.
+         */
+        ByteString getTokenData();
+
+    }
+
+}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/Identity.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/Identity.java
@@ -49,7 +49,6 @@ public interface Identity {
      */
     interface UsernameIdentity extends Identity {
 
-
         /**
          * @return the username for this identity.
          */
@@ -61,7 +60,6 @@ public interface Identity {
      * An {@link Identity} derived from validation of an {@link X509IdentityToken}.
      */
     interface X509UserIdentity extends Identity {
-
 
         /**
          * @return the {@link X509Certificate} for this identity.

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/Identity.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/Identity.java
@@ -73,7 +73,7 @@ public interface Identity {
     /**
      * An {@link Identity} derived from validation of an {@link IssuedIdentityToken}.
      */
-    interface IssuedUserIdentity extends Identity {
+    interface IssuedIdentity extends Identity {
 
         /**
          * @return a {@link ByteString} containing opaque issued token data.

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/Identity.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/Identity.java
@@ -14,6 +14,10 @@ import java.security.cert.X509Certificate;
 
 import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.UserTokenType;
+import org.eclipse.milo.opcua.stack.core.types.structured.AnonymousIdentityToken;
+import org.eclipse.milo.opcua.stack.core.types.structured.IssuedIdentityToken;
+import org.eclipse.milo.opcua.stack.core.types.structured.UserNameIdentityToken;
+import org.eclipse.milo.opcua.stack.core.types.structured.X509IdentityToken;
 import org.jetbrains.annotations.Nullable;
 
 public interface Identity {
@@ -29,16 +33,20 @@ public interface Identity {
     @Nullable Object getUserData();
 
     /**
-     * Associate an arbitrary user data object on this identity.
+     * Associate an arbitrary user data object with this identity.
      *
      * @param userData the user data object.
      */
     void setUserData(Object userData);
 
-    interface AnonymousIdentity extends Identity {
+    /**
+     * An {@link Identity} derived from validation of an {@link AnonymousIdentityToken}.
+     */
+    interface AnonymousIdentity extends Identity {}
 
-    }
-
+    /**
+     * An {@link Identity} derived from validation of a {@link UserNameIdentityToken}.
+     */
     interface UsernameIdentity extends Identity {
 
 
@@ -49,6 +57,9 @@ public interface Identity {
 
     }
 
+    /**
+     * An {@link Identity} derived from validation of an {@link X509IdentityToken}.
+     */
     interface X509UserIdentity extends Identity {
 
 
@@ -59,6 +70,9 @@ public interface Identity {
 
     }
 
+    /**
+     * An {@link Identity} derived from validation of an {@link IssuedIdentityToken}.
+     */
     interface IssuedUserIdentity extends Identity {
 
         /**

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/IdentityValidator.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/IdentityValidator.java
@@ -17,26 +17,24 @@ import org.eclipse.milo.opcua.stack.core.types.structured.SignatureData;
 import org.eclipse.milo.opcua.stack.core.types.structured.UserIdentityToken;
 import org.eclipse.milo.opcua.stack.core.types.structured.UserTokenPolicy;
 
-public interface IdentityValidator<T> {
+public interface IdentityValidator {
 
     /**
-     * Validate the provided {@link UserIdentityToken} and return an identity Object that represents the user.
-     * <p>
-     * This Object should implement equality in such a way that a subsequent identity validation for the same user
-     * yields a comparable Object.
+     * Validate a {@link UserIdentityToken} and return an {@link Identity} that represents the
+     * user.
      *
-     * @param session        the {@link Session} the request is arriving on.
-     * @param token          the {@link UserIdentityToken}.
-     * @param tokenPolicy    the {@link UserTokenPolicy} specified by the policyId in {@code token}.
-     * @param tokenSignature the {@link SignatureData} sent in the {@link ActivateSessionRequest}
-     * @return an identity object of type {@code T} that represents the authenticated user.
-     * @throws UaException if the token is invalid, rejected, or user access is denied.
+     * @param session the {@link Session} that made the request.
+     * @param token the {@link UserIdentityToken}.
+     * @param policy the {@link UserTokenPolicy} specified by the policyId in {@code token}.
+     * @param signature the {@link SignatureData} from the {@link ActivateSessionRequest}.
+     * @return an {@link Identity} that represents the authenticated user.
+     * @throws UaException if the token is invalid, rejected, or user access is otherwise denied.
      */
-    T validateIdentityToken(
+    Identity validateIdentityToken(
         Session session,
         UserIdentityToken token,
-        UserTokenPolicy tokenPolicy,
-        SignatureData tokenSignature
+        UserTokenPolicy policy,
+        SignatureData signature
     ) throws UaException;
 
 }

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/IdentityValidator.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/IdentityValidator.java
@@ -23,7 +23,7 @@ public interface IdentityValidator {
      * Validate a {@link UserIdentityToken} and return an {@link Identity} that represents the
      * user.
      *
-     * @param session the {@link Session} that made the request.
+     * @param session the {@link Session} making the request.
      * @param token the {@link UserIdentityToken}.
      * @param policy the {@link UserTokenPolicy} specified by the policyId in {@code token}.
      * @param signature the {@link SignatureData} from the {@link ActivateSessionRequest}.

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/UsernameIdentityValidator.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/UsernameIdentityValidator.java
@@ -15,7 +15,7 @@ import java.util.function.Predicate;
 import org.eclipse.milo.opcua.sdk.server.Session;
 import org.jetbrains.annotations.Nullable;
 
-public class UsernameIdentityValidator extends AbstractUsernameIdentityValidator<String> {
+public class UsernameIdentityValidator extends AbstractUsernameIdentityValidator {
 
     private final boolean anonymousAccessAllowed;
     private final Predicate<AuthenticationChallenge> predicate;
@@ -29,27 +29,25 @@ public class UsernameIdentityValidator extends AbstractUsernameIdentityValidator
         this.predicate = predicate;
     }
 
-    @Nullable
     @Override
-    protected String authenticateAnonymous(Session session) {
+    protected @Nullable Identity.AnonymousIdentity authenticateAnonymous(Session session) {
         if (anonymousAccessAllowed) {
-            return String.format(
-                "anonymous_%s_%s",
-                session.getSessionName(),
-                session.getSessionId().toParseableString()
-            );
+            return new DefaultAnonymousIdentity();
         } else {
             return null;
         }
     }
 
-    @Nullable
     @Override
-    protected String authenticateUsernamePassword(Session session, String username, String password) {
-        AuthenticationChallenge challenge =
-            new AuthenticationChallenge(username, password);
+    protected @Nullable DefaultUsernameIdentity authenticateUsernamePassword(
+        Session session,
+        String username,
+        String password
+    ) {
 
-        return predicate.test(challenge) ? username : null;
+        var challenge = new AuthenticationChallenge(username, password);
+
+        return predicate.test(challenge) ? new DefaultUsernameIdentity(username) : null;
     }
 
     public static final class AuthenticationChallenge {

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/UsernameIdentityValidator.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/UsernameIdentityValidator.java
@@ -39,7 +39,7 @@ public class UsernameIdentityValidator extends AbstractUsernameIdentityValidator
     }
 
     @Override
-    protected @Nullable DefaultUsernameIdentity authenticateUsernamePassword(
+    protected @Nullable Identity.UsernameIdentity authenticateUsernamePassword(
         Session session,
         String username,
         String password

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/X509IdentityValidator.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/X509IdentityValidator.java
@@ -26,9 +26,9 @@ public class X509IdentityValidator extends AbstractX509IdentityValidator {
 
     @Nullable
     @Override
-    protected Object authenticateIdentityCertificate(Session session, X509Certificate identityCertificate) {
+    protected DefaultX509UserIdentity authenticateIdentityCertificate(Session session, X509Certificate identityCertificate) {
         if (predicate.test(identityCertificate)) {
-            return identityCertificate;
+            return new DefaultX509UserIdentity(identityCertificate);
         } else {
             return null;
         }

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/X509IdentityValidator.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/X509IdentityValidator.java
@@ -24,11 +24,14 @@ public class X509IdentityValidator extends AbstractX509IdentityValidator {
         this.predicate = predicate;
     }
 
-    @Nullable
     @Override
-    protected Identity.X509UserIdentity authenticateIdentityCertificate(Session session, X509Certificate identityCertificate) {
-        if (predicate.test(identityCertificate)) {
-            return new DefaultX509UserIdentity(identityCertificate);
+    protected @Nullable Identity.X509UserIdentity authenticateCertificate(
+        Session session,
+        X509Certificate certificate
+    ) {
+
+        if (predicate.test(certificate)) {
+            return new DefaultX509UserIdentity(certificate);
         } else {
             return null;
         }

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/X509IdentityValidator.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/X509IdentityValidator.java
@@ -26,7 +26,7 @@ public class X509IdentityValidator extends AbstractX509IdentityValidator {
 
     @Nullable
     @Override
-    protected DefaultX509UserIdentity authenticateIdentityCertificate(Session session, X509Certificate identityCertificate) {
+    protected Identity.X509UserIdentity authenticateIdentityCertificate(Session session, X509Certificate identityCertificate) {
         if (predicate.test(identityCertificate)) {
             return new DefaultX509UserIdentity(identityCertificate);
         } else {

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/servicesets/impl/DefaultSubscriptionServiceSet.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/servicesets/impl/DefaultSubscriptionServiceSet.java
@@ -278,10 +278,7 @@ public class DefaultSubscriptionServiceSet implements SubscriptionServiceSet {
     }
 
     private static boolean sessionsHaveSameUser(Session s1, Session s2) {
-        Object identity1 = s1.getIdentityObject();
-        Object identity2 = s2.getIdentityObject();
-
-        return Objects.equals(identity1, identity2);
+        return Objects.equals(s1.getIdentity(), s2.getIdentity());
     }
 
 }


### PR DESCRIPTION
Clean up `IdentityValidator` by removing the unnecessary type parameter and introduce the `Identity` interface to use as the return type.