### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -1,4 +1,6 @@
 name: Run `mvn verify` on JDK 17
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/eclipse-milo/milo/security/code-scanning/5](https://github.com/eclipse-milo/milo/security/code-scanning/5)

The fix is to explicitly restrict the permissions for the workflow to the minimal set required. The workflow runs Maven verification and checks out code, which only requires the workflow to read repository contents, not write. Thus, adding a `permissions:` block with `contents: read` at the root of the workflow is sufficient and adheres to the principle of least privilege. The most robust way is to insert a block like `permissions: contents: read` at the top-level, just below `name:` (line 2 or 3), before the `on:` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
