### PR TITLE
Decrement `keepAliveCounter` on transition to `State.KeepAlive`

### DIFF
--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/subscriptions/Subscription.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/subscriptions/Subscription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 the Eclipse Milo Authors
+ * Copyright (c) 2024 the Eclipse Milo Authors
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -937,6 +937,7 @@ public class Subscription {
                 /* Subscription State Table Row 9 */
                 setState(State.KeepAlive);
                 resetKeepAliveCounter();
+                keepAliveCounter--;
             } else {
                 throw new IllegalStateException("unhandled subscription state");
             }


### PR DESCRIPTION
Errata 1.04.8 changed Subscription State Table row 9 so that the keep alive counter is decremented upon the initial transition. This results in a keep alive PublishResponse being sent one publishing interval earlier, which better matches the description of the behavior in the spec.

fixes #1304
