### PR TITLE
Missing Constraint when using as bundle in OSGi context #1174

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -343,6 +343,7 @@
                                 <instructions>
                                     <Import-Package>
                                         com.sun.management.*;resolution:=optional,
+                                        sun.security.*;resolution:=optional,
                                         !javax.annotation.*,
                                         *
                                     </Import-Package>


### PR DESCRIPTION
Mark imported packages sun.security.* as optional when generating manifest.

Fixes https://github.com/eclipse/milo/issues/1174

Before you submit a pull request please acknowledge the following:
- [x] You have signed an Eclipse Contributor Agreement and are committing using the same email address
- [ ] Your code contains any tests relevant to the problem you are solving
- [x] All new and existing tests passed
- [x] Code follows the style guidelines and Checkstyle passes

See [CONTRIBUTING](https://github.com/eclipse/milo/blob/master/CONTRIBUTING.md) for more information.
