### PR TITLE
Potential fix for code scanning alert no. 12: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/maven-deploy-snapshot.yml
+++ b/.github/workflows/maven-deploy-snapshot.yml
@@ -1,4 +1,6 @@
 name: Deploy SNAPSHOT to Maven Central
+permissions:
+  contents: read
 on:
   workflow_dispatch:
 


### PR DESCRIPTION
Potential fix for [https://github.com/eclipse-milo/milo/security/code-scanning/12](https://github.com/eclipse-milo/milo/security/code-scanning/12)

The fix is to add a `permissions` block specifying the least privilege necessary for this workflow. The minimal required permission for most workflows unrelated to repository modifications is `contents: read`. This restricts the GITHUB_TOKEN to only be able to read repository contents, mitigating the risk of tokens being abused to manipulate code, issues, or PRs.  
Place the following block at the top of the workflow file, just after the `name` line and before the `on:` block for clarity and to apply to all jobs in the workflow (global setting). No further permissions (for issues, deployments, etc.) appear necessary from the steps shown.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
