### PR TITLE
Add X.509 extensions to CSR generation

### DIFF
--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/util/CertificateUtil.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/util/CertificateUtil.java
@@ -36,10 +36,14 @@ import org.bouncycastle.asn1.pkcs.PKCSObjectIdentifiers;
 import org.bouncycastle.asn1.x500.X500Name;
 import org.bouncycastle.asn1.x500.style.IETFUtils;
 import org.bouncycastle.asn1.x500.style.RFC4519Style;
+import org.bouncycastle.asn1.x509.BasicConstraints;
+import org.bouncycastle.asn1.x509.ExtendedKeyUsage;
 import org.bouncycastle.asn1.x509.Extension;
 import org.bouncycastle.asn1.x509.ExtensionsGenerator;
 import org.bouncycastle.asn1.x509.GeneralName;
 import org.bouncycastle.asn1.x509.GeneralNames;
+import org.bouncycastle.asn1.x509.KeyPurposeId;
+import org.bouncycastle.asn1.x509.KeyUsage;
 import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
 import org.bouncycastle.openssl.MiscPEMGenerator;
 import org.bouncycastle.operator.ContentSigner;
@@ -143,6 +147,23 @@ public class CertificateUtil {
 
     ExtensionsGenerator extGen = new ExtensionsGenerator();
     extGen.addExtension(Extension.subjectAlternativeName, false, subjectAltNames);
+
+    KeyUsage keyUsage =
+        new KeyUsage(
+            KeyUsage.digitalSignature
+                | KeyUsage.nonRepudiation
+                | KeyUsage.keyEncipherment
+                | KeyUsage.dataEncipherment);
+    extGen.addExtension(Extension.keyUsage, true, keyUsage);
+
+    ExtendedKeyUsage extendedKeyUsage =
+        new ExtendedKeyUsage(
+            new KeyPurposeId[] {KeyPurposeId.id_kp_clientAuth, KeyPurposeId.id_kp_serverAuth});
+    extGen.addExtension(Extension.extendedKeyUsage, false, extendedKeyUsage);
+
+    BasicConstraints basicConstraints = new BasicConstraints(false);
+    extGen.addExtension(Extension.basicConstraints, true, basicConstraints);
+
     builder.addAttribute(PKCSObjectIdentifiers.pkcs_9_at_extensionRequest, extGen.generate());
 
     JcaContentSignerBuilder signerBuilder =
@@ -224,6 +245,22 @@ public class CertificateUtil {
         Extension.subjectAlternativeName,
         false,
         new GeneralNames(generalNames.toArray(new GeneralName[0])));
+
+    KeyUsage keyUsage =
+        new KeyUsage(
+            KeyUsage.digitalSignature
+                | KeyUsage.nonRepudiation
+                | KeyUsage.keyEncipherment
+                | KeyUsage.dataEncipherment);
+    extGen.addExtension(Extension.keyUsage, true, keyUsage);
+
+    ExtendedKeyUsage extendedKeyUsage =
+        new ExtendedKeyUsage(
+            new KeyPurposeId[] {KeyPurposeId.id_kp_clientAuth, KeyPurposeId.id_kp_serverAuth});
+    extGen.addExtension(Extension.extendedKeyUsage, false, extendedKeyUsage);
+
+    BasicConstraints basicConstraints = new BasicConstraints(false);
+    extGen.addExtension(Extension.basicConstraints, true, basicConstraints);
 
     builder.addAttribute(PKCSObjectIdentifiers.pkcs_9_at_extensionRequest, extGen.generate());
 

--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/util/CertificateUtilTest.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/util/CertificateUtilTest.java
@@ -11,11 +11,21 @@
 package org.eclipse.milo.opcua.stack.core.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.security.KeyPair;
 import java.security.cert.X509Certificate;
 import java.util.List;
+import org.bouncycastle.asn1.pkcs.Attribute;
+import org.bouncycastle.asn1.pkcs.PKCSObjectIdentifiers;
+import org.bouncycastle.asn1.x509.BasicConstraints;
+import org.bouncycastle.asn1.x509.ExtendedKeyUsage;
+import org.bouncycastle.asn1.x509.Extension;
+import org.bouncycastle.asn1.x509.Extensions;
+import org.bouncycastle.asn1.x509.KeyPurposeId;
+import org.bouncycastle.asn1.x509.KeyUsage;
 import org.bouncycastle.pkcs.PKCS10CertificationRequest;
 import org.junit.jupiter.api.Test;
 
@@ -86,5 +96,52 @@ public class CertificateUtilTest {
   public void testGetSanIpAddresses() {
     List<String> sanDnsNames = CertificateUtil.getSanIpAddresses(certificate);
     assertEquals(List.of("127.0.0.1", "127.0.0.2"), sanDnsNames);
+  }
+
+  @Test
+  public void testGenerateCsrContainsRequiredExtensions() throws Exception {
+    PKCS10CertificationRequest csr = CertificateUtil.generateCsr(keyPair, certificate);
+
+    Attribute[] attributes = csr.getAttributes(PKCSObjectIdentifiers.pkcs_9_at_extensionRequest);
+    assertNotNull(attributes, "extension request attribute should be present");
+    assertEquals(1, attributes.length, "should have exactly one extension request attribute");
+
+    Extensions extensions = Extensions.getInstance(attributes[0].getAttrValues().getObjectAt(0));
+
+    Extension keyUsageExt = extensions.getExtension(Extension.keyUsage);
+    assertNotNull(keyUsageExt, "keyUsage extension should be present");
+    assertTrue(keyUsageExt.isCritical(), "keyUsage extension should be critical");
+
+    KeyUsage keyUsage = KeyUsage.getInstance(keyUsageExt.getParsedValue());
+    assertTrue(
+        keyUsage.hasUsages(KeyUsage.digitalSignature), "keyUsage should include digitalSignature");
+    assertTrue(
+        keyUsage.hasUsages(KeyUsage.nonRepudiation), "keyUsage should include nonRepudiation");
+    assertTrue(
+        keyUsage.hasUsages(KeyUsage.keyEncipherment), "keyUsage should include keyEncipherment");
+    assertTrue(
+        keyUsage.hasUsages(KeyUsage.dataEncipherment), "keyUsage should include dataEncipherment");
+
+    Extension extendedKeyUsageExt = extensions.getExtension(Extension.extendedKeyUsage);
+    assertNotNull(extendedKeyUsageExt, "extendedKeyUsage extension should be present");
+    assertFalse(
+        extendedKeyUsageExt.isCritical(), "extendedKeyUsage extension should not be critical");
+
+    ExtendedKeyUsage extendedKeyUsage =
+        ExtendedKeyUsage.getInstance(extendedKeyUsageExt.getParsedValue());
+    assertTrue(
+        extendedKeyUsage.hasKeyPurposeId(KeyPurposeId.id_kp_clientAuth),
+        "extendedKeyUsage should include clientAuth");
+    assertTrue(
+        extendedKeyUsage.hasKeyPurposeId(KeyPurposeId.id_kp_serverAuth),
+        "extendedKeyUsage should include serverAuth");
+
+    Extension basicConstraintsExt = extensions.getExtension(Extension.basicConstraints);
+    assertNotNull(basicConstraintsExt, "basicConstraints extension should be present");
+    assertTrue(basicConstraintsExt.isCritical(), "basicConstraints extension should be critical");
+
+    BasicConstraints basicConstraints =
+        BasicConstraints.getInstance(basicConstraintsExt.getParsedValue());
+    assertFalse(basicConstraints.isCA(), "basicConstraints should have cA=false");
   }
 }


### PR DESCRIPTION
## Summary

- Added KeyUsage extension with digitalSignature, nonRepudiation, keyEncipherment, and dataEncipherment
- Added ExtendedKeyUsage extension with clientAuth and serverAuth
- Added BasicConstraints extension with cA=false
- Added comprehensive test coverage to verify extension presence and values