### PR TITLE
Upgrade bouncycastle to 1.78.1

### DIFF
--- a/opc-ua-stack/pom.xml
+++ b/opc-ua-stack/pom.xml
@@ -22,7 +22,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <bouncycastle.version>1.75</bouncycastle.version>
+        <bouncycastle.version>1.78.1</bouncycastle.version>
         <guava.version>33.0.0-jre</guava.version>
         <javassist.version>3.23.1-GA</javassist.version>
         <annotations.version>22.0.0</annotations.version>


### PR DESCRIPTION
As explained in https://github.com/eclipse/milo/issues/1272

Bouncycasle 1.75 has several reported vulnerabilities:
- https://www.cve.org/CVERecord?id=CVE-2024-30172
- https://www.cve.org/CVERecord?id=CVE-2024-30171
- https://www.cve.org/CVERecord?id=CVE-2024-29857 These have all been fixed in 1.78

Upgraded milo's bouncycastle dependency to 1.78.1