### PR TITLE
Updated Guava version to 32.1.3-jre

### DIFF
--- a/opc-ua-stack/pom.xml
+++ b/opc-ua-stack/pom.xml
@@ -23,7 +23,7 @@
 
     <properties>
         <bouncycastle.version>1.75</bouncycastle.version>
-        <guava.version>31.0.1-jre</guava.version>
+        <guava.version>32.1.3-jre</guava.version>
         <javassist.version>3.23.1-GA</javassist.version>
         <annotations.version>22.0.0</annotations.version>
         <netty.version>4.1.97.Final</netty.version>


### PR DESCRIPTION

This PR contains only the update of the guava version. It should make the warning about insecure transitive dependencies disappear, even though milo is basically unaffected.


Before you submit a pull request please acknowledge the following:
- [ ok ] You have signed an Eclipse Contributor Agreement and are committing using the same email address
- [ ok ] Your code contains any tests relevant to the problem you are solving
- [ ok ] All new and existing tests passed
- [ ok ] Code follows the style guidelines and Checkstyle passes

