### PR TITLE
Add Spotless plugin to enforce code formatting

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,7 @@
     <maven-site-plugin.version>4.0.0-M9</maven-site-plugin.version>
     <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
     <maven-surefire-plugin.version>3.5.3</maven-surefire-plugin.version>
+    <spotless-maven-plugin.version>3.0.0</spotless-maven-plugin.version>
     <versions-maven-plugin.version>2.19.0</versions-maven-plugin.version>
     <flatten-maven-plugin.version>1.7.2</flatten-maven-plugin.version>
 
@@ -501,6 +502,23 @@
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>flatten-maven-plugin</artifactId>
           <version>${flatten-maven-plugin.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>com.diffplug.spotless</groupId>
+          <artifactId>spotless-maven-plugin</artifactId>
+          <version>${spotless-maven-plugin.version}</version>
+          <configuration>
+            <java>
+              <googleJavaFormat/>
+            </java>
+          </configuration>
+          <executions>
+            <execution>
+              <goals>
+                <goal>check</goal>
+              </goals>
+            </execution>
+          </executions>
         </plugin>
       </plugins>
     </pluginManagement>


### PR DESCRIPTION
- Defined `spotless-maven-plugin` version in properties.
- Configured Spotless Maven plugin with Google Java Format.
- Added execution to check code formatting during the build process.