### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/google-java-format.yml
+++ b/.github/workflows/google-java-format.yml
@@ -1,4 +1,6 @@
 name: check google-java-format
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/eclipse-milo/milo/security/code-scanning/7](https://github.com/eclipse-milo/milo/security/code-scanning/7)

The proper fix is to add a `permissions` block at the workflow or job level to explicitly specify the minimum set of privileges required by the workflow. In this particular workflow, actions/checkout and formatting tools typically do not need write access; read access is generally sufficient unless you want to commit formatting changes back (which this workflow does not appear to do). Therefore, adding `permissions: contents: read` to the workflow root (so it applies to all jobs) is the most straightforward and appropriate fix, and will resolve the CodeQL warning.

You need to insert the following after the `name:` block and before the `on:` keyword in `.github/workflows/google-java-format.yml`:

```yaml
permissions:
  contents: read
```

No further changes, imports, or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
