### PR TITLE
Fix OSGi Export-Package for shaded Guava packages

### DIFF
--- a/opc-ua-stack/stack-core/pom.xml
+++ b/opc-ua-stack/stack-core/pom.xml
@@ -95,6 +95,21 @@
         </configuration>
       </plugin>
       <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <configuration>
+          <instructions>
+            <!-- Export the shaded Guava packages for OSGi.
+                 The maven-bundle-plugin runs before maven-shade-plugin, so it doesn't
+                 see the relocated packages. We explicitly declare them here using
+                 _exportcontents which adds exports without copying classes. -->
+            <_exportcontents>
+              org.eclipse.milo.shaded.com.google.common.*;version="${project.version}"
+            </_exportcontents>
+          </instructions>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
         <executions>


### PR DESCRIPTION
## What problem(s) was I solving?

Fixes #1688 - OSGi bundle deployment fails with constraint violations due to mismatched package imports/exports for shaded Guava packages.

When deploying Milo as an OSGi bundle, `sdk-client` declares an import for `org.eclipse.milo.shaded.com.google.common.collect`, but `stack-core` only exports `com.google.common.collect` (the unshaded name). This happens because `maven-bundle-plugin` generates the MANIFEST.MF in the `process-classes` phase, before `maven-shade-plugin` relocates the Guava packages in the `package` phase.

## What user-facing changes did I ship?

OSGi deployments of Milo should now work correctly without constraint violations for the shaded Guava packages.

## How I implemented it

Added explicit `maven-bundle-plugin` configuration in `stack-core/pom.xml` using the `_exportcontents` BND instruction. This instruction adds packages to the OSGi `Export-Package` manifest header without requiring the packages to exist at analysis time, allowing `stack-core` to declare exports for the shaded packages that `maven-shade-plugin` creates later in the build lifecycle.

## How to verify it

### Manual Testing

1. Build the project: `mvn clean package`
2. Inspect `stack-core`'s MANIFEST.MF to verify it now includes `Export-Package` entries for `org.eclipse.milo.shaded.com.google.common.*`
3. Deploy the bundles in an OSGi container and verify no constraint violations occur

## Description for the changelog

Fixed OSGi Export-Package manifest to include shaded Guava packages, resolving bundle deployment constraint violations.
