### PR TITLE
Return Bad_NodeIdUnknown for ReferenceResult.BadNodeIdUnknown

### DIFF
--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/servicesets/impl/helpers/BrowsePathsHelper.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/servicesets/impl/helpers/BrowsePathsHelper.java
@@ -222,7 +222,7 @@ public class BrowsePathsHelper {
                 return ExpandedNodeId.NULL_VALUE;
             }
         } else {
-            throw new UaException(StatusCodes.Bad_NoMatch);
+            throw new UaException(StatusCodes.Bad_NodeIdUnknown);
         }
     }
 
@@ -281,7 +281,7 @@ public class BrowsePathsHelper {
                 return targets;
             }
         } else {
-            throw new UaException(StatusCodes.Bad_NoMatch);
+            throw new UaException(StatusCodes.Bad_NodeIdUnknown);
         }
     }
 


### PR DESCRIPTION
When processing browse paths return `Bad_NodeIdUnknown` instead of `Bad_NoMatch` if the browse result was `ReferenceResult.BadNodeIdUnknown`.

fixes #1315