### PR TITLE
Replace System.out with SLF4J logging in tests

### DIFF
--- a/opc-ua-sdk/codec-json/pom.xml
+++ b/opc-ua-sdk/codec-json/pom.xml
@@ -89,6 +89,12 @@
       <version>${data-type-test.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>${slf4j.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/opc-ua-sdk/codec-json/src/test/java/org/eclipse/milo/sdk/core/types/json/JsonConversionsTest.java
+++ b/opc-ua-sdk/codec-json/src/test/java/org/eclipse/milo/sdk/core/types/json/JsonConversionsTest.java
@@ -39,8 +39,12 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 class JsonConversionsTest {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(JsonConversionsTest.class);
 
   @ParameterizedTest
   @ValueSource(ints = {Byte.MIN_VALUE, 0, Byte.MAX_VALUE})
@@ -342,7 +346,7 @@ class JsonConversionsTest {
   @MethodSource("convertDataValueProvider")
   void convertDataValue(DataValue dataValue, String expectedJson) {
     JsonElement asJson = JsonConversions.fromDataValue(dataValue);
-    System.out.println(asJson);
+    LOGGER.debug("{}", asJson);
 
     assertEquals(expectedJson, asJson.toString());
 

--- a/opc-ua-sdk/dtd-core/pom.xml
+++ b/opc-ua-sdk/dtd-core/pom.xml
@@ -56,6 +56,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>${slf4j.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.jspecify</groupId>
       <artifactId>jspecify</artifactId>
       <version>1.0.0</version>

--- a/opc-ua-sdk/dtd-core/src/test/java/org/eclipse/milo/opcua/sdk/core/dtd/AbstractBsdCodecTest.java
+++ b/opc-ua-sdk/dtd-core/src/test/java/org/eclipse/milo/opcua/sdk/core/dtd/AbstractBsdCodecTest.java
@@ -33,8 +33,12 @@ import org.eclipse.milo.opcua.stack.core.types.UaStructuredType;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.opcfoundation.opcua.binaryschema.StructuredType;
 import org.opcfoundation.opcua.binaryschema.TypeDictionary;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public abstract class AbstractBsdCodecTest {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(AbstractBsdCodecTest.class);
 
   private static final String BSD_CODEC_TEST_NAMESPACE = "https://github.com/eclipse-milo/milo";
 
@@ -121,9 +125,9 @@ public abstract class AbstractBsdCodecTest {
   }
 
   protected void assertRoundTrip(String type, Object originalValue, BinaryDataTypeCodec codec) {
-    System.out.printf("--- assertRoundTrip Type: %s ---\n", type);
+    LOGGER.debug("--- assertRoundTrip Type: {} ---", type);
 
-    System.out.println("originalValue:\t" + originalValue);
+    LOGGER.debug("originalValue:\t{}", originalValue);
     ByteBuf buffer = Unpooled.buffer();
     codec.encodeBinary(
         context,
@@ -131,12 +135,12 @@ public abstract class AbstractBsdCodecTest {
         (UaStructuredType) originalValue);
 
     ByteBuf encodedValue = buffer.copy();
-    System.out.println("encodedValue:\t" + ByteBufUtil.hexDump(encodedValue));
+    LOGGER.debug("encodedValue:\t{}", ByteBufUtil.hexDump(encodedValue));
 
     Object decodedValue =
         codec.decodeBinary(context, new OpcUaBinaryDecoder(context).setBuffer(buffer));
     assertEquals(originalValue, decodedValue);
-    System.out.println("decodedValue:\t" + decodedValue);
+    LOGGER.debug("decodedValue:\t{}", decodedValue);
   }
 
   /**
@@ -150,9 +154,9 @@ public abstract class AbstractBsdCodecTest {
   protected void assertRoundTripUsingToString(
       String type, Object originalValue, BinaryDataTypeCodec codec) {
 
-    System.out.printf("--- assertRoundTrip Type: %s ---\n", type);
+    LOGGER.debug("--- assertRoundTrip Type: {} ---", type);
 
-    System.out.println("originalValue:\t" + originalValue);
+    LOGGER.debug("originalValue:\t{}", originalValue);
     ByteBuf buffer = Unpooled.buffer();
     codec.encodeBinary(
         context,
@@ -160,11 +164,11 @@ public abstract class AbstractBsdCodecTest {
         (UaStructuredType) originalValue);
 
     ByteBuf encodedValue = buffer.copy();
-    System.out.println("encodedValue:\t" + ByteBufUtil.hexDump(encodedValue));
+    LOGGER.debug("encodedValue:\t{}", ByteBufUtil.hexDump(encodedValue));
 
     Object decodedValue =
         codec.decodeBinary(context, new OpcUaBinaryDecoder(context).setBuffer(buffer));
     assertEquals(originalValue.toString(), decodedValue.toString());
-    System.out.println("decodedValue:\t" + decodedValue);
+    LOGGER.debug("decodedValue:\t{}", decodedValue);
   }
 }

--- a/opc-ua-sdk/dtd-reader/src/test/java/org/eclipse/milo/opcua/sdk/client/dtd/BinaryDataTypeDictionaryReaderTest.java
+++ b/opc-ua-sdk/dtd-reader/src/test/java/org/eclipse/milo/opcua/sdk/client/dtd/BinaryDataTypeDictionaryReaderTest.java
@@ -40,8 +40,13 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 class BinaryDataTypeDictionaryReaderTest {
+
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(BinaryDataTypeDictionaryReaderTest.class);
 
   private final OpcTcpClientTransport transport = Mockito.mock(OpcTcpClientTransport.class);
   private final OpcTcpClientTransportConfig transportConfig =
@@ -80,7 +85,7 @@ class BinaryDataTypeDictionaryReaderTest {
           dictionary[i] = b;
         }
 
-        System.out.printf("fragmentSize=%d dictionarySize=%d\n", fragmentSize, dictionarySize);
+        LOGGER.debug("fragmentSize={} dictionarySize={}", fragmentSize, dictionarySize);
 
         testReadDataTypeDictionaryBytes(ByteString.of(dictionary), fragmentSize);
       }

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/AddressSpaceTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/AddressSpaceTest.java
@@ -28,8 +28,12 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.BrowseDirection;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class AddressSpaceTest extends AbstractClientServerTest {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(AddressSpaceTest.class);
 
   @Test
   public void browse() throws UaException {
@@ -40,14 +44,14 @@ public class AddressSpaceTest extends AbstractClientServerTest {
 
     nodes.forEach(
         n -> {
-          System.out.printf(
-              "%s (%s) [%s]%n",
+          LOGGER.debug(
+              "{} ({}) [{}]",
               n.getBrowseName().toParseableString(),
               n.getNodeId().toParseableString(),
               n.getNodeClass());
 
           if (n instanceof UaVariableNode) {
-            System.out.println("└─ value = " + ((UaVariableNode) n).getValue().value());
+            LOGGER.debug("└─ value = {}", ((UaVariableNode) n).getValue().value());
           }
         });
   }

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/DynamicMatrixTestTypeTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/DynamicMatrixTestTypeTest.java
@@ -22,8 +22,12 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExtensionObject;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class DynamicMatrixTestTypeTest extends AbstractClientServerTest {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(DynamicMatrixTestTypeTest.class);
 
   @Test
   public void read() throws UaException {
@@ -42,6 +46,6 @@ public class DynamicMatrixTestTypeTest extends AbstractClientServerTest {
     assertEquals(
         MatrixTestType.TYPE_ID,
         decoded.getTypeId().absolute(client.getNamespaceTable()).orElseThrow());
-    System.out.println(decoded);
+    LOGGER.debug("{}", decoded);
   }
 }

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/StaticMatrixTestTypeTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/StaticMatrixTestTypeTest.java
@@ -19,8 +19,12 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExtensionObject;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class StaticMatrixTestTypeTest extends AbstractClientServerTest {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(StaticMatrixTestTypeTest.class);
 
   @Test
   public void read() throws Exception {
@@ -46,6 +50,6 @@ public class StaticMatrixTestTypeTest extends AbstractClientServerTest {
     assert xo != null;
 
     MatrixTestType decoded = (MatrixTestType) xo.decode(client.getStaticEncodingContext());
-    System.out.println(decoded);
+    LOGGER.debug("{}", decoded);
   }
 }

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/UaNodeTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/UaNodeTest.java
@@ -41,8 +41,12 @@ import org.eclipse.milo.opcua.stack.core.types.structured.ReadResponse;
 import org.eclipse.milo.opcua.stack.core.types.structured.ReadValueId;
 import org.eclipse.milo.opcua.stack.core.types.structured.ReferenceDescription;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class UaNodeTest extends AbstractClientServerTest {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(UaNodeTest.class);
 
   @Test
   public void browse() throws UaException {
@@ -119,7 +123,7 @@ public class UaNodeTest extends AbstractClientServerTest {
 
     ReadResponse response = client.readAsync(0.0, TimestampsToReturn.Both, readValueIds).get();
 
-    Arrays.stream(response.getResults()).forEach(v -> System.out.println(v.value().value()));
+    Arrays.stream(response.getResults()).forEach(v -> LOGGER.debug("{}", v.value().value()));
   }
 
   @Test

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/methods/UaMethodTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/methods/UaMethodTest.java
@@ -31,8 +31,12 @@ import org.eclipse.milo.opcua.stack.core.types.structured.Argument;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class UaMethodTest extends AbstractClientServerTest {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(UaMethodTest.class);
 
   OpcUaSubscription subscription;
   OpcUaMonitoredItem monitoredItem;
@@ -168,9 +172,8 @@ public class UaMethodTest extends AbstractClientServerTest {
                 new QualifiedName(2, "onlyAcceptsPositiveInputs()"),
                 new Variant[] {new Variant(-1)});
           } catch (UaMethodException e) {
-            System.out.println("result: " + e.getStatusCode());
-            System.out.println(
-                "inputArgumentResults: " + Arrays.toString(e.getInputArgumentResults()));
+            LOGGER.debug("result: {}", e.getStatusCode());
+            LOGGER.debug("inputArgumentResults: {}", Arrays.toString(e.getInputArgumentResults()));
 
             throw e;
           }

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/subscriptions/SubscriptionWatchdogTimerTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/subscriptions/SubscriptionWatchdogTimerTest.java
@@ -22,8 +22,12 @@ import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class SubscriptionWatchdogTimerTest extends AbstractClientServerTest {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(SubscriptionWatchdogTimerTest.class);
 
   @Test
   void subscriptionWatchdogTimerCallback() throws UaException, InterruptedException {
@@ -47,8 +51,7 @@ public class SubscriptionWatchdogTimerTest extends AbstractClientServerTest {
               List<OpcUaMonitoredItem> items,
               List<DataValue> values) {
 
-            System.out.println(
-                "onDataReceived() id=" + subscription.getSubscriptionId().orElseThrow());
+            LOGGER.debug("onDataReceived() id={}", subscription.getSubscriptionId().orElseThrow());
 
             // kill the subscription after the first notification is received
             UInteger subscriptionId = subscription.getSubscriptionId().orElseThrow();
@@ -63,9 +66,10 @@ public class SubscriptionWatchdogTimerTest extends AbstractClientServerTest {
           public void onWatchdogTimerElapsed(OpcUaSubscription subscription) {
             var elapsed = System.currentTimeMillis() - start.get();
 
-            System.out.printf(
-                "onWatchdogTimerElapsed() id=%s, elapsed=%sms%n",
-                subscription.getSubscriptionId().orElseThrow(), elapsed);
+            LOGGER.debug(
+                "onWatchdogTimerElapsed() id={}, elapsed={}ms",
+                subscription.getSubscriptionId().orElseThrow(),
+                elapsed);
 
             latch.countDown();
           }

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/core/typetree/AbstractDataTypeTreeTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/core/typetree/AbstractDataTypeTreeTest.java
@@ -34,9 +34,13 @@ import org.eclipse.milo.opcua.stack.core.util.Tree;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public abstract class AbstractDataTypeTreeTest extends AbstractClientServerTest {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(AbstractDataTypeTreeTest.class);
 
   private DataTypeTree dataTypeTree;
 
@@ -53,10 +57,11 @@ public abstract class AbstractDataTypeTreeTest extends AbstractClientServerTest 
         .getRoot()
         .traverseWithDepth(
             (dataType, depth) -> {
+              StringBuilder indent = new StringBuilder();
               for (int i = 0; i < depth; i++) {
-                System.out.print("\t");
+                indent.append("\t");
               }
-              System.out.println(dataType.getBrowseName().toParseableString());
+              LOGGER.debug("{}{}", indent, dataType.getBrowseName().toParseableString());
             },
             (o1, o2) -> {
               String name1 = requireNonNullElse(o1.getValue().getBrowseName().name(), "");
@@ -101,7 +106,7 @@ public abstract class AbstractDataTypeTreeTest extends AbstractClientServerTest 
     nodeIdNode.traverse(
         dataType -> {
           Class<?> backingClass = dataTypeTree.getBackingClass(dataType.getNodeId());
-          System.out.println(dataType.getBrowseName().toParseableString() + " : " + backingClass);
+          LOGGER.debug("{} : {}", dataType.getBrowseName().toParseableString(), backingClass);
           assertEquals(expectedBackingClass, backingClass);
         });
   }

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/methods/AbstractMethodInvocationHandlerTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/methods/AbstractMethodInvocationHandlerTest.java
@@ -39,8 +39,13 @@ import org.eclipse.milo.opcua.stack.core.types.structured.CallResponse;
 import org.eclipse.milo.opcua.stack.core.types.structured.ThreeDVector;
 import org.eclipse.milo.opcua.stack.core.types.structured.XVType;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class AbstractMethodInvocationHandlerTest extends AbstractClientServerTest {
+
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(AbstractMethodInvocationHandlerTest.class);
 
   @Test
   public void inputArgumentResultsIsEmptyOnSuccess() throws UaException {
@@ -69,8 +74,8 @@ public class AbstractMethodInvocationHandlerTest extends AbstractClientServerTes
       objectsNode.callMethod(
           new QualifiedName(2, "onlyAcceptsPositiveInputs()"), new Variant[] {new Variant(-1)});
     } catch (UaMethodException e) {
-      System.out.println("result: " + e.getStatusCode());
-      System.out.println("inputArgumentResults: " + Arrays.toString(e.getInputArgumentResults()));
+      LOGGER.debug("result: {}", e.getStatusCode());
+      LOGGER.debug("inputArgumentResults: {}", Arrays.toString(e.getInputArgumentResults()));
 
       assertEquals(StatusCode.of(Bad_InvalidArgument), e.getStatusCode());
       assertEquals(StatusCode.of(Bad_OutOfRange), e.getInputArgumentResults()[0]);

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/types/ReferenceTypeTreeBuilderTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/types/ReferenceTypeTreeBuilderTest.java
@@ -16,9 +16,13 @@ import org.eclipse.milo.opcua.sdk.test.TestServer;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class ReferenceTypeTreeBuilderTest {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(ReferenceTypeTreeBuilderTest.class);
 
   private ReferenceTypeTree referenceTypeTree;
 
@@ -33,10 +37,11 @@ public class ReferenceTypeTreeBuilderTest {
         .getRoot()
         .traverseWithDepth(
             (dataType, depth) -> {
+              StringBuilder indent = new StringBuilder();
               for (int i = 0; i < depth; i++) {
-                System.out.print("\t");
+                indent.append("\t");
               }
-              System.out.println(dataType.getBrowseName().toParseableString());
+              LOGGER.debug("{}{}", indent, dataType.getBrowseName().toParseableString());
             });
   }
 }

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/test/KeyStoreLoader.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/test/KeyStoreLoader.java
@@ -37,7 +37,7 @@ class KeyStoreLoader {
   private static final String SERVER_ALIAS = "server-ai";
   private static final char[] PASSWORD = "password".toCharArray();
 
-  private final Logger logger = LoggerFactory.getLogger(getClass());
+  private static final Logger LOGGER = LoggerFactory.getLogger(KeyStoreLoader.class);
 
   private X509Certificate[] serverCertificateChain;
   private X509Certificate serverCertificate;
@@ -48,7 +48,7 @@ class KeyStoreLoader {
 
     File serverKeyStore = baseDir.toPath().resolve("example-server.pfx").toFile();
 
-    logger.info("Loading KeyStore at {}", serverKeyStore);
+    LOGGER.debug("Loading KeyStore at {}", serverKeyStore);
 
     if (!serverKeyStore.exists()) {
       keyStore.load(null, PASSWORD);

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/test/TestNamespace.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/test/TestNamespace.java
@@ -68,7 +68,7 @@ public class TestNamespace extends ManagedNamespaceWithLifecycle {
 
   public static final String NAMESPACE_URI = "urn:eclipse:milo:test";
 
-  private final Logger logger = LoggerFactory.getLogger(getClass());
+  private static final Logger LOGGER = LoggerFactory.getLogger(TestNamespace.class);
 
   private volatile Thread eventThread;
   private volatile boolean keepPostingEvents = true;
@@ -494,7 +494,7 @@ public class TestNamespace extends ManagedNamespaceWithLifecycle {
 
                     eventNode.delete();
                   } catch (Throwable e) {
-                    logger.error("Error creating EventNode: {}", e.getMessage(), e);
+                    LOGGER.debug("Error creating EventNode: {}", e.getMessage(), e);
                   }
 
                   try {

--- a/opc-ua-sdk/sdk-core/src/test/java/org/eclipse/milo/opcua/sdk/server/util/AsyncGroupMapCollateTest.java
+++ b/opc-ua-sdk/sdk-core/src/test/java/org/eclipse/milo/opcua/sdk/server/util/AsyncGroupMapCollateTest.java
@@ -20,8 +20,12 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class AsyncGroupMapCollateTest {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(AsyncGroupMapCollateTest.class);
 
   @Test
   public void testGroupMapCollate() throws ExecutionException, InterruptedException {
@@ -37,8 +41,7 @@ public class AsyncGroupMapCollateTest {
               item -> item % mod,
               remainder ->
                   group -> {
-                    System.out.println(
-                        "mod=" + mod + " remainder=" + remainder + " group=" + group);
+                    LOGGER.debug("mod={} remainder={} group={}", mod, remainder, group);
 
                     CompletableFuture<List<String>> future = new CompletableFuture<>();
 
@@ -52,7 +55,7 @@ public class AsyncGroupMapCollateTest {
       for (int j = 0; j < strings.size(); j++) {
         assertEquals(String.valueOf(j), strings.get(j));
       }
-      System.out.println("--");
+      LOGGER.debug("--");
     }
   }
 }

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/events/conversions/AbstractConversionTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/events/conversions/AbstractConversionTest.java
@@ -18,8 +18,12 @@ import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 abstract class AbstractConversionTest<S> {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(AbstractConversionTest.class);
 
   @Test
   public void testNullConversion() {
@@ -41,7 +45,7 @@ abstract class AbstractConversionTest<S> {
           fail("expected conversions for " + targetType);
         }
 
-        System.out.printf("%s -> %s [%s]%n", sourceType, targetType, conversionType);
+        LOGGER.debug("{} -> {} [{}]", sourceType, targetType, conversionType);
 
         for (Conversion conversion : conversions) {
           assertEquals(conversion.targetType, targetType);
@@ -52,7 +56,7 @@ abstract class AbstractConversionTest<S> {
           Object convertedValue =
               convert(fromValue, targetType, conversionType == ConversionType.IMPLICIT);
 
-          System.out.printf("\tfromValue=%s targetValue=%s%n", fromValue, targetValue);
+          LOGGER.debug("\tfromValue={} targetValue={}", fromValue, targetValue);
 
           assertEquals(targetValue, convertedValue);
         }
@@ -99,9 +103,12 @@ abstract class AbstractConversionTest<S> {
 
           Object convertedValue = convert(fromValue, targetType, false);
 
-          System.out.printf(
-              "[%s] fromValue=%s targetType=%s targetValue=%s%n",
-              conversionType, fromValue, targetType, conversion.targetValue);
+          LOGGER.debug(
+              "[{}] fromValue={} targetType={} targetValue={}",
+              conversionType,
+              fromValue,
+              targetType,
+              conversion.targetValue);
 
           assertEquals(conversion.targetValue, convertedValue);
         }

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/events/conversions/DateTimeConversionsTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/events/conversions/DateTimeConversionsTest.java
@@ -17,23 +17,27 @@ import java.util.Calendar;
 import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class DateTimeConversionsTest {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(DateTimeConversionsTest.class);
 
   @Test
   public void testDateTimeToString() {
     DateTime now = DateTime.now();
     String nowAsString = (String) DateTimeConversions.convert(now, OpcUaDataType.String, false);
 
-    System.out.println("now: " + now);
-    System.out.println("nowAsString: " + nowAsString);
+    LOGGER.debug("now: {}", now);
+    LOGGER.debug("nowAsString: {}", nowAsString);
 
     assertNotNull(nowAsString);
 
     DateTime nowAsStringAsDateTime =
         (DateTime) StringConversions.convert(nowAsString, OpcUaDataType.DateTime, false);
 
-    System.out.println("nowAsStringAsDateTime: " + nowAsStringAsDateTime);
+    LOGGER.debug("nowAsStringAsDateTime: {}", nowAsStringAsDateTime);
 
     assertNotNull(nowAsStringAsDateTime);
 

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/nodes/factories/NodeFactoryTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/nodes/factories/NodeFactoryTest.java
@@ -46,9 +46,13 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Disabled
 public class NodeFactoryTest {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(NodeFactoryTest.class);
 
   private OpcUaServer server;
   private UaNodeManager nodeManager;
@@ -151,11 +155,10 @@ public class NodeFactoryTest {
                   @Override
                   public void onMethodAdded(@Nullable UaObjectNode parent, UaMethodNode instance) {
                     String pbn = parent != null ? parent.getBrowseName().name() : null;
-                    System.out.println(
-                        "onMethodAdded parent="
-                            + pbn
-                            + " instance="
-                            + instance.getBrowseName().name());
+                    LOGGER.debug(
+                        "onMethodAdded parent={} instance={}",
+                        pbn,
+                        instance.getBrowseName().name());
                     methodAdded.set(true);
                   }
 
@@ -163,11 +166,10 @@ public class NodeFactoryTest {
                   public void onObjectAdded(
                       @Nullable UaNode parent, UaObjectNode instance, NodeId typeDefinitionId) {
                     String pbn = parent != null ? parent.getBrowseName().name() : null;
-                    System.out.println(
-                        "onObjectAdded parent="
-                            + pbn
-                            + " instance="
-                            + instance.getBrowseName().name());
+                    LOGGER.debug(
+                        "onObjectAdded parent={} instance={}",
+                        pbn,
+                        instance.getBrowseName().name());
                     objectAdded.set(true);
                   }
 
@@ -175,11 +177,10 @@ public class NodeFactoryTest {
                   public void onVariableAdded(
                       @Nullable UaNode parent, UaVariableNode instance, NodeId typeDefinitionId) {
                     String pbn = parent != null ? parent.getBrowseName().name() : null;
-                    System.out.println(
-                        "onVariableAdded parent="
-                            + pbn
-                            + " instance="
-                            + instance.getBrowseName().name());
+                    LOGGER.debug(
+                        "onVariableAdded parent={} instance={}",
+                        pbn,
+                        instance.getBrowseName().name());
                     variableAdded.set(true);
                   }
                 });

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/util/HostnameUtilTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/util/HostnameUtilTest.java
@@ -14,8 +14,12 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import java.util.Set;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class HostnameUtilTest {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(HostnameUtilTest.class);
 
   @Test
   public void testGetHostnames_ExcludeLocal() throws Exception {
@@ -25,7 +29,7 @@ public class HostnameUtilTest {
         hostname -> {
           assertNotEquals("127.0.0.1", hostname);
           assertNotEquals("localhost", hostname);
-          System.out.println(hostname);
+          LOGGER.debug("{}", hostname);
         });
   }
 }

--- a/opc-ua-stack/encoding-xml/pom.xml
+++ b/opc-ua-stack/encoding-xml/pom.xml
@@ -69,6 +69,12 @@
       <version>2.10.0</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>${slf4j.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/opc-ua-stack/encoding-xml/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/xml/OpcUaXmlEncoderTest.java
+++ b/opc-ua-stack/encoding-xml/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/xml/OpcUaXmlEncoderTest.java
@@ -20,10 +20,14 @@ import org.eclipse.milo.opcua.stack.core.types.structured.ThreeDVector;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.xmlunit.builder.DiffBuilder;
 import org.xmlunit.diff.Diff;
 
 class OpcUaXmlEncoderTest {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(OpcUaXmlEncoderTest.class);
 
   private static final boolean DEBUG = true;
 
@@ -122,8 +126,8 @@ class OpcUaXmlEncoderTest {
    */
   static void maybePrintXml(Diff diff, String expected, String actual) {
     if (diff.hasDifferences() || DEBUG) {
-      System.out.printf("Expected:%n%s%n", expected);
-      System.out.printf("Actual:%n%s%n", actual);
+      LOGGER.debug("Expected:\n{}", expected);
+      LOGGER.debug("Actual:\n{}", actual);
     }
   }
 

--- a/opc-ua-stack/encoding-xml/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/xml/OpcUaXmlSerializationTest.java
+++ b/opc-ua-stack/encoding-xml/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/xml/OpcUaXmlSerializationTest.java
@@ -37,10 +37,14 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UShort;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.xmlunit.builder.DiffBuilder;
 import org.xmlunit.diff.Diff;
 
 public class OpcUaXmlSerializationTest {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(OpcUaXmlSerializationTest.class);
 
   @MethodSource("booleanArguments")
   @ParameterizedTest
@@ -51,8 +55,8 @@ public class OpcUaXmlSerializationTest {
       encoded = encoder.getOutputString();
     }
 
-    System.out.println("value: " + value);
-    System.out.println("encoded: " + encoded);
+    LOGGER.debug("value: {}", value);
+    LOGGER.debug("encoded: {}", encoded);
 
     boolean decoded;
     try (var decoder = new OpcUaXmlDecoder(new DefaultEncodingContext())) {
@@ -77,8 +81,8 @@ public class OpcUaXmlSerializationTest {
       encoded = encoder.getOutputString();
     }
 
-    System.out.println("value: " + value);
-    System.out.println("encoded: " + encoded);
+    LOGGER.debug("value: {}", value);
+    LOGGER.debug("encoded: {}", encoded);
 
     byte decoded;
     try (var decoder = new OpcUaXmlDecoder(new DefaultEncodingContext())) {
@@ -104,8 +108,8 @@ public class OpcUaXmlSerializationTest {
       encoded = encoder.getOutputString();
     }
 
-    System.out.println("value: " + value);
-    System.out.println("encoded: " + encoded);
+    LOGGER.debug("value: {}", value);
+    LOGGER.debug("encoded: {}", encoded);
 
     UByte decoded;
     try (var decoder = new OpcUaXmlDecoder(new DefaultEncodingContext())) {
@@ -131,8 +135,8 @@ public class OpcUaXmlSerializationTest {
       encoded = encoder.getOutputString();
     }
 
-    System.out.println("value: " + value);
-    System.out.println("encoded: " + encoded);
+    LOGGER.debug("value: {}", value);
+    LOGGER.debug("encoded: {}", encoded);
 
     short decoded;
     try (var decoder = new OpcUaXmlDecoder(new DefaultEncodingContext())) {
@@ -158,8 +162,8 @@ public class OpcUaXmlSerializationTest {
       encoded = encoder.getOutputString();
     }
 
-    System.out.println("value: " + value);
-    System.out.println("encoded: " + encoded);
+    LOGGER.debug("value: {}", value);
+    LOGGER.debug("encoded: {}", encoded);
 
     UShort decoded;
     try (var decoder = new OpcUaXmlDecoder(new DefaultEncodingContext())) {
@@ -185,8 +189,8 @@ public class OpcUaXmlSerializationTest {
       encoded = encoder.getOutputString();
     }
 
-    System.out.println("value: " + value);
-    System.out.println("encoded: " + encoded);
+    LOGGER.debug("value: {}", value);
+    LOGGER.debug("encoded: {}", encoded);
 
     int decoded;
     try (var decoder = new OpcUaXmlDecoder(new DefaultEncodingContext())) {
@@ -212,8 +216,8 @@ public class OpcUaXmlSerializationTest {
       encoded = encoder.getOutputString();
     }
 
-    System.out.println("value: " + value);
-    System.out.println("encoded: " + encoded);
+    LOGGER.debug("value: {}", value);
+    LOGGER.debug("encoded: {}", encoded);
 
     UInteger decoded;
     try (var decoder = new OpcUaXmlDecoder(new DefaultEncodingContext())) {
@@ -241,8 +245,8 @@ public class OpcUaXmlSerializationTest {
       encoded = encoder.getOutputString();
     }
 
-    System.out.println("value: " + value);
-    System.out.println("encoded: " + encoded);
+    LOGGER.debug("value: {}", value);
+    LOGGER.debug("encoded: {}", encoded);
 
     long decoded;
     try (var decoder = new OpcUaXmlDecoder(new DefaultEncodingContext())) {
@@ -267,8 +271,8 @@ public class OpcUaXmlSerializationTest {
       encoded = encoder.getOutputString();
     }
 
-    System.out.println("value: " + value);
-    System.out.println("encoded: " + encoded);
+    LOGGER.debug("value: {}", value);
+    LOGGER.debug("encoded: {}", encoded);
 
     ULong decoded;
     try (var decoder = new OpcUaXmlDecoder(new DefaultEncodingContext())) {
@@ -296,8 +300,8 @@ public class OpcUaXmlSerializationTest {
       encoded = encoder.getOutputString();
     }
 
-    System.out.println("value: " + value);
-    System.out.println("encoded: " + encoded);
+    LOGGER.debug("value: {}", value);
+    LOGGER.debug("encoded: {}", encoded);
 
     float decoded;
     try (var decoder = new OpcUaXmlDecoder(new DefaultEncodingContext())) {
@@ -328,8 +332,8 @@ public class OpcUaXmlSerializationTest {
       encoded = encoder.getOutputString();
     }
 
-    System.out.println("value: " + value);
-    System.out.println("encoded: " + encoded);
+    LOGGER.debug("value: {}", value);
+    LOGGER.debug("encoded: {}", encoded);
 
     double decoded;
     try (var decoder = new OpcUaXmlDecoder(new DefaultEncodingContext())) {
@@ -362,8 +366,8 @@ public class OpcUaXmlSerializationTest {
       encoded = encoder.getOutputString();
     }
 
-    System.out.println("value: " + value);
-    System.out.println("encoded: " + encoded);
+    LOGGER.debug("value: {}", value);
+    LOGGER.debug("encoded: {}", encoded);
 
     String decoded;
     try (var decoder = new OpcUaXmlDecoder(new DefaultEncodingContext())) {
@@ -394,8 +398,8 @@ public class OpcUaXmlSerializationTest {
       encoded = encoder.getOutputString();
     }
 
-    System.out.println("value: " + value);
-    System.out.println("encoded: " + encoded);
+    LOGGER.debug("value: {}", value);
+    LOGGER.debug("encoded: {}", encoded);
 
     DateTime decoded;
     try (var decoder = new OpcUaXmlDecoder(new DefaultEncodingContext())) {
@@ -430,8 +434,8 @@ public class OpcUaXmlSerializationTest {
       encoded = encoder.getOutputString();
     }
 
-    System.out.println("value: " + value);
-    System.out.println("encoded: " + encoded);
+    LOGGER.debug("value: {}", value);
+    LOGGER.debug("encoded: {}", encoded);
 
     UUID decoded;
     try (var decoder = new OpcUaXmlDecoder(new DefaultEncodingContext())) {
@@ -456,8 +460,8 @@ public class OpcUaXmlSerializationTest {
       encoded = encoder.getOutputString();
     }
 
-    System.out.println("value: " + value);
-    System.out.println("encoded: " + encoded);
+    LOGGER.debug("value: {}", value);
+    LOGGER.debug("encoded: {}", encoded);
 
     ByteString decoded;
     try (var decoder = new OpcUaXmlDecoder(new DefaultEncodingContext())) {
@@ -490,8 +494,8 @@ public class OpcUaXmlSerializationTest {
       encoded = encoder.getOutputString();
     }
 
-    System.out.println("value: " + value);
-    System.out.println("encoded: " + encoded);
+    LOGGER.debug("value: {}", value);
+    LOGGER.debug("encoded: {}", encoded);
 
     XmlElement decoded;
     try (var decoder = new OpcUaXmlDecoder(new DefaultEncodingContext())) {
@@ -526,8 +530,8 @@ public class OpcUaXmlSerializationTest {
       encoded = encoder.getOutputString();
     }
 
-    System.out.println("value: " + value);
-    System.out.println("encoded: " + encoded);
+    LOGGER.debug("value: {}", value);
+    LOGGER.debug("encoded: {}", encoded);
 
     NodeId decoded;
     try (var decoder = new OpcUaXmlDecoder(new DefaultEncodingContext())) {
@@ -557,8 +561,8 @@ public class OpcUaXmlSerializationTest {
       encoded = encoder.getOutputString();
     }
 
-    System.out.println("value: " + value);
-    System.out.println("encoded: " + encoded);
+    LOGGER.debug("value: {}", value);
+    LOGGER.debug("encoded: {}", encoded);
 
     ExpandedNodeId decoded;
     try (var decoder = new OpcUaXmlDecoder(new DefaultEncodingContext())) {
@@ -589,8 +593,8 @@ public class OpcUaXmlSerializationTest {
       encoded = encoder.getOutputString();
     }
 
-    System.out.println("value: " + value);
-    System.out.println("encoded: " + encoded);
+    LOGGER.debug("value: {}", value);
+    LOGGER.debug("encoded: {}", encoded);
 
     StatusCode decoded;
     try (var decoder = new OpcUaXmlDecoder(new DefaultEncodingContext())) {
@@ -618,8 +622,8 @@ public class OpcUaXmlSerializationTest {
       encoded = encoder.getOutputString();
     }
 
-    System.out.println("value: " + value);
-    System.out.println("encoded: " + encoded);
+    LOGGER.debug("value: {}", value);
+    LOGGER.debug("encoded: {}", encoded);
 
     QualifiedName decoded;
     try (var decoder = new OpcUaXmlDecoder(new DefaultEncodingContext())) {
@@ -647,8 +651,8 @@ public class OpcUaXmlSerializationTest {
       encoded = encoder.getOutputString();
     }
 
-    System.out.println("value: " + value);
-    System.out.println("encoded: " + encoded);
+    LOGGER.debug("value: {}", value);
+    LOGGER.debug("encoded: {}", encoded);
 
     LocalizedText decoded;
     try (var decoder = new OpcUaXmlDecoder(new DefaultEncodingContext())) {
@@ -678,8 +682,8 @@ public class OpcUaXmlSerializationTest {
       encoded = encoder.getOutputString();
     }
 
-    System.out.println("value: " + value);
-    System.out.println("encoded: " + encoded);
+    LOGGER.debug("value: {}", value);
+    LOGGER.debug("encoded: {}", encoded);
 
     ExtensionObject decoded;
     try (var decoder = new OpcUaXmlDecoder(new DefaultEncodingContext())) {
@@ -706,8 +710,8 @@ public class OpcUaXmlSerializationTest {
       encoded = encoder.getOutputString();
     }
 
-    System.out.println("value: " + value);
-    System.out.println("encoded: " + encoded);
+    LOGGER.debug("value: {}", value);
+    LOGGER.debug("encoded: {}", encoded);
 
     DataValue decoded;
     try (var decoder = new OpcUaXmlDecoder(new DefaultEncodingContext())) {
@@ -738,8 +742,8 @@ public class OpcUaXmlSerializationTest {
       encoded = encoder.getOutputString();
     }
 
-    System.out.println("value: " + value);
-    System.out.println("encoded: " + encoded);
+    LOGGER.debug("value: {}", value);
+    LOGGER.debug("encoded: {}", encoded);
 
     Variant decoded;
     try (var decoder = new OpcUaXmlDecoder(new DefaultEncodingContext())) {
@@ -769,8 +773,8 @@ public class OpcUaXmlSerializationTest {
       encoded = encoder.getOutputString();
     }
 
-    System.out.println("value: " + value);
-    System.out.println("encoded: " + encoded);
+    LOGGER.debug("value: {}", value);
+    LOGGER.debug("encoded: {}", encoded);
 
     DiagnosticInfo decoded;
     try (var decoder = new OpcUaXmlDecoder(new DefaultEncodingContext())) {

--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/types/builtin/ExtensionObjectTest.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/types/builtin/ExtensionObjectTest.java
@@ -3,15 +3,19 @@ package org.eclipse.milo.opcua.stack.core.types.builtin;
 import static org.junit.jupiter.api.Assertions.*;
 
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 class ExtensionObjectTest {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(ExtensionObjectTest.class);
 
   @Test
   void ofByteString() {
     ByteString byteString = new ByteString(new byte[] {1, 2, 3});
     ExtensionObject extensionObject = ExtensionObject.of(byteString, NodeId.NULL_VALUE);
 
-    System.out.println(extensionObject);
+    LOGGER.debug("{}", extensionObject);
     assertEquals(byteString, extensionObject.getBody());
     assertInstanceOf(ExtensionObject.Binary.class, extensionObject);
   }
@@ -21,7 +25,7 @@ class ExtensionObjectTest {
     XmlElement xmlElement = new XmlElement("<test>Test</test>");
     ExtensionObject extensionObject = ExtensionObject.of(xmlElement, NodeId.NULL_VALUE);
 
-    System.out.println(extensionObject);
+    LOGGER.debug("{}", extensionObject);
     assertEquals(xmlElement, extensionObject.getBody());
     assertInstanceOf(ExtensionObject.Xml.class, extensionObject);
   }
@@ -31,7 +35,7 @@ class ExtensionObjectTest {
     String jsonString = "{\"test\": \"Test\"}";
     ExtensionObject extensionObject = ExtensionObject.of(jsonString, NodeId.NULL_VALUE);
 
-    System.out.println(extensionObject);
+    LOGGER.debug("{}", extensionObject);
     assertEquals(jsonString, extensionObject.getBody());
     assertInstanceOf(ExtensionObject.Json.class, extensionObject);
   }

--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/util/ExecutionQueueTest.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/util/ExecutionQueueTest.java
@@ -19,8 +19,12 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ExecutionQueueTest {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(ExecutionQueueTest.class);
 
   private final ExecutorService executor = Executors.newCachedThreadPool();
 
@@ -38,7 +42,7 @@ public class ExecutionQueueTest {
           () -> {
             int nn = n.getAndIncrement();
             if (ii != nn) {
-              System.out.println("n=" + nn + " i=" + ii);
+              LOGGER.debug("n={} i={}", nn, ii);
               failed.set(true);
             }
           });

--- a/opc-ua-stack/stack-tests/src/test/java/org/eclipse/milo/opcua/stack/ChunkSerializationTest.java
+++ b/opc-ua-stack/stack-tests/src/test/java/org/eclipse/milo/opcua/stack/ChunkSerializationTest.java
@@ -48,7 +48,7 @@ public class ChunkSerializationTest extends SecureChannelFixture {
     Security.addProvider(new BouncyCastleProvider());
   }
 
-  private final Logger logger = LoggerFactory.getLogger(getClass());
+  private static final Logger LOGGER = LoggerFactory.getLogger(ChunkSerializationTest.class);
 
   private final ChannelParameters smallParameters =
       new ChannelParameters(32 * 8196, 8196, 8196, 64, 32 * 8196, 8196, 8196, 64);
@@ -237,7 +237,7 @@ public class ChunkSerializationTest extends SecureChannelFixture {
       SecurityPolicy securityPolicy, MessageSecurityMode messageSecurity, int messageSize)
       throws Exception {
 
-    logger.info(
+    LOGGER.debug(
         "Asymmetric chunk serialization, securityPolicy={}, messageSecurityMode={}, messageSize={}",
         securityPolicy,
         messageSecurity,
@@ -321,7 +321,7 @@ public class ChunkSerializationTest extends SecureChannelFixture {
   public void testSymmetricMessage(
       SecurityPolicy securityPolicy, MessageSecurityMode messageSecurity) throws Exception {
 
-    logger.info(
+    LOGGER.debug(
         "Symmetric chunk serialization, " + "securityPolicy={}, messageSecurityMode={}",
         securityPolicy,
         messageSecurity);

--- a/opc-ua-stack/transport/src/test/java/org/eclipse/milo/opcua/stack/transport/client/tcp/OpcTcpTransportTest.java
+++ b/opc-ua-stack/transport/src/test/java/org/eclipse/milo/opcua/stack/transport/client/tcp/OpcTcpTransportTest.java
@@ -59,8 +59,12 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 class OpcTcpTransportTest extends SecurityFixture {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(OpcTcpTransportTest.class);
 
   static {
     // Required for SecurityPolicy.Aes256_Sha256_RsaPss
@@ -126,17 +130,17 @@ class OpcTcpTransportTest extends SecurityFixture {
 
     var transport = new OpcTcpClientTransport(config);
 
-    System.out.println("connecting...");
+    LOGGER.debug("connecting...");
     transport.connect(applicationContext).get();
-    System.out.println("connected");
+    LOGGER.debug("connected");
 
-    System.out.println("disconnecting...");
+    LOGGER.debug("disconnecting...");
     transport.disconnect().get();
-    System.out.println("disconnected");
+    LOGGER.debug("disconnected");
 
-    System.out.println("unbinding server transport...");
+    LOGGER.debug("unbinding server transport...");
     serverTransport.unbind();
-    System.out.println("server transport unbound");
+    LOGGER.debug("server transport unbound");
   }
 
   @Test
@@ -191,17 +195,17 @@ class OpcTcpTransportTest extends SecurityFixture {
 
     var transport = new OpcTcpClientTransport(config);
 
-    System.out.println("connecting...");
+    LOGGER.debug("connecting...");
     transport.connect(applicationContext).get();
-    System.out.println("connected");
+    LOGGER.debug("connected");
 
-    System.out.println("disconnecting...");
+    LOGGER.debug("disconnecting...");
     transport.disconnect().get();
-    System.out.println("disconnected");
+    LOGGER.debug("disconnected");
 
-    System.out.println("unbinding server transport...");
+    LOGGER.debug("unbinding server transport...");
     serverTransport.unbind();
-    System.out.println("server transport unbound");
+    LOGGER.debug("server transport unbound");
   }
 
   @Test
@@ -254,9 +258,9 @@ class OpcTcpTransportTest extends SecurityFixture {
 
     var transport = new OpcTcpClientTransport(config);
 
-    System.out.println("connecting...");
+    LOGGER.debug("connecting...");
     transport.connect(applicationContext).get();
-    System.out.println("connected");
+    LOGGER.debug("connected");
 
     assertThrows(ExecutionException.class, () -> createSession(transport));
 
@@ -342,7 +346,7 @@ class OpcTcpTransportTest extends SecurityFixture {
               }
             }
 
-            System.out.println("request: " + requestMessage);
+            LOGGER.debug("request: {}", requestMessage);
 
             return CompletableFuture.failedFuture(new RuntimeException("not implemented"));
           }


### PR DESCRIPTION
## Summary

Migrates test logging from `System.out.println()` to proper SLF4J logging framework using DEBUG level.

- Adds `slf4j-simple` test dependency to codec-json, dtd-core, and encoding-xml modules
- Replaces all `System.out.println()` calls with `Logger.debug()` across 25 test classes
- Introduces Logger instances to test classes that previously used direct console output