### PR TITLE
Use case insensitive hostname comparison for validating certificate

### DIFF
--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/util/validation/CertificateValidationUtil.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/util/validation/CertificateValidationUtil.java
@@ -497,6 +497,17 @@ public class CertificateValidationUtil {
     }
 
     /**
+     * Creates a predicate to compare a hostname against a SubjectAltName DNSName entry in a
+     * certificate. The comparison is case-insensitive, following RFC 3986.
+     *
+     * @param hostname the hostname to compare against.
+     * @return a predicate that returns {@code true} if the hostname matches the DNSName entry.
+     */
+    private static Predicate<Object> hostnameValidationPredicate(String hostname) {
+        return input -> input instanceof String && hostname.equalsIgnoreCase((String) input);
+    }
+
+    /**
      * Validate that one of {@code hostNames} matches a SubjectAltName DNSName or IPAddress entry in the certificate.
      *
      * @param certificate the certificate to validate against.
@@ -513,7 +524,7 @@ public class CertificateValidationUtil {
                 return checkSubjectAltNameField(
                     certificate,
                     SUBJECT_ALT_NAME_DNS_NAME,
-                    n::equals
+                    hostnameValidationPredicate(n)
                 );
             } catch (Throwable t) {
                 return false;

--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/util/validation/CertificateValidationUtilTest.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/util/validation/CertificateValidationUtilTest.java
@@ -43,6 +43,7 @@ import static com.google.common.collect.Lists.newArrayList;
 import static com.google.common.collect.Sets.newHashSet;
 import static java.util.Collections.emptySet;
 import static org.eclipse.milo.opcua.stack.core.util.validation.CertificateValidationUtil.buildTrustedCertPath;
+import static org.eclipse.milo.opcua.stack.core.util.validation.CertificateValidationUtil.checkHostnameOrIpAddress;
 import static org.eclipse.milo.opcua.stack.core.util.validation.CertificateValidationUtil.validateTrustedCertPath;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -451,6 +452,15 @@ public class CertificateValidationUtilTest {
         );
     }
 
+    @Test
+    public void testHostnameWithCaseInsensitive() throws Exception {
+        String hostname = "digitalpetri.com";
+        checkHostnameOrIpAddress(createSelfSignedCertificate("digitalpetri.com"), hostname);
+        checkHostnameOrIpAddress(createSelfSignedCertificate("DIGITALPETRI.COM"), hostname);
+        checkHostnameOrIpAddress(createSelfSignedCertificate("DIGITALPETRI.com"), hostname);
+        checkHostnameOrIpAddress(createSelfSignedCertificate("DigitalPetri.com"), hostname);
+    }
+
     private X509CRL generateCrl(X509Certificate ca, PrivateKey caPrivateKey, X509Certificate... revoked) throws Exception {
         X509v2CRLBuilder builder = new X509v2CRLBuilder(
             new X500Name(ca.getSubjectDN().getName()),
@@ -485,6 +495,16 @@ public class CertificateValidationUtilTest {
         X509Certificate certificate = (X509Certificate) keyStore.getCertificate(alias);
         assertNotNull(certificate);
         return certificate;
+    }
+
+    private static X509Certificate createSelfSignedCertificate(String dnsName) throws Exception {
+        KeyPair keyPair = SelfSignedCertificateGenerator.generateRsaKeyPair(2048);
+
+        SelfSignedCertificateBuilder builder = new SelfSignedCertificateBuilder(keyPair)
+            .setApplicationUri("urn:eclipse:milo:test")
+            .addDnsName(dnsName);
+
+        return builder.build();
     }
 
 }


### PR DESCRIPTION
Implements case-insensitive hostname comparison to follow the [RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986#section-6.2.2.1). A similar discussion can be found [here](https://opcfoundation.org/forum/opc-ua-standard/case-sensitivity-of-opc-ua-opc-tcp-endpoints/).

When trying to use the Eclipse Milo client to connect to a server that has a certificate with an uppercase DNS name in its SAN section, the library raises the following error when validating the DNS name against the hostname (lowercase) extracted from the connection endpoint.

```
INFO | jvm 1 | 2024/09/19 18:07:51 | java.util.concurrent.CompletionException: UaException: status=Bad_CertificateHostNameInvalid, message=The HostName used to connect to a Server does not match a HostName in the Certificate.
INFO | jvm 1 | 2024/09/19 18:07:51 | at java.util.concurrent.CompletableFuture.encodeRelay(CompletableFuture.java:326)
INFO | jvm 1 | 2024/09/19 18:07:51 | at java.util.concurrent.CompletableFuture.completeRelay(CompletableFuture.java:338)
INFO | jvm 1 | 2024/09/19 18:07:51 | at java.util.concurrent.CompletableFuture.uniRelay(CompletableFuture.java:925)
INFO | jvm 1 | 2024/09/19 18:07:51 | at java.util.concurrent.CompletableFuture.uniCompose(CompletableFuture.java:967)
INFO | jvm 1 | 2024/09/19 18:07:51 | at java.util.concurrent.CompletableFuture$UniCompose.tryFire(CompletableFuture.java:940)
INFO | jvm 1 | 2024/09/19 18:07:51 | at java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:488)
INFO | jvm 1 | 2024/09/19 18:07:51 | at java.util.concurrent.CompletableFuture.complete(CompletableFuture.java:1975)
INFO | jvm 1 | 2024/09/19 18:07:51 | at org.eclipse.milo.opcua.stack.client.UaStackClient.lambda$deliverResponse$5(UaStackClient.java:318)
INFO | jvm 1 | 2024/09/19 18:07:51 | at org.eclipse.milo.opcua.stack.core.util.ExecutionQueue$Task.run(ExecutionQueue.java:119)
INFO | jvm 1 | 2024/09/19 18:07:51 | at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
INFO | jvm 1 | 2024/09/19 18:07:51 | at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
INFO | jvm 1 | 2024/09/19 18:07:51 | at java.lang.Thread.run(Thread.java:750)
INFO | jvm 1 | 2024/09/19 18:07:51 | Caused by: org.eclipse.milo.opcua.stack.core.UaException: status=Bad_CertificateHostNameInvalid, description=The HostName used to connect to a Server does not match a HostName in the Certificate.
INFO | jvm 1 | 2024/09/19 18:07:51 | at org.eclipse.milo.opcua.stack.core.util.validation.CertificateValidationUtil.checkHostnameOrIpAddress(CertificateValidationUtil.java:535)
INFO | jvm 1 | 2024/09/19 18:07:51 | at org.eclipse.milo.opcua.stack.client.security.DefaultClientCertificateValidator.validateCertificateChain(DefaultClientCertificateValidator.java:113)
INFO | jvm 1 | 2024/09/19 18:07:51 | at org.eclipse.milo.opcua.sdk.client.session.SessionFsmFactory.lambda$createSession$53(SessionFsmFactory.java:880)
```

Before you submit a pull request please acknowledge the following:
- [x] You have signed an Eclipse Contributor Agreement and are committing using the same email address
- [x] Your code contains any tests relevant to the problem you are solving
- [x] All new and existing tests passed
- [x] Code follows the style guidelines and Checkstyle passes

See [CONTRIBUTING](https://github.com/eclipse/milo/blob/master/CONTRIBUTING.md) for more information.
