### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -1,4 +1,6 @@
 name: Maven Release
+permissions:
+  contents: read
 
 on:
   release:


### PR DESCRIPTION
Potential fix for [https://github.com/eclipse-milo/milo/security/code-scanning/10](https://github.com/eclipse-milo/milo/security/code-scanning/10)

To fix the problem, add an explicit `permissions` block to the workflow. The recommended minimal starting point is `contents: read`, which restricts the `GITHUB_TOKEN` to reading repository content only. If the job or any steps need additional permissions (such as write access to pull requests, releases, or any other GitHub resources), those can be added, but in this case, none of the steps shown require such access—the workflow publishes to Maven Central, installs a GPG key, and runs Maven, all without manipulating or writing GitHub resources. 

Add the following block directly below the workflow `name` (line 1), at the root level in `.github/workflows/maven-release.yml`:
```yaml
permissions:
  contents: read
```
This ensures all jobs in the workflow inherit the read-only permissions for contents, satisfying CodeQL's requirement and adhering to least privilege principles.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
