### PR TITLE
Call `Bootstrap::connect` with `InetSocketAddress`

### DIFF
--- a/opc-ua-stack/transport-https/src/main/java/org/eclipse/milo/opcua/stack/transport/https/OpcHttpClientTransport.java
+++ b/opc-ua-stack/transport-https/src/main/java/org/eclipse/milo/opcua/stack/transport/https/OpcHttpClientTransport.java
@@ -24,6 +24,7 @@ import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import io.netty.util.concurrent.FutureListener;
+import java.net.InetSocketAddress;
 import java.util.concurrent.CompletableFuture;
 import org.eclipse.milo.opcua.stack.core.types.UaRequestMessageType;
 import org.eclipse.milo.opcua.stack.core.types.UaResponseMessageType;
@@ -131,7 +132,7 @@ public class OpcHttpClientTransport implements OpcClientTransport {
         new Bootstrap()
             .channel(NioSocketChannel.class)
             .group(config.getEventLoop())
-            .remoteAddress(host, port);
+            .remoteAddress(new InetSocketAddress(host, port));
 
     return new SimpleChannelPool(
         bootstrap,

--- a/opc-ua-stack/transport-websocket/src/main/java/org/eclipse/milo/opcua/stack/transport/websocket/OpcWebSocketClientTransport.java
+++ b/opc-ua-stack/transport-websocket/src/main/java/org/eclipse/milo/opcua/stack/transport/websocket/OpcWebSocketClientTransport.java
@@ -47,6 +47,7 @@ import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import io.netty.util.Timeout;
 import io.netty.util.TimerTask;
 import java.net.ConnectException;
+import java.net.InetSocketAddress;
 import java.net.URI;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -230,7 +231,7 @@ public class OpcWebSocketClientTransport extends AbstractUascClientTransport {
       int port = EndpointUtil.getPort(endpointUrl);
 
       bootstrap
-          .connect(host, port)
+          .connect(new InetSocketAddress(host, port))
           .addListener(
               (ChannelFuture f) -> {
                 if (!f.isSuccess()) {

--- a/opc-ua-stack/transport/src/main/java/org/eclipse/milo/opcua/stack/transport/client/tcp/OpcTcpClientTransport.java
+++ b/opc-ua-stack/transport/src/main/java/org/eclipse/milo/opcua/stack/transport/client/tcp/OpcTcpClientTransport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 the Eclipse Milo Authors
+ * Copyright (c) 2025 the Eclipse Milo Authors
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -34,6 +34,7 @@ import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.util.Timeout;
 import io.netty.util.TimerTask;
 import java.net.ConnectException;
+import java.net.InetSocketAddress;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
@@ -168,7 +169,7 @@ public class OpcTcpClientTransport extends AbstractUascClientTransport {
       int port = EndpointUtil.getPort(endpointUrl);
 
       bootstrap
-          .connect(host, port)
+          .connect(new InetSocketAddress(host, port))
           .addListener(
               (ChannelFuture f) -> {
                 if (!f.isSuccess()) {


### PR DESCRIPTION
This causes hostname resolution to happen immediately instead of creating an unresolved `InetSocketAddress` that is later resolved on a Netty event loop thread.

