### PR TITLE
Refactor `OperationLimits` for lenient type handling

### DIFF
--- a/opc-ua-sdk/integration-tests/pom.xml
+++ b/opc-ua-sdk/integration-tests/pom.xml
@@ -77,6 +77,12 @@
       <version>${junit.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>${mockito.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/OperationLimitsTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/OperationLimitsTest.java
@@ -10,11 +10,21 @@
 
 package org.eclipse.milo.opcua.sdk.client;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import java.util.List;
 import org.eclipse.milo.opcua.sdk.test.AbstractClientServerTest;
 import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UShort;
 import org.junit.jupiter.api.Test;
 
 public class OperationLimitsTest extends AbstractClientServerTest {
@@ -42,5 +52,70 @@ public class OperationLimitsTest extends AbstractClientServerTest {
     client.disconnect();
 
     assertThrows(UaException.class, () -> client.readOperationLimits());
+  }
+
+  @Test
+  void readHandlesUShortValues() throws UaException {
+    // Create a mock client that returns UShort values instead of UInteger
+    var mockClient = mock(OpcUaClient.class);
+
+    // Create DataValues with UShort values (simulating a server that returns the wrong type)
+    var values =
+        List.of(
+            new DataValue(new Variant(UShort.valueOf(100))), // maxNodesPerRead
+            new DataValue(new Variant(UShort.valueOf(200))), // maxNodesPerWrite
+            new DataValue(new Variant(UShort.valueOf(300))), // maxNodesPerMethodCall
+            new DataValue(new Variant(UShort.valueOf(400))), // maxNodesPerBrowse
+            new DataValue(new Variant(UShort.valueOf(500))), // maxNodesPerRegisterNodes
+            new DataValue(
+                new Variant(UShort.valueOf(600))), // maxNodesPerTranslateBrowsePathsToNodeIds
+            new DataValue(new Variant(UShort.valueOf(700))), // maxNodesPerNodeManagement
+            new DataValue(new Variant(UShort.valueOf(800))), // maxMonitoredItemsPerCall
+            new DataValue(new Variant(UShort.valueOf(900))), // maxNodesPerHistoryReadData
+            new DataValue(new Variant(UShort.valueOf(1000))), // maxNodesPerHistoryReadEvents
+            new DataValue(new Variant(UShort.valueOf(1100))), // maxNodesPerHistoryUpdateData
+            new DataValue(new Variant(UShort.valueOf(1200)))); // maxNodesPerHistoryUpdateEvents
+
+    when(mockClient.readValues(anyDouble(), any(), anyList())).thenReturn(values);
+
+    // Call the static read method with our mock
+    var operationLimits = OperationLimits.read(mockClient);
+
+    // Verify all values are present and correctly converted from UShort to UInteger
+    assertTrue(operationLimits.maxNodesPerRead().isPresent());
+    assertEquals(100, operationLimits.maxNodesPerRead().get().intValue());
+
+    assertTrue(operationLimits.maxNodesPerWrite().isPresent());
+    assertEquals(200, operationLimits.maxNodesPerWrite().get().intValue());
+
+    assertTrue(operationLimits.maxNodesPerMethodCall().isPresent());
+    assertEquals(300, operationLimits.maxNodesPerMethodCall().get().intValue());
+
+    assertTrue(operationLimits.maxNodesPerBrowse().isPresent());
+    assertEquals(400, operationLimits.maxNodesPerBrowse().get().intValue());
+
+    assertTrue(operationLimits.maxNodesPerRegisterNodes().isPresent());
+    assertEquals(500, operationLimits.maxNodesPerRegisterNodes().get().intValue());
+
+    assertTrue(operationLimits.maxNodesPerTranslateBrowsePathsToNodeIds().isPresent());
+    assertEquals(600, operationLimits.maxNodesPerTranslateBrowsePathsToNodeIds().get().intValue());
+
+    assertTrue(operationLimits.maxNodesPerNodeManagement().isPresent());
+    assertEquals(700, operationLimits.maxNodesPerNodeManagement().get().intValue());
+
+    assertTrue(operationLimits.maxMonitoredItemsPerCall().isPresent());
+    assertEquals(800, operationLimits.maxMonitoredItemsPerCall().get().intValue());
+
+    assertTrue(operationLimits.maxNodesPerHistoryReadData().isPresent());
+    assertEquals(900, operationLimits.maxNodesPerHistoryReadData().get().intValue());
+
+    assertTrue(operationLimits.maxNodesPerHistoryReadEvents().isPresent());
+    assertEquals(1000, operationLimits.maxNodesPerHistoryReadEvents().get().intValue());
+
+    assertTrue(operationLimits.maxNodesPerHistoryUpdateData().isPresent());
+    assertEquals(1100, operationLimits.maxNodesPerHistoryUpdateData().get().intValue());
+
+    assertTrue(operationLimits.maxNodesPerHistoryUpdateEvents().isPresent());
+    assertEquals(1200, operationLimits.maxNodesPerHistoryUpdateEvents().get().intValue());
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/OperationLimits.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/OperationLimits.java
@@ -200,18 +200,18 @@ public class OperationLimits {
     List<DataValue> values =
         client.readValues(0.0, TimestampsToReturn.Neither, OPERATION_LIMITS_NODES);
 
-    UInteger maxNodesPerRead = (UInteger) values.get(0).value().value();
-    UInteger maxNodesPerWrite = (UInteger) values.get(1).value().value();
-    UInteger maxNodesPerMethodCall = (UInteger) values.get(2).value().value();
-    UInteger maxNodesPerBrowse = (UInteger) values.get(3).value().value();
-    UInteger maxNodesPerRegisterNodes = (UInteger) values.get(4).value().value();
-    UInteger maxNodesPerTranslateBrowsePathsToNodeIds = (UInteger) values.get(5).value().value();
-    UInteger maxNodesPerNodeManagement = (UInteger) values.get(6).value().value();
-    UInteger maxMonitoredItemsPerCall = (UInteger) values.get(7).value().value();
-    UInteger maxNodesPerHistoryReadData = (UInteger) values.get(8).value().value();
-    UInteger maxNodesPerHistoryReadEvents = (UInteger) values.get(9).value().value();
-    UInteger maxNodesPerHistoryUpdateData = (UInteger) values.get(10).value().value();
-    UInteger maxNodesPerHistoryUpdateEvents = (UInteger) values.get(11).value().value();
+    UInteger maxNodesPerRead = toUInteger(values.get(0).value().value());
+    UInteger maxNodesPerWrite = toUInteger(values.get(1).value().value());
+    UInteger maxNodesPerMethodCall = toUInteger(values.get(2).value().value());
+    UInteger maxNodesPerBrowse = toUInteger(values.get(3).value().value());
+    UInteger maxNodesPerRegisterNodes = toUInteger(values.get(4).value().value());
+    UInteger maxNodesPerTranslateBrowsePathsToNodeIds = toUInteger(values.get(5).value().value());
+    UInteger maxNodesPerNodeManagement = toUInteger(values.get(6).value().value());
+    UInteger maxMonitoredItemsPerCall = toUInteger(values.get(7).value().value());
+    UInteger maxNodesPerHistoryReadData = toUInteger(values.get(8).value().value());
+    UInteger maxNodesPerHistoryReadEvents = toUInteger(values.get(9).value().value());
+    UInteger maxNodesPerHistoryUpdateData = toUInteger(values.get(10).value().value());
+    UInteger maxNodesPerHistoryUpdateEvents = toUInteger(values.get(11).value().value());
 
     return new OperationLimits(
         maxNodesPerRead,
@@ -232,8 +232,8 @@ public class OperationLimits {
     Function<NodeId, UInteger> read =
         nodeId -> {
           try {
-            return (UInteger)
-                client.readValue(0.0, TimestampsToReturn.Neither, nodeId).value().value();
+            return toUInteger(
+                client.readValue(0.0, TimestampsToReturn.Neither, nodeId).value().value());
           } catch (UaException e) {
             return null;
           }
@@ -282,5 +282,29 @@ public class OperationLimits {
         maxNodesPerHistoryReadEvents,
         maxNodesPerHistoryUpdateData,
         maxNodesPerHistoryUpdateEvents);
+  }
+
+  /**
+   * Converts a value to a {@link UInteger}, handling various numeric types that a server might
+   * return.
+   *
+   * @param value the value to convert.
+   * @return the value as a {@link UInteger}, or {@code null} if the value is {@code null} or cannot
+   *     be converted.
+   */
+  private static @Nullable UInteger toUInteger(@Nullable Object value) {
+    if (value == null) {
+      return null;
+    }
+
+    if (value instanceof UInteger uInteger) {
+      return uInteger;
+    }
+
+    if (value instanceof Number number) {
+      return UInteger.valueOf(number.longValue());
+    }
+
+    return null;
   }
 }


### PR DESCRIPTION
- Introduced `toUInteger` helper method for consistent conversion to `UInteger`, handling various numeric types.
- Updated `OperationLimits` to use `toUInteger` for value extraction, reducing duplication.
- Created a new test in `OperationLimitsTest` to validate behavior with `UShort` values.

fixes #1664 