### PR TITLE
Make sun.security package optional for OSGi bundles

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -434,6 +434,7 @@
                 <instructions>
                   <Import-Package>
                     com.sun.management.*;resolution:=optional,
+                    sun.security.*;resolution:=optional,
                     !javax.annotation.*,
                     *
                   </Import-Package>


### PR DESCRIPTION
Mark imported packages sun.security.* as optional for OSGi context.

Fixes first error in #1688 

Before you submit a pull request please acknowledge the following:
- [x] You have signed an Eclipse Contributor Agreement and are committing using the same email address
- [ ] Your code contains any tests relevant to the problem you are solving
- [x] All new and existing tests passed
- [x] Code follows the style guidelines and Checkstyle passes

See [CONTRIBUTING](https://github.com/eclipse-milo/milo/blob/master/CONTRIBUTING.md) for more information.
