### PR TITLE
Add attribute ID validation and fix null UserWriteMask handling

### DIFF
--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/servicesets/impl/AccessController.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/servicesets/impl/AccessController.java
@@ -102,8 +102,16 @@ public interface AccessController {
   /** The result of an access control check. */
   sealed interface AccessResult {
 
+    /** Access is allowed. */
     AccessResult ALLOWED = new Allowed();
+
+    /** Access is denied due to an invalid attribute id. */
+    AccessResult DENIED_ATTRIBUTE_ID_INVALID = new Denied(StatusCodes.Bad_AttributeIdInvalid);
+
+    /** Access is denied due to insufficient user access rights. */
     AccessResult DENIED_USER_ACCESS = new Denied(StatusCodes.Bad_UserAccessDenied);
+
+    /** Access is denied due to insufficient security mode. */
     AccessResult DENIED_SECURITY_MODE = new Denied(StatusCodes.Bad_SecurityModeInsufficient);
 
     /** Access is allowed. */


### PR DESCRIPTION
## Summary

- Validates attribute IDs in read and write access checks
- Returns Bad_AttributeIdInvalid for invalid attribute IDs  
- Allows operations when UserWriteMask is null so they fail with Bad_NodeIdUnknown instead of Bad_UserAccessDenied
- Adds javadoc for AccessResult constants
- Adds tests for invalid attribute IDs and null UserWriteMask handling

Fixes #1624