### PR TITLE
Warn instead of throw when Structure is not found

### DIFF
--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/OpcUaClient.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/OpcUaClient.java
@@ -2954,7 +2954,8 @@ public class OpcUaClient {
       } else {
         LoggerFactory.getLogger(getClass())
             .warn(
-                "Structure (i=22) not found in the DataType tree; is the Server's DataType hierarchy sane?");
+                "Structure (i=22) not found in the DataType tree; is the Server's DataType"
+                    + " hierarchy sane?");
       }
     }
 


### PR DESCRIPTION
Change DefaultDataTypeManagerInitializer to log a warning rather than throw UaException when the Structure node (i=22) is missing from the DataType tree.