### PR TITLE
Update certificate generation and validation logic

### DIFF
--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/util/SelfSignedCertificateGenerator.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/util/SelfSignedCertificateGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 the Eclipse Milo Authors
+ * Copyright (c) 2024 the Eclipse Milo Authors
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -128,8 +128,7 @@ public class SelfSignedCertificateGenerator {
             subjectPublicKeyInfo
         );
 
-        // Explicitly set path length constraint to 0. This constructor also sets cA=true.
-        BasicConstraints basicConstraints = new BasicConstraints(0);
+        BasicConstraints basicConstraints = new BasicConstraints(false);
 
         // Authority Key Identifier
         addAuthorityKeyIdentifier(certificateBuilder, keyPair);
@@ -213,7 +212,6 @@ public class SelfSignedCertificateGenerator {
             new KeyUsage(
                 KeyUsage.dataEncipherment |
                     KeyUsage.digitalSignature |
-                    KeyUsage.keyAgreement |
                     KeyUsage.keyCertSign |
                     KeyUsage.keyEncipherment |
                     KeyUsage.nonRepudiation

--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/util/validation/CertificateValidationUtilTest.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/util/validation/CertificateValidationUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 the Eclipse Milo Authors
+ * Copyright (c) 2024 the Eclipse Milo Authors
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -11,6 +11,7 @@
 package org.eclipse.milo.opcua.stack.core.util.validation;
 
 import java.io.InputStream;
+import java.security.KeyPair;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.PrivateKey;
@@ -33,6 +34,8 @@ import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
+import org.eclipse.milo.opcua.stack.core.util.SelfSignedCertificateBuilder;
+import org.eclipse.milo.opcua.stack.core.util.SelfSignedCertificateGenerator;
 import org.testng.annotations.BeforeSuite;
 import org.testng.annotations.Test;
 
@@ -82,6 +85,41 @@ public class CertificateValidationUtilTest {
         leafSelfSigned = getCertificate(ALIAS_LEAF_SELF_SIGNED);
         leafIntermediateSigned = getCertificate(ALIAS_LEAF_INTERMEDIATE_SIGNED);
         uriWithSpaces = getCertificate(ALIAS_URI_WITH_SPACES);
+    }
+
+    @Test
+    void selfSignedCertificateOpcUa105() throws Exception {
+        KeyPair keyPair = SelfSignedCertificateGenerator.generateRsaKeyPair(2048);
+
+        SelfSignedCertificateBuilder builder = new SelfSignedCertificateBuilder(keyPair)
+            .setApplicationUri("urn:eclipse:milo:test")
+            .addDnsName("localhost")
+            .addDnsName("hostname")
+            .addIpAddress("127.0.0.1");
+
+        X509Certificate certificate = builder.build();
+
+        PKIXCertPathBuilderResult result = buildTrustedCertPath(
+            newArrayList(certificate),
+            newHashSet(certificate),
+            emptySet()
+        );
+
+        validateTrustedCertPath(
+            result.getCertPath(),
+            result.getTrustAnchor(),
+            emptySet(),
+            ValidationCheck.ALL_OPTIONAL_CHECKS,
+            false
+        );
+
+        validateTrustedCertPath(
+            result.getCertPath(),
+            result.getTrustAnchor(),
+            emptySet(),
+            ValidationCheck.ALL_OPTIONAL_CHECKS,
+            true
+        );
     }
 
     @Test


### PR DESCRIPTION
- generate new certificates without `cA` bit set
- generate new certificates without `keyAgreement` KeyUsage
- allow self-signed certificates without `cA` bit set to validate

fixes #1286
