### PR TITLE
Add Wireshark key log support for OPC UA secure channel decryption

### DIFF
--- a/docs/features/wireshark-key-log.md
+++ b/docs/features/wireshark-key-log.md
@@ -1,0 +1,233 @@
+# Wireshark Key Log
+
+Milo can export the symmetric encryption keys derived during OPC UA SecureChannel
+handshakes in a format that Wireshark 4.4+ understands, enabling offline decryption of
+encrypted OPC UA traffic. The feature is disabled by default and must be explicitly
+enabled by configuring a `SecurityKeysListener` on the client or server.
+
+* * *
+
+## Table of Contents
+
+- [Overview](#overview)
+- [How It Works](#how-it-works)
+- [Usage](#usage)
+- [Design Decisions](#design-decisions)
+- [Testing](#testing)
+
+* * *
+
+## Overview
+
+Debugging encrypted OPC UA traffic normally requires running with
+`MessageSecurityMode.None`, which changes protocol behavior and is not always possible.
+Wireshark 4.4 introduced support for decrypting OPC UA Secure Conversation messages when
+given the ephemeral symmetric keys from the `OpenSecureChannel` handshake.
+
+This feature adds a listener-based callback that fires after every key derivation, plus a
+built-in file writer (`WiresharkKeyLogWriter`) that produces key log files Wireshark can
+consume directly. The listener is generic — applications can implement
+`SecurityKeysListener` to route keys anywhere (logging framework, remote service, etc.),
+but the common case is writing to a file and loading it into Wireshark via
+**Edit > Preferences > Protocols > OPC UA > Key log file**.
+
+Both the client and server SDK support the feature. Each side sees its own key derivation
+event, so a key log file from either the client or the server is sufficient for
+Wireshark to decrypt traffic in both directions.
+
+* * *
+
+## How It Works
+
+Key derivation happens at two points in the codebase — one client-side, one server-side —
+both immediately after `ChannelSecurity.generateKeyPair()` returns. When a
+`SecurityKeysListener` is configured, the transport handler constructs a `SecurityKeyset`
+value object from the derived key material and invokes the listener synchronously on the
+Netty event loop thread. If no listener is configured, the code path is a no-op. If the
+security policy is `None`, no keys are derived and the listener is never invoked.
+
+```mermaid
+sequenceDiagram
+    participant App as Application Code
+    participant Config as OpcUaClient/ServerConfig
+    participant Ctx as ApplicationContext
+    participant Handler as Transport Handler
+    participant Listener as SecurityKeysListener
+
+    App->>Config: setSecurityKeysListener(writer)
+    Note over Config,Ctx: Config flows through ApplicationContext bridge
+    Handler->>Handler: ChannelSecurity.generateKeyPair()
+    Handler->>Ctx: get configured listener
+    Ctx-->>Handler: SecurityKeysListener (or null)
+    Handler->>Listener: onSecurityKeysCreated(keyset)
+    Listener->>Listener: Write to file / log / etc.
+```
+
+Channel renewals produce new keysets with the same channel ID but a new token ID. Each
+renewal triggers another listener invocation, and `WiresharkKeyLogWriter` appends the new
+entry to the same file. Wireshark matches entries by `(channelId, tokenId)` so both
+initial and renewed keys are used for the appropriate message ranges.
+
+### Key Log File Format
+
+Each keyset produces six lines. The suffix `<channelId>_<tokenId>` identifies the
+SecureChannel and security token the keys belong to:
+
+```
+client_iv_<channelId>_<tokenId>: <HEX>
+client_key_<channelId>_<tokenId>: <HEX>
+client_siglen_<channelId>_<tokenId>: <signatureSize>
+server_iv_<channelId>_<tokenId>: <HEX>
+server_key_<channelId>_<tokenId>: <HEX>
+server_siglen_<channelId>_<tokenId>: <signatureSize>
+```
+
+- Hex values are uppercase with no separators (e.g., `A1A2A3A4...`).
+- `signatureSize` is a decimal integer (20 for SHA-1, 32 for SHA-256).
+- Signing keys are intentionally omitted — Wireshark does not need them.
+
+### Key Components
+
+| Component | Location | Role |
+| --- | --- | --- |
+| `SecurityKeysListener` | `opc-ua-stack/stack-core/.../channel/SecurityKeysListener.java` | Callback interface notified after key derivation |
+| `SecurityKeyset` | `opc-ua-stack/stack-core/.../channel/SecurityKeyset.java` | Immutable value object carrying channel ID, token ID, keys, IVs, and signature size |
+| `WiresharkKeyLogWriter` | `opc-ua-stack/stack-core/.../channel/WiresharkKeyLogWriter.java` | Built-in `SecurityKeysListener` that writes the Wireshark key log format to a file |
+| `ClientApplicationContext` | `opc-ua-stack/transport/.../client/ClientApplicationContext.java` | Bridge interface — exposes the listener from client config to the transport layer |
+| `ServerApplicationContext` | `opc-ua-stack/transport/.../server/ServerApplicationContext.java` | Bridge interface — exposes the listener from server config to the transport layer |
+| `UascClientMessageHandler` | `opc-ua-stack/transport/.../client/uasc/UascClientMessageHandler.java` | Client-side integration point — invokes listener in `installSecurityToken()` |
+| `UascServerAsymmetricHandler` | `opc-ua-stack/transport/.../server/uasc/UascServerAsymmetricHandler.java` | Server-side integration point — invokes listener in `openSecureChannel()` |
+
+* * *
+
+## Usage
+
+### Client
+
+```java
+Path keyLogFile = Path.of("/tmp/opcua_client_keys.log");
+var writer = new WiresharkKeyLogWriter(keyLogFile);
+
+OpcUaClientConfig config = OpcUaClientConfig.builder()
+    .setSecurityKeysListener(writer)
+    // ... other config ...
+    .build();
+
+OpcUaClient client = OpcUaClient.create(config);
+client.connect();
+
+// ... use the client ...
+
+writer.close(); // flush and close when done
+```
+
+### Server
+
+```java
+Path keyLogFile = Path.of("/tmp/opcua_server_keys.log");
+var writer = new WiresharkKeyLogWriter(keyLogFile);
+
+OpcUaServerConfig config = OpcUaServerConfig.builder()
+    .setSecurityKeysListener(writer)
+    // ... other config ...
+    .build();
+
+OpcUaServer server = new OpcUaServer(config, transportFactory);
+server.startup().get();
+
+// ... server runs ...
+
+writer.close();
+```
+
+### Loading in Wireshark
+
+1. Capture OPC UA traffic (e.g., with tcpdump or Wireshark itself).
+2. Open the capture in Wireshark 4.4+.
+3. Go to **Edit > Preferences > Protocols > OPC UA**.
+4. Set **Key log file** to the path of the key log file.
+5. Encrypted OPC UA messages are now decrypted in the packet list.
+
+A key log file from either the client or the server is sufficient — both contain the same
+symmetric key material for both directions.
+
+### Custom Listener
+
+Implement `SecurityKeysListener` to handle key material in any way:
+
+```java
+SecurityKeysListener listener = keyset -> {
+    logger.debug(
+        "Keys derived for channel={}, token={}",
+        keyset.channelId(),
+        keyset.tokenId()
+    );
+    // write to database, send to remote service, etc.
+};
+
+OpcUaClientConfig config = OpcUaClientConfig.builder()
+    .setSecurityKeysListener(listener)
+    .build();
+```
+
+The interface is a single-method interface and is lambda-compatible. Implementations must
+be thread-safe — multiple channels may derive keys concurrently.
+
+* * *
+
+## Design Decisions
+
+### Signing keys are excluded from the keyset
+
+`SecurityKeyset` carries encryption keys, IVs, and the signature size, but not the
+signing keys themselves. Wireshark does not need signing keys for decryption — it only
+needs the signature length to know how many trailing bytes to strip before decrypting.
+Omitting signing keys limits the exposure if a key log file is accidentally leaked or
+left on disk.
+
+### Listener is invoked synchronously on the event loop
+
+The listener callback runs synchronously on the Netty event loop thread, immediately
+after key derivation and before the first encrypted message is sent. This guarantees the
+key log entry is written before any traffic that uses those keys, which is important
+because Wireshark needs the keys to decrypt the corresponding messages. The built-in
+`WiresharkKeyLogWriter` uses a buffered file append that completes in microseconds, so
+event loop latency is negligible. If a custom listener performs slow I/O, it should
+dispatch to a separate executor internally.
+
+### SecurityKeyset uses defensive copying for byte arrays
+
+The `SecurityKeyset` record clones all `byte[]` fields in both the compact constructor
+and the accessor methods. This ensures the keyset is truly immutable — callers cannot
+corrupt it by modifying the original arrays or the returned copies. The cost is minimal
+since key arrays are small (16-32 bytes) and key derivation happens infrequently (once
+per channel lifetime, plus renewals).
+
+* * *
+
+## Testing
+
+```bash
+mvn -q verify -pl opc-ua-stack/stack-core \
+    -Dtest="SecurityKeysetTest,WiresharkKeyLogWriterTest"
+```
+
+| Test Class | What It Covers |
+| --- | --- |
+| `SecurityKeysetTest` | Defensive copy behavior and value round-tripping |
+| `WiresharkKeyLogWriterTest` | File format correctness, append mode, and thread safety |
+
+Key test scenarios:
+
+- **Single entry format** — verifies the exact six-line output for AES-256 keys with a
+  large channel ID, confirming field names, hex formatting, and decimal signature size.
+- **Append mode** — writes two keysets (same channel, different tokens) and verifies 12
+  lines with correct token ID ordering.
+- **Thread safety** — 20 concurrent threads each write a keyset and the test verifies
+  no interleaved lines (every 6-line group has the correct field order).
+- **Defensive copy on construction** — mutates the original `byte[]` arrays after
+  constructing a `SecurityKeyset` and verifies the record retains the original values.
+- **Defensive copy on accessor return** — mutates the arrays returned by accessors and
+  verifies subsequent accessor calls still return the original values.
+- **Component value round-trip** — confirms all fields (including large unsigned 32-bit
+  channel IDs carried as `long`) survive construction and accessor calls.

--- a/milo-examples/client-examples/src/main/java/org/eclipse/milo/examples/client/ClientExample.java
+++ b/milo-examples/client-examples/src/main/java/org/eclipse/milo/examples/client/ClientExample.java
@@ -13,13 +13,21 @@ package org.eclipse.milo.examples.client;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Predicate;
 import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
+import org.eclipse.milo.opcua.sdk.client.OpcUaClientConfigBuilder;
 import org.eclipse.milo.opcua.sdk.client.identity.AnonymousProvider;
 import org.eclipse.milo.opcua.sdk.client.identity.IdentityProvider;
+import org.eclipse.milo.opcua.sdk.server.OpcUaServerConfigBuilder;
 import org.eclipse.milo.opcua.stack.core.security.SecurityPolicy;
 import org.eclipse.milo.opcua.stack.core.types.structured.EndpointDescription;
 
 public interface ClientExample {
 
+  /**
+   * Returns the endpoint URL the client connects to. The port from this URL is also used as the
+   * bind port for the embedded ExampleServer when run via {@link ClientExampleRunner}.
+   *
+   * @return the endpoint URL.
+   */
   default String getEndpointUrl() {
     return "opc.tcp://localhost:12686/milo";
   }
@@ -35,6 +43,20 @@ public interface ClientExample {
   default IdentityProvider getIdentityProvider() {
     return new AnonymousProvider();
   }
+
+  /**
+   * Override to customize the client's configuration before it is built.
+   *
+   * @param builder the client config builder, pre-populated with defaults.
+   */
+  default void configureClient(OpcUaClientConfigBuilder builder) {}
+
+  /**
+   * Override to customize the ExampleServer's configuration before it is built.
+   *
+   * @param builder the server config builder, pre-populated with defaults.
+   */
+  default void configureServer(OpcUaServerConfigBuilder builder) {}
 
   void run(OpcUaClient client, CompletableFuture<OpcUaClient> future) throws Exception;
 }

--- a/milo-examples/client-examples/src/main/java/org/eclipse/milo/examples/client/ClientExampleRunner.java
+++ b/milo-examples/client-examples/src/main/java/org/eclipse/milo/examples/client/ClientExampleRunner.java
@@ -27,6 +27,7 @@ import org.eclipse.milo.opcua.stack.core.security.FileBasedTrustListManager;
 import org.eclipse.milo.opcua.stack.core.security.MemoryCertificateQuarantine;
 import org.eclipse.milo.opcua.stack.core.security.TrustListManager;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.eclipse.milo.opcua.stack.core.util.EndpointUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -57,7 +58,8 @@ public class ClientExampleRunner {
     this.serverRequired = serverRequired;
 
     if (serverRequired) {
-      exampleServer = new ExampleServer();
+      int port = EndpointUtil.getPort(clientExample.getEndpointUrl());
+      exampleServer = new ExampleServer(port, clientExample::configureServer);
       exampleServer.startup().get();
     }
   }
@@ -86,15 +88,17 @@ public class ClientExampleRunner {
         clientExample.getEndpointUrl(),
         endpoints -> endpoints.stream().filter(clientExample.endpointFilter()).findFirst(),
         transportConfigBuilder -> {},
-        clientConfigBuilder ->
-            clientConfigBuilder
-                .setApplicationName(LocalizedText.english("eclipse milo opc-ua client"))
-                .setApplicationUri("urn:eclipse:milo:examples:client")
-                .setKeyPair(loader.getClientKeyPair())
-                .setCertificate(loader.getClientCertificate())
-                .setCertificateChain(loader.getClientCertificateChain())
-                .setCertificateValidator(certificateValidator)
-                .setIdentityProvider(clientExample.getIdentityProvider()));
+        clientConfigBuilder -> {
+          clientConfigBuilder
+              .setApplicationName(LocalizedText.english("eclipse milo opc-ua client"))
+              .setApplicationUri("urn:eclipse:milo:examples:client")
+              .setKeyPair(loader.getClientKeyPair())
+              .setCertificate(loader.getClientCertificate())
+              .setCertificateChain(loader.getClientCertificateChain())
+              .setCertificateValidator(certificateValidator)
+              .setIdentityProvider(clientExample.getIdentityProvider());
+          clientExample.configureClient(clientConfigBuilder);
+        });
   }
 
   public void run() {

--- a/milo-examples/client-examples/src/main/java/org/eclipse/milo/examples/client/KeyLogExample.java
+++ b/milo-examples/client-examples/src/main/java/org/eclipse/milo/examples/client/KeyLogExample.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2025 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.examples.client;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
+import org.eclipse.milo.opcua.sdk.client.OpcUaClientConfigBuilder;
+import org.eclipse.milo.opcua.sdk.server.OpcUaServerConfigBuilder;
+import org.eclipse.milo.opcua.stack.core.NodeIds;
+import org.eclipse.milo.opcua.stack.core.channel.WiresharkKeyLogWriter;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.TimestampsToReturn;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Demonstrates OPC UA key logging for Wireshark decryption.
+ *
+ * <p>Starts an embedded server and client, both configured with {@link WiresharkKeyLogWriter}.
+ * After the encrypted connection is established and some traffic is exchanged, the key log file
+ * contents are printed. The resulting file can be loaded into Wireshark 4.4+ via Edit → Preferences
+ * → Protocols → OPC UA → Key log file.
+ */
+public class KeyLogExample implements ClientExample {
+
+  public static void main(String[] args) throws Exception {
+    var example = new KeyLogExample();
+
+    logger.info("Server key log: {}", example.serverKeyLogFile);
+    logger.info("Client key log: {}", example.clientKeyLogFile);
+
+    new ClientExampleRunner(example).run();
+  }
+
+  private static final Logger logger = LoggerFactory.getLogger(KeyLogExample.class);
+
+  private final Path serverKeyLogFile;
+  private final Path clientKeyLogFile;
+  private final WiresharkKeyLogWriter serverKeyLogWriter;
+  private final WiresharkKeyLogWriter clientKeyLogWriter;
+
+  public KeyLogExample() throws IOException {
+    Path keyLogDir = Files.createTempDirectory("opcua-keylog");
+    serverKeyLogFile = keyLogDir.resolve("server_keys.log");
+    clientKeyLogFile = keyLogDir.resolve("client_keys.log");
+    serverKeyLogWriter = new WiresharkKeyLogWriter(serverKeyLogFile);
+    clientKeyLogWriter = new WiresharkKeyLogWriter(clientKeyLogFile);
+  }
+
+  @Override
+  public String getEndpointUrl() {
+    return "opc.tcp://localhost:4840/milo";
+  }
+
+  @Override
+  public void configureServer(OpcUaServerConfigBuilder builder) {
+    builder.setSecurityKeysListener(serverKeyLogWriter);
+  }
+
+  @Override
+  public void configureClient(OpcUaClientConfigBuilder builder) {
+    builder.setSecurityKeysListener(clientKeyLogWriter);
+  }
+
+  @Override
+  public void run(OpcUaClient client, CompletableFuture<OpcUaClient> future) throws Exception {
+    client.connect();
+    logger.info("Connected with Basic256Sha256 / SignAndEncrypt");
+
+    List<DataValue> values =
+        client
+            .readValuesAsync(
+                0.0,
+                TimestampsToReturn.Both,
+                List.of(NodeIds.Server_ServerStatus_State, NodeIds.Server_ServerStatus_CurrentTime))
+            .get();
+
+    logger.info("ServerState = {}", values.get(0).value().value());
+    logger.info("CurrentTime = {}", values.get(1).value().value());
+
+    serverKeyLogWriter.close();
+    clientKeyLogWriter.close();
+
+    logger.info("--- Server key log ({}) ---", serverKeyLogFile);
+    Files.readAllLines(serverKeyLogFile).forEach(line -> logger.info("  {}", line));
+
+    logger.info("--- Client key log ({}) ---", clientKeyLogFile);
+    Files.readAllLines(clientKeyLogFile).forEach(line -> logger.info("  {}", line));
+
+    logger.info("Load either file into Wireshark 4.4+ via:");
+    logger.info("  Edit > Preferences > Protocols > OPC UA > Key log file");
+
+    future.complete(client);
+  }
+}

--- a/milo-examples/client-examples/src/main/java/org/eclipse/milo/examples/client/KeyLogExample.java
+++ b/milo-examples/client-examples/src/main/java/org/eclipse/milo/examples/client/KeyLogExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 the Eclipse Milo Authors
+ * Copyright (c) 2026 the Eclipse Milo Authors
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/milo-examples/server-examples/src/main/java/org/eclipse/milo/examples/server/ExampleServer.java
+++ b/milo-examples/server-examples/src/main/java/org/eclipse/milo/examples/server/ExampleServer.java
@@ -28,10 +28,12 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.function.Consumer;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.eclipse.milo.opcua.sdk.server.EndpointConfig;
 import org.eclipse.milo.opcua.sdk.server.OpcUaServer;
 import org.eclipse.milo.opcua.sdk.server.OpcUaServerConfig;
+import org.eclipse.milo.opcua.sdk.server.OpcUaServerConfigBuilder;
 import org.eclipse.milo.opcua.sdk.server.identity.AnonymousIdentityValidator;
 import org.eclipse.milo.opcua.sdk.server.identity.CompositeValidator;
 import org.eclipse.milo.opcua.sdk.server.identity.UsernameIdentityValidator;
@@ -60,7 +62,9 @@ import org.slf4j.LoggerFactory;
 
 public class ExampleServer {
 
-  private static final int TCP_BIND_PORT = 12686;
+  private static final int DEFAULT_TCP_BIND_PORT = 12686;
+
+  private final int tcpBindPort;
 
   static {
     // Required for SecurityPolicy.Aes256_Sha256_RsaPss
@@ -90,6 +94,23 @@ public class ExampleServer {
   private final ExampleNamespace exampleNamespace;
 
   public ExampleServer() throws Exception {
+    this(DEFAULT_TCP_BIND_PORT, builder -> {});
+  }
+
+  public ExampleServer(Consumer<OpcUaServerConfigBuilder> configCustomizer) throws Exception {
+    this(DEFAULT_TCP_BIND_PORT, configCustomizer);
+  }
+
+  /**
+   * Creates an ExampleServer with a custom TCP bind port and additional configuration applied to
+   * the {@link OpcUaServerConfigBuilder} before the config is built.
+   *
+   * @param tcpBindPort the TCP port to bind the server on.
+   * @param configCustomizer a consumer that can modify the server config builder.
+   */
+  public ExampleServer(int tcpBindPort, Consumer<OpcUaServerConfigBuilder> configCustomizer)
+      throws Exception {
+    this.tcpBindPort = tcpBindPort;
     Path securityTempDir = Paths.get(System.getProperty("java.io.tmpdir"), "server", "security");
     Files.createDirectories(securityTempDir);
     if (!Files.exists(securityTempDir)) {
@@ -164,7 +185,7 @@ public class ExampleServer {
 
     Set<EndpointConfig> endpointConfigurations = createEndpointConfigs(certificate);
 
-    OpcUaServerConfig serverConfig =
+    var serverConfigBuilder =
         OpcUaServerConfig.builder()
             .setApplicationUri(applicationUri)
             .setApplicationName(LocalizedText.english("Eclipse Milo OPC UA Example Server"))
@@ -181,8 +202,11 @@ public class ExampleServer {
             .setIdentityValidator(
                 new CompositeValidator(
                     AnonymousIdentityValidator.INSTANCE, identityValidator, x509IdentityValidator))
-            .setProductUri("urn:eclipse:milo:example-server")
-            .build();
+            .setProductUri("urn:eclipse:milo:example-server");
+
+    configCustomizer.accept(serverConfigBuilder);
+
+    OpcUaServerConfig serverConfig = serverConfigBuilder.build();
 
     server =
         new OpcUaServer(
@@ -263,10 +287,10 @@ public class ExampleServer {
     return endpointConfigs;
   }
 
-  private static EndpointConfig buildTcpEndpoint(EndpointConfig.Builder base) {
+  private EndpointConfig buildTcpEndpoint(EndpointConfig.Builder base) {
     return base.copy()
         .setTransportProfile(TransportProfile.TCP_UASC_UABINARY)
-        .setBindPort(TCP_BIND_PORT)
+        .setBindPort(tcpBindPort)
         .build();
   }
 

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/OpcUaClient.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/OpcUaClient.java
@@ -49,6 +49,7 @@ import org.eclipse.milo.opcua.sdk.core.typetree.ObjectTypeTree;
 import org.eclipse.milo.opcua.sdk.core.typetree.VariableTypeTree;
 import org.eclipse.milo.opcua.stack.core.*;
 import org.eclipse.milo.opcua.stack.core.channel.EncodingLimits;
+import org.eclipse.milo.opcua.stack.core.channel.SecurityKeysListener;
 import org.eclipse.milo.opcua.stack.core.encoding.DefaultEncodingManager;
 import org.eclipse.milo.opcua.stack.core.encoding.EncodingContext;
 import org.eclipse.milo.opcua.stack.core.encoding.EncodingManager;
@@ -163,6 +164,7 @@ import org.eclipse.milo.opcua.stack.transport.client.OpcClientTransport;
 import org.eclipse.milo.opcua.stack.transport.client.tcp.OpcTcpClientTransport;
 import org.eclipse.milo.opcua.stack.transport.client.tcp.OpcTcpClientTransportConfig;
 import org.eclipse.milo.opcua.stack.transport.client.tcp.OpcTcpClientTransportConfigBuilder;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -422,6 +424,11 @@ public class OpcUaClient {
           @Override
           public UInteger getRequestTimeout() {
             return config.getRequestTimeout();
+          }
+
+          @Override
+          public @Nullable SecurityKeysListener getSecurityKeysListener() {
+            return config.getSecurityKeysListener().orElse(null);
           }
         };
 

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/OpcUaClientConfig.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/OpcUaClientConfig.java
@@ -19,6 +19,7 @@ import java.util.function.Consumer;
 import java.util.function.Supplier;
 import org.eclipse.milo.opcua.sdk.client.identity.IdentityProvider;
 import org.eclipse.milo.opcua.stack.core.channel.EncodingLimits;
+import org.eclipse.milo.opcua.stack.core.channel.SecurityKeysListener;
 import org.eclipse.milo.opcua.stack.core.security.CertificateValidator;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
@@ -164,6 +165,14 @@ public interface OpcUaClientConfig {
   boolean isSessionEndpointValidationEnabled();
 
   /**
+   * Get the {@link SecurityKeysListener} to be notified when symmetric security keys are derived
+   * during OpenSecureChannel handshakes.
+   *
+   * @return an {@link Optional} containing the {@link SecurityKeysListener}, if configured.
+   */
+  Optional<SecurityKeysListener> getSecurityKeysListener();
+
+  /**
    * @return a new {@link OpcUaClientConfigBuilder}.
    */
   static OpcUaClientConfigBuilder builder() {
@@ -200,6 +209,7 @@ public interface OpcUaClientConfig {
     builder.setKeepAliveTimeout(config.getKeepAliveTimeout());
     builder.setSessionLocaleIds(config.getSessionLocaleIds());
     builder.setSessionEndpointValidationEnabled(config.isSessionEndpointValidationEnabled());
+    config.getSecurityKeysListener().ifPresent(builder::setSecurityKeysListener);
 
     return builder;
   }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/OpcUaClientConfig.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/OpcUaClientConfig.java
@@ -170,7 +170,9 @@ public interface OpcUaClientConfig {
    *
    * @return an {@link Optional} containing the {@link SecurityKeysListener}, if configured.
    */
-  Optional<SecurityKeysListener> getSecurityKeysListener();
+  default Optional<SecurityKeysListener> getSecurityKeysListener() {
+    return Optional.empty();
+  }
 
   /**
    * @return a new {@link OpcUaClientConfigBuilder}.

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/OpcUaClientConfigBuilder.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/OpcUaClientConfigBuilder.java
@@ -20,6 +20,7 @@ import java.util.function.Supplier;
 import org.eclipse.milo.opcua.sdk.client.identity.AnonymousProvider;
 import org.eclipse.milo.opcua.sdk.client.identity.IdentityProvider;
 import org.eclipse.milo.opcua.stack.core.channel.EncodingLimits;
+import org.eclipse.milo.opcua.stack.core.channel.SecurityKeysListener;
 import org.eclipse.milo.opcua.stack.core.security.CertificateValidator;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
@@ -56,6 +57,8 @@ public class OpcUaClientConfigBuilder {
   private UInteger keepAliveTimeout = uint(5000);
 
   private boolean sessionEndpointValidationEnabled = false;
+
+  private SecurityKeysListener securityKeysListener;
 
   public OpcUaClientConfigBuilder setApplicationName(LocalizedText applicationName) {
     this.applicationName = applicationName;
@@ -167,6 +170,12 @@ public class OpcUaClientConfigBuilder {
     return this;
   }
 
+  public OpcUaClientConfigBuilder setSecurityKeysListener(
+      SecurityKeysListener securityKeysListener) {
+    this.securityKeysListener = securityKeysListener;
+    return this;
+  }
+
   public OpcUaClientConfig build() {
     if (sessionName == null) {
       sessionName =
@@ -195,7 +204,8 @@ public class OpcUaClientConfigBuilder {
         keepAliveFailuresAllowed,
         keepAliveInterval,
         keepAliveTimeout,
-        sessionEndpointValidationEnabled);
+        sessionEndpointValidationEnabled,
+        securityKeysListener);
   }
 
   static class OpcUaClientConfigImpl implements OpcUaClientConfig {
@@ -222,6 +232,7 @@ public class OpcUaClientConfigBuilder {
     private final UInteger keepAliveInterval;
     private final UInteger keepAliveTimeout;
     private final boolean sessionEndpointValidationEnabled;
+    private final SecurityKeysListener securityKeysListener;
 
     OpcUaClientConfigImpl(
         EndpointDescription endpoint,
@@ -244,7 +255,8 @@ public class OpcUaClientConfigBuilder {
         UInteger keepAliveFailuresAllowed,
         UInteger keepAliveInterval,
         UInteger keepAliveTimeout,
-        boolean sessionEndpointValidationEnabled) {
+        boolean sessionEndpointValidationEnabled,
+        SecurityKeysListener securityKeysListener) {
 
       this.endpoint = endpoint;
       this.discoveryEndpoints = discoveryEndpoints;
@@ -267,6 +279,7 @@ public class OpcUaClientConfigBuilder {
       this.keepAliveInterval = keepAliveInterval;
       this.keepAliveTimeout = keepAliveTimeout;
       this.sessionEndpointValidationEnabled = sessionEndpointValidationEnabled;
+      this.securityKeysListener = securityKeysListener;
     }
 
     @Override
@@ -372,6 +385,11 @@ public class OpcUaClientConfigBuilder {
     @Override
     public boolean isSessionEndpointValidationEnabled() {
       return sessionEndpointValidationEnabled;
+    }
+
+    @Override
+    public Optional<SecurityKeysListener> getSecurityKeysListener() {
+      return Optional.ofNullable(securityKeysListener);
     }
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/OpcUaClientConfigBuilder.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/OpcUaClientConfigBuilder.java
@@ -25,6 +25,7 @@ import org.eclipse.milo.opcua.stack.core.security.CertificateValidator;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.structured.EndpointDescription;
+import org.jspecify.annotations.Nullable;
 
 public class OpcUaClientConfigBuilder {
 
@@ -58,7 +59,7 @@ public class OpcUaClientConfigBuilder {
 
   private boolean sessionEndpointValidationEnabled = false;
 
-  private SecurityKeysListener securityKeysListener;
+  private @Nullable SecurityKeysListener securityKeysListener;
 
   public OpcUaClientConfigBuilder setApplicationName(LocalizedText applicationName) {
     this.applicationName = applicationName;
@@ -171,7 +172,7 @@ public class OpcUaClientConfigBuilder {
   }
 
   public OpcUaClientConfigBuilder setSecurityKeysListener(
-      SecurityKeysListener securityKeysListener) {
+      @Nullable SecurityKeysListener securityKeysListener) {
     this.securityKeysListener = securityKeysListener;
     return this;
   }
@@ -232,7 +233,7 @@ public class OpcUaClientConfigBuilder {
     private final UInteger keepAliveInterval;
     private final UInteger keepAliveTimeout;
     private final boolean sessionEndpointValidationEnabled;
-    private final SecurityKeysListener securityKeysListener;
+    private final @Nullable SecurityKeysListener securityKeysListener;
 
     OpcUaClientConfigImpl(
         EndpointDescription endpoint,
@@ -256,7 +257,7 @@ public class OpcUaClientConfigBuilder {
         UInteger keepAliveInterval,
         UInteger keepAliveTimeout,
         boolean sessionEndpointValidationEnabled,
-        SecurityKeysListener securityKeysListener) {
+        @Nullable SecurityKeysListener securityKeysListener) {
 
       this.endpoint = endpoint;
       this.discoveryEndpoints = discoveryEndpoints;

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/OpcUaServer.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/OpcUaServer.java
@@ -64,6 +64,7 @@ import org.eclipse.milo.opcua.stack.core.Stack;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.channel.EncodingLimits;
+import org.eclipse.milo.opcua.stack.core.channel.SecurityKeysListener;
 import org.eclipse.milo.opcua.stack.core.channel.messages.ErrorMessage;
 import org.eclipse.milo.opcua.stack.core.encoding.DefaultEncodingManager;
 import org.eclipse.milo.opcua.stack.core.encoding.EncodingContext;
@@ -601,6 +602,11 @@ public class OpcUaServer extends AbstractServiceHandler {
     @Override
     public Long getNextSecureChannelId() {
       return secureChannelIds.getAndIncrement();
+    }
+
+    @Override
+    public @Nullable SecurityKeysListener getSecurityKeysListener() {
+      return config.getSecurityKeysListener().orElse(null);
     }
 
     @Override

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/OpcUaServerConfig.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/OpcUaServerConfig.java
@@ -123,7 +123,9 @@ public interface OpcUaServerConfig {
    *
    * @return an {@link Optional} containing the {@link SecurityKeysListener}, if configured.
    */
-  Optional<SecurityKeysListener> getSecurityKeysListener();
+  default Optional<SecurityKeysListener> getSecurityKeysListener() {
+    return Optional.empty();
+  }
 
   /**
    * @return the {@link ExecutorService} for this server.

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/OpcUaServerConfig.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/OpcUaServerConfig.java
@@ -21,6 +21,7 @@ import org.eclipse.milo.opcua.sdk.server.identity.IdentityValidator;
 import org.eclipse.milo.opcua.sdk.server.identity.UsernameIdentityValidator;
 import org.eclipse.milo.opcua.sdk.server.identity.X509IdentityValidator;
 import org.eclipse.milo.opcua.stack.core.channel.EncodingLimits;
+import org.eclipse.milo.opcua.stack.core.channel.SecurityKeysListener;
 import org.eclipse.milo.opcua.stack.core.security.CertificateManager;
 import org.eclipse.milo.opcua.stack.core.security.SecurityPolicy;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
@@ -117,6 +118,14 @@ public interface OpcUaServerConfig {
   Optional<RoleMapper> getRoleMapper();
 
   /**
+   * Get the {@link SecurityKeysListener} to be notified when symmetric security keys are derived
+   * during OpenSecureChannel handshakes.
+   *
+   * @return an {@link Optional} containing the {@link SecurityKeysListener}, if configured.
+   */
+  Optional<SecurityKeysListener> getSecurityKeysListener();
+
+  /**
    * @return the {@link ExecutorService} for this server.
    */
   ExecutorService getExecutor();
@@ -155,6 +164,7 @@ public interface OpcUaServerConfig {
     builder.setCertificateManager(config.getCertificateManager());
     builder.setExecutor(config.getExecutor());
     builder.setScheduledExecutor(config.getScheduledExecutorService());
+    config.getSecurityKeysListener().ifPresent(builder::setSecurityKeysListener);
 
     return builder;
   }

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/OpcUaServerConfigBuilder.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/OpcUaServerConfigBuilder.java
@@ -19,6 +19,7 @@ import org.eclipse.milo.opcua.sdk.server.identity.AnonymousIdentityValidator;
 import org.eclipse.milo.opcua.sdk.server.identity.IdentityValidator;
 import org.eclipse.milo.opcua.stack.core.Stack;
 import org.eclipse.milo.opcua.stack.core.channel.EncodingLimits;
+import org.eclipse.milo.opcua.stack.core.channel.SecurityKeysListener;
 import org.eclipse.milo.opcua.stack.core.security.CertificateManager;
 import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
@@ -46,6 +47,8 @@ public class OpcUaServerConfigBuilder {
   private CertificateManager certificateManager;
 
   private RoleMapper roleMapper;
+
+  private SecurityKeysListener securityKeysListener;
 
   private ExecutorService executor;
   private ScheduledExecutorService scheduledExecutor;
@@ -100,6 +103,12 @@ public class OpcUaServerConfigBuilder {
     return this;
   }
 
+  public OpcUaServerConfigBuilder setSecurityKeysListener(
+      SecurityKeysListener securityKeysListener) {
+    this.securityKeysListener = securityKeysListener;
+    return this;
+  }
+
   public OpcUaServerConfigBuilder setExecutor(ExecutorService executor) {
     this.executor = executor;
     return this;
@@ -129,6 +138,7 @@ public class OpcUaServerConfigBuilder {
         limits,
         certificateManager,
         roleMapper,
+        securityKeysListener,
         executor,
         scheduledExecutor);
   }
@@ -145,6 +155,7 @@ public class OpcUaServerConfigBuilder {
     private final OpcUaServerConfigLimits limits;
     private final CertificateManager certificateManager;
     private final RoleMapper roleMapper;
+    private final SecurityKeysListener securityKeysListener;
     private final ExecutorService executor;
     private final ScheduledExecutorService scheduledExecutorService;
 
@@ -159,6 +170,7 @@ public class OpcUaServerConfigBuilder {
         OpcUaServerConfigLimits limits,
         CertificateManager certificateManager,
         RoleMapper roleMapper,
+        SecurityKeysListener securityKeysListener,
         ExecutorService executor,
         ScheduledExecutorService scheduledExecutorService) {
 
@@ -172,6 +184,7 @@ public class OpcUaServerConfigBuilder {
       this.limits = limits;
       this.certificateManager = certificateManager;
       this.roleMapper = roleMapper;
+      this.securityKeysListener = securityKeysListener;
       this.executor = executor;
       this.scheduledExecutorService = scheduledExecutorService;
     }
@@ -224,6 +237,11 @@ public class OpcUaServerConfigBuilder {
     @Override
     public Optional<RoleMapper> getRoleMapper() {
       return Optional.ofNullable(roleMapper);
+    }
+
+    @Override
+    public Optional<SecurityKeysListener> getSecurityKeysListener() {
+      return Optional.ofNullable(securityKeysListener);
     }
 
     @Override

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/OpcUaServerConfigBuilder.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/OpcUaServerConfigBuilder.java
@@ -24,6 +24,7 @@ import org.eclipse.milo.opcua.stack.core.security.CertificateManager;
 import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.structured.BuildInfo;
+import org.jspecify.annotations.Nullable;
 
 public class OpcUaServerConfigBuilder {
 
@@ -48,7 +49,7 @@ public class OpcUaServerConfigBuilder {
 
   private RoleMapper roleMapper;
 
-  private SecurityKeysListener securityKeysListener;
+  private @Nullable SecurityKeysListener securityKeysListener;
 
   private ExecutorService executor;
   private ScheduledExecutorService scheduledExecutor;
@@ -104,7 +105,7 @@ public class OpcUaServerConfigBuilder {
   }
 
   public OpcUaServerConfigBuilder setSecurityKeysListener(
-      SecurityKeysListener securityKeysListener) {
+      @Nullable SecurityKeysListener securityKeysListener) {
     this.securityKeysListener = securityKeysListener;
     return this;
   }
@@ -155,7 +156,7 @@ public class OpcUaServerConfigBuilder {
     private final OpcUaServerConfigLimits limits;
     private final CertificateManager certificateManager;
     private final RoleMapper roleMapper;
-    private final SecurityKeysListener securityKeysListener;
+    private final @Nullable SecurityKeysListener securityKeysListener;
     private final ExecutorService executor;
     private final ScheduledExecutorService scheduledExecutorService;
 
@@ -170,7 +171,7 @@ public class OpcUaServerConfigBuilder {
         OpcUaServerConfigLimits limits,
         CertificateManager certificateManager,
         RoleMapper roleMapper,
-        SecurityKeysListener securityKeysListener,
+        @Nullable SecurityKeysListener securityKeysListener,
         ExecutorService executor,
         ScheduledExecutorService scheduledExecutorService) {
 

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/channel/SecurityKeysListener.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/channel/SecurityKeysListener.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2025 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.stack.core.channel;
+
+/**
+ * A listener that is notified when symmetric security keys are derived during an OpenSecureChannel
+ * handshake.
+ *
+ * <p>Implementations must be thread-safe — multiple channels may derive keys concurrently.
+ *
+ * @see SecurityKeyset
+ * @see WiresharkKeyLogWriter
+ */
+public interface SecurityKeysListener {
+
+  /**
+   * Called after symmetric keys have been derived and installed on a SecureChannel.
+   *
+   * @param keyset the derived keyset for the new security token.
+   */
+  void onSecurityKeysCreated(SecurityKeyset keyset);
+}

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/channel/SecurityKeysListener.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/channel/SecurityKeysListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 the Eclipse Milo Authors
+ * Copyright (c) 2026 the Eclipse Milo Authors
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/channel/SecurityKeyset.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/channel/SecurityKeyset.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 the Eclipse Milo Authors
+ * Copyright (c) 2026 the Eclipse Milo Authors
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/channel/SecurityKeyset.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/channel/SecurityKeyset.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2025 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.stack.core.channel;
+
+/**
+ * An immutable snapshot of the symmetric keyset derived during an OpenSecureChannel handshake,
+ * suitable for writing to a Wireshark OPC UA key log file.
+ *
+ * @param channelId the SecureChannelId (unsigned 32-bit, carried as long).
+ * @param tokenId the SecurityTokenId (unsigned 32-bit, carried as long).
+ * @param clientEncryptionKey the client-to-server AES encryption key.
+ * @param clientInitializationVector the client-to-server initialization vector.
+ * @param serverEncryptionKey the server-to-client AES encryption key.
+ * @param serverInitializationVector the server-to-client initialization vector.
+ * @param signatureSize the HMAC output length in bytes (20 for SHA-1, 32 for SHA-256).
+ */
+public record SecurityKeyset(
+    long channelId,
+    long tokenId,
+    byte[] clientEncryptionKey,
+    byte[] clientInitializationVector,
+    byte[] serverEncryptionKey,
+    byte[] serverInitializationVector,
+    int signatureSize) {
+  public SecurityKeyset {
+    clientEncryptionKey = clientEncryptionKey.clone();
+    clientInitializationVector = clientInitializationVector.clone();
+    serverEncryptionKey = serverEncryptionKey.clone();
+    serverInitializationVector = serverInitializationVector.clone();
+  }
+
+  @Override
+  public byte[] clientEncryptionKey() {
+    return clientEncryptionKey.clone();
+  }
+
+  @Override
+  public byte[] clientInitializationVector() {
+    return clientInitializationVector.clone();
+  }
+
+  @Override
+  public byte[] serverEncryptionKey() {
+    return serverEncryptionKey.clone();
+  }
+
+  @Override
+  public byte[] serverInitializationVector() {
+    return serverInitializationVector.clone();
+  }
+}

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/channel/WiresharkKeyLogWriter.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/channel/WiresharkKeyLogWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 the Eclipse Milo Authors
+ * Copyright (c) 2026 the Eclipse Milo Authors
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/channel/WiresharkKeyLogWriter.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/channel/WiresharkKeyLogWriter.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2025 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.stack.core.channel;
+
+import java.io.BufferedWriter;
+import java.io.Closeable;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.HexFormat;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A {@link SecurityKeysListener} that writes keysets to a file in the Wireshark OPC UA key log
+ * format.
+ *
+ * <p>The output file can be loaded into Wireshark (4.4+) via Edit → Preferences → Protocols → OPC
+ * UA → Key log file.
+ *
+ * <p>This class is thread-safe. Each entry is written as a single synchronized operation.
+ *
+ * @see SecurityKeyset
+ */
+public class WiresharkKeyLogWriter implements SecurityKeysListener, Closeable {
+
+  private static final Logger logger = LoggerFactory.getLogger(WiresharkKeyLogWriter.class);
+
+  private static final HexFormat HEX = HexFormat.of().withUpperCase();
+
+  private final BufferedWriter writer;
+
+  /**
+   * Create a new writer that appends to {@code keyLogFile}.
+   *
+   * <p>The file is created if it does not exist.
+   *
+   * @param keyLogFile the path to the key log file.
+   * @throws IOException if the file cannot be opened for writing.
+   */
+  public WiresharkKeyLogWriter(Path keyLogFile) throws IOException {
+    this.writer =
+        Files.newBufferedWriter(
+            keyLogFile,
+            StandardCharsets.US_ASCII,
+            StandardOpenOption.CREATE,
+            StandardOpenOption.APPEND);
+  }
+
+  @Override
+  public synchronized void onSecurityKeysCreated(SecurityKeyset keyset) {
+    try {
+      String suffix = keyset.channelId() + "_" + keyset.tokenId();
+
+      writer.write(
+          "client_iv_" + suffix + ": " + HEX.formatHex(keyset.clientInitializationVector()));
+      writer.newLine();
+      writer.write("client_key_" + suffix + ": " + HEX.formatHex(keyset.clientEncryptionKey()));
+      writer.newLine();
+      writer.write("client_siglen_" + suffix + ": " + keyset.signatureSize());
+      writer.newLine();
+      writer.write(
+          "server_iv_" + suffix + ": " + HEX.formatHex(keyset.serverInitializationVector()));
+      writer.newLine();
+      writer.write("server_key_" + suffix + ": " + HEX.formatHex(keyset.serverEncryptionKey()));
+      writer.newLine();
+      writer.write("server_siglen_" + suffix + ": " + keyset.signatureSize());
+      writer.newLine();
+      writer.flush();
+    } catch (IOException e) {
+      logger.warn(
+          "Failed to write key log entry for channel={}, token={}",
+          keyset.channelId(),
+          keyset.tokenId(),
+          e);
+    }
+  }
+
+  /**
+   * Close the underlying file writer.
+   *
+   * @throws IOException if an I/O error occurs.
+   */
+  @Override
+  public void close() throws IOException {
+    writer.close();
+  }
+}

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/channel/WiresharkKeyLogWriter.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/channel/WiresharkKeyLogWriter.java
@@ -39,6 +39,7 @@ public class WiresharkKeyLogWriter implements SecurityKeysListener, Closeable {
   private static final HexFormat HEX = HexFormat.of().withUpperCase();
 
   private final BufferedWriter writer;
+  private boolean closed = false;
 
   /**
    * Create a new writer that appends to {@code keyLogFile}.
@@ -59,6 +60,9 @@ public class WiresharkKeyLogWriter implements SecurityKeysListener, Closeable {
 
   @Override
   public synchronized void onSecurityKeysCreated(SecurityKeyset keyset) {
+    if (closed) {
+      return;
+    }
     try {
       String suffix = keyset.channelId() + "_" + keyset.tokenId();
 
@@ -92,7 +96,10 @@ public class WiresharkKeyLogWriter implements SecurityKeysListener, Closeable {
    * @throws IOException if an I/O error occurs.
    */
   @Override
-  public void close() throws IOException {
-    writer.close();
+  public synchronized void close() throws IOException {
+    if (!closed) {
+      closed = true;
+      writer.close();
+    }
   }
 }

--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/channel/SecurityKeysetTest.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/channel/SecurityKeysetTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 the Eclipse Milo Authors
+ * Copyright (c) 2026 the Eclipse Milo Authors
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/channel/SecurityKeysetTest.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/channel/SecurityKeysetTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2025 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.stack.core.channel;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class SecurityKeysetTest {
+
+  @Test
+  void defensiveCopyOnConstruction() {
+    byte[] clientKey = {0x01, 0x02, 0x03};
+    byte[] clientIv = {0x04, 0x05, 0x06};
+    byte[] serverKey = {0x07, 0x08, 0x09};
+    byte[] serverIv = {0x0A, 0x0B, 0x0C};
+
+    SecurityKeyset keyset =
+        new SecurityKeyset(1L, 2L, clientKey, clientIv, serverKey, serverIv, 20);
+
+    // Mutate the original arrays
+    clientKey[0] = (byte) 0xFF;
+    clientIv[0] = (byte) 0xFF;
+    serverKey[0] = (byte) 0xFF;
+    serverIv[0] = (byte) 0xFF;
+
+    // Record should retain the original values
+    assertEquals((byte) 0x01, keyset.clientEncryptionKey()[0]);
+    assertEquals((byte) 0x04, keyset.clientInitializationVector()[0]);
+    assertEquals((byte) 0x07, keyset.serverEncryptionKey()[0]);
+    assertEquals((byte) 0x0A, keyset.serverInitializationVector()[0]);
+  }
+
+  @Test
+  void componentValuesRoundTrip() {
+    byte[] clientKey = {0x10, 0x20};
+    byte[] clientIv = {0x30, 0x40};
+    byte[] serverKey = {0x50, 0x60};
+    byte[] serverIv = {0x70, (byte) 0x80};
+
+    SecurityKeyset keyset =
+        new SecurityKeyset(2265448448L, 1L, clientKey, clientIv, serverKey, serverIv, 32);
+
+    assertEquals(2265448448L, keyset.channelId());
+    assertEquals(1L, keyset.tokenId());
+    assertArrayEquals(clientKey, keyset.clientEncryptionKey());
+    assertArrayEquals(clientIv, keyset.clientInitializationVector());
+    assertArrayEquals(serverKey, keyset.serverEncryptionKey());
+    assertArrayEquals(serverIv, keyset.serverInitializationVector());
+    assertEquals(32, keyset.signatureSize());
+  }
+
+  @Test
+  void defensiveCopyOnAccessorReturn() {
+    byte[] clientKey = {0x01, 0x02, 0x03};
+    byte[] clientIv = {0x04, 0x05, 0x06};
+    byte[] serverKey = {0x07, 0x08, 0x09};
+    byte[] serverIv = {0x0A, 0x0B, 0x0C};
+
+    SecurityKeyset keyset =
+        new SecurityKeyset(1L, 2L, clientKey, clientIv, serverKey, serverIv, 20);
+
+    // Mutate the arrays returned by accessors
+    keyset.clientEncryptionKey()[0] = (byte) 0xFF;
+    keyset.clientInitializationVector()[0] = (byte) 0xFF;
+    keyset.serverEncryptionKey()[0] = (byte) 0xFF;
+    keyset.serverInitializationVector()[0] = (byte) 0xFF;
+
+    // Record should retain the original values
+    assertEquals((byte) 0x01, keyset.clientEncryptionKey()[0]);
+    assertEquals((byte) 0x04, keyset.clientInitializationVector()[0]);
+    assertEquals((byte) 0x07, keyset.serverEncryptionKey()[0]);
+    assertEquals((byte) 0x0A, keyset.serverInitializationVector()[0]);
+  }
+}

--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/channel/WiresharkKeyLogWriterTest.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/channel/WiresharkKeyLogWriterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 the Eclipse Milo Authors
+ * Copyright (c) 2026 the Eclipse Milo Authors
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/channel/WiresharkKeyLogWriterTest.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/channel/WiresharkKeyLogWriterTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2025 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.stack.core.channel;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class WiresharkKeyLogWriterTest {
+
+  private static final HexFormat HEX = HexFormat.of().withUpperCase();
+
+  @TempDir Path tempDir;
+
+  @Test
+  void singleEntryFormat() throws IOException {
+    Path keyLogFile = tempDir.resolve("keys.log");
+
+    // Use values that exercise the Wireshark format: large channelId, AES-256 keys
+    byte[] clientKey =
+        hexToBytes("0102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F20");
+    byte[] clientIv = hexToBytes("A1A2A3A4A5A6A7A8A9AAABACADAEAF10");
+    byte[] serverKey =
+        hexToBytes("2122232425262728292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F40");
+    byte[] serverIv = hexToBytes("B1B2B3B4B5B6B7B8B9BABBBCBDBEBF10");
+
+    SecurityKeyset keyset =
+        new SecurityKeyset(2265448448L, 1L, clientKey, clientIv, serverKey, serverIv, 32);
+
+    var writer = new WiresharkKeyLogWriter(keyLogFile);
+    writer.onSecurityKeysCreated(keyset);
+    writer.close();
+
+    List<String> lines = Files.readAllLines(keyLogFile);
+    assertEquals(6, lines.size());
+
+    String suffix = "2265448448_1";
+    assertEquals("client_iv_" + suffix + ": " + HEX.formatHex(clientIv), lines.get(0));
+    assertEquals("client_key_" + suffix + ": " + HEX.formatHex(clientKey), lines.get(1));
+    assertEquals("client_siglen_" + suffix + ": 32", lines.get(2));
+    assertEquals("server_iv_" + suffix + ": " + HEX.formatHex(serverIv), lines.get(3));
+    assertEquals("server_key_" + suffix + ": " + HEX.formatHex(serverKey), lines.get(4));
+    assertEquals("server_siglen_" + suffix + ": 32", lines.get(5));
+  }
+
+  @Test
+  void appendMode() throws IOException {
+    Path keyLogFile = tempDir.resolve("keys.log");
+
+    byte[] key = {0x01, 0x02};
+    byte[] iv = {0x03, 0x04};
+
+    SecurityKeyset keyset1 = new SecurityKeyset(100L, 1L, key, iv, key, iv, 20);
+    SecurityKeyset keyset2 = new SecurityKeyset(100L, 2L, key, iv, key, iv, 20);
+
+    var writer = new WiresharkKeyLogWriter(keyLogFile);
+    writer.onSecurityKeysCreated(keyset1);
+    writer.onSecurityKeysCreated(keyset2);
+    writer.close();
+
+    List<String> lines = Files.readAllLines(keyLogFile);
+    assertEquals(12, lines.size());
+
+    // First entry uses token 1
+    assertTrue(lines.get(0).contains("100_1"));
+    // Second entry uses token 2
+    assertTrue(lines.get(6).contains("100_2"));
+  }
+
+  @Test
+  void threadSafetyConcurrentWrites() throws Exception {
+    Path keyLogFile = tempDir.resolve("keys.log");
+
+    int numThreads = 20;
+    byte[] key = {0x0A, 0x0B, 0x0C, 0x0D};
+    byte[] iv = {0x01, 0x02, 0x03, 0x04};
+
+    var writer = new WiresharkKeyLogWriter(keyLogFile);
+    ExecutorService executor = Executors.newFixedThreadPool(numThreads);
+    var latch = new CountDownLatch(numThreads);
+
+    List<SecurityKeyset> keysets = new ArrayList<>();
+    for (int i = 0; i < numThreads; i++) {
+      keysets.add(new SecurityKeyset(1L, i + 1L, key, iv, key, iv, 20));
+    }
+
+    for (SecurityKeyset keyset : keysets) {
+      executor.submit(
+          () -> {
+            try {
+              writer.onSecurityKeysCreated(keyset);
+            } finally {
+              latch.countDown();
+            }
+          });
+    }
+
+    latch.await();
+    executor.shutdown();
+    writer.close();
+
+    List<String> lines = Files.readAllLines(keyLogFile);
+
+    // Each keyset produces 6 lines
+    assertEquals(numThreads * 6, lines.size());
+
+    // Verify no interleaved lines: every 6th line should start a new entry
+    for (int i = 0; i < lines.size(); i++) {
+      int posInEntry = i % 6;
+      switch (posInEntry) {
+        case 0 -> assertTrue(lines.get(i).startsWith("client_iv_"));
+        case 1 -> assertTrue(lines.get(i).startsWith("client_key_"));
+        case 2 -> assertTrue(lines.get(i).startsWith("client_siglen_"));
+        case 3 -> assertTrue(lines.get(i).startsWith("server_iv_"));
+        case 4 -> assertTrue(lines.get(i).startsWith("server_key_"));
+        case 5 -> assertTrue(lines.get(i).startsWith("server_siglen_"));
+      }
+    }
+  }
+
+  private static byte[] hexToBytes(String hex) {
+    return HexFormat.of().parseHex(hex);
+  }
+}

--- a/opc-ua-stack/transport/src/main/java/org/eclipse/milo/opcua/stack/transport/client/ClientApplicationContext.java
+++ b/opc-ua-stack/transport/src/main/java/org/eclipse/milo/opcua/stack/transport/client/ClientApplicationContext.java
@@ -13,10 +13,12 @@ package org.eclipse.milo.opcua.stack.transport.client;
 import java.security.KeyPair;
 import java.security.cert.X509Certificate;
 import java.util.Optional;
+import org.eclipse.milo.opcua.stack.core.channel.SecurityKeysListener;
 import org.eclipse.milo.opcua.stack.core.encoding.EncodingContext;
 import org.eclipse.milo.opcua.stack.core.security.CertificateValidator;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.structured.EndpointDescription;
+import org.jspecify.annotations.Nullable;
 
 public interface ClientApplicationContext {
 
@@ -74,4 +76,16 @@ public interface ClientApplicationContext {
    * @return the client request timeout to use when opening or renewing a secure channel.
    */
   UInteger getRequestTimeout();
+
+  /**
+   * Get the {@link SecurityKeysListener}, if configured.
+   *
+   * <p>When non-null, the listener is invoked after symmetric keys are derived during an
+   * OpenSecureChannel handshake.
+   *
+   * @return the {@link SecurityKeysListener}, or {@code null} if key logging is not enabled.
+   */
+  default @Nullable SecurityKeysListener getSecurityKeysListener() {
+    return null;
+  }
 }

--- a/opc-ua-stack/transport/src/main/java/org/eclipse/milo/opcua/stack/transport/client/uasc/UascClientMessageHandler.java
+++ b/opc-ua-stack/transport/src/main/java/org/eclipse/milo/opcua/stack/transport/client/uasc/UascClientMessageHandler.java
@@ -42,6 +42,8 @@ import org.eclipse.milo.opcua.stack.core.channel.ChunkEncoder.EncodedMessage;
 import org.eclipse.milo.opcua.stack.core.channel.MessageAbortException;
 import org.eclipse.milo.opcua.stack.core.channel.MessageDecodeException;
 import org.eclipse.milo.opcua.stack.core.channel.MessageEncodeException;
+import org.eclipse.milo.opcua.stack.core.channel.SecurityKeysListener;
+import org.eclipse.milo.opcua.stack.core.channel.SecurityKeyset;
 import org.eclipse.milo.opcua.stack.core.channel.headers.AsymmetricSecurityHeader;
 import org.eclipse.milo.opcua.stack.core.channel.messages.ErrorMessage;
 import org.eclipse.milo.opcua.stack.core.channel.messages.MessageType;
@@ -474,6 +476,21 @@ public class UascClientMessageHandler extends ByteToMessageCodec<UascRequest> {
     ChannelSecurityToken oldToken = oldSecrets != null ? oldSecrets.getCurrentToken() : null;
 
     secureChannel.setChannelSecurity(new ChannelSecurity(newKeys, newToken, oldKeys, oldToken));
+
+    SecurityKeysListener listener = application.getSecurityKeysListener();
+
+    if (listener != null && newKeys != null) {
+      var keyset =
+          new SecurityKeyset(
+              secureChannel.getChannelId(),
+              newToken.getTokenId().longValue(),
+              newKeys.getClientKeys().getEncryptionKey(),
+              newKeys.getClientKeys().getInitializationVector(),
+              newKeys.getServerKeys().getEncryptionKey(),
+              newKeys.getServerKeys().getInitializationVector(),
+              secureChannel.getSymmetricSignatureSize());
+      listener.onSecurityKeysCreated(keyset);
+    }
 
     DateTime createdAt = response.getSecurityToken().getCreatedAt();
     long revisedLifetime = response.getSecurityToken().getRevisedLifetime().longValue();

--- a/opc-ua-stack/transport/src/main/java/org/eclipse/milo/opcua/stack/transport/server/ServerApplicationContext.java
+++ b/opc-ua-stack/transport/src/main/java/org/eclipse/milo/opcua/stack/transport/server/ServerApplicationContext.java
@@ -12,11 +12,13 @@ package org.eclipse.milo.opcua.stack.transport.server;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import org.eclipse.milo.opcua.stack.core.channel.SecurityKeysListener;
 import org.eclipse.milo.opcua.stack.core.encoding.EncodingContext;
 import org.eclipse.milo.opcua.stack.core.security.CertificateManager;
 import org.eclipse.milo.opcua.stack.core.types.UaRequestMessageType;
 import org.eclipse.milo.opcua.stack.core.types.UaResponseMessageType;
 import org.eclipse.milo.opcua.stack.core.types.structured.EndpointDescription;
+import org.jspecify.annotations.Nullable;
 
 public interface ServerApplicationContext {
 
@@ -64,4 +66,16 @@ public interface ServerApplicationContext {
    */
   CompletableFuture<UaResponseMessageType> handleServiceRequest(
       ServiceRequestContext context, UaRequestMessageType requestMessage);
+
+  /**
+   * Get the {@link SecurityKeysListener}, if configured.
+   *
+   * <p>When non-null, the listener is invoked after symmetric keys are derived during an
+   * OpenSecureChannel handshake.
+   *
+   * @return the {@link SecurityKeysListener}, or {@code null} if key logging is not enabled.
+   */
+  default @Nullable SecurityKeysListener getSecurityKeysListener() {
+    return null;
+  }
 }

--- a/opc-ua-stack/transport/src/main/java/org/eclipse/milo/opcua/stack/transport/server/uasc/UascServerAsymmetricHandler.java
+++ b/opc-ua-stack/transport/src/main/java/org/eclipse/milo/opcua/stack/transport/server/uasc/UascServerAsymmetricHandler.java
@@ -45,6 +45,8 @@ import org.eclipse.milo.opcua.stack.core.channel.ExceptionHandler;
 import org.eclipse.milo.opcua.stack.core.channel.MessageAbortException;
 import org.eclipse.milo.opcua.stack.core.channel.MessageDecodeException;
 import org.eclipse.milo.opcua.stack.core.channel.MessageEncodeException;
+import org.eclipse.milo.opcua.stack.core.channel.SecurityKeysListener;
+import org.eclipse.milo.opcua.stack.core.channel.SecurityKeyset;
 import org.eclipse.milo.opcua.stack.core.channel.ServerSecureChannel;
 import org.eclipse.milo.opcua.stack.core.channel.headers.AsymmetricSecurityHeader;
 import org.eclipse.milo.opcua.stack.core.channel.headers.HeaderDecoder;
@@ -581,6 +583,21 @@ public class UascServerAsymmetricHandler extends ByteToMessageDecoder implements
     ChannelSecurity newSecrets = new ChannelSecurity(newKeys, newToken, oldKeys, oldToken);
 
     secureChannel.setChannelSecurity(newSecrets);
+
+    SecurityKeysListener listener = application.getSecurityKeysListener();
+
+    if (listener != null && newKeys != null) {
+      var keyset =
+          new SecurityKeyset(
+              secureChannel.getChannelId(),
+              newToken.getTokenId().longValue(),
+              newKeys.getClientKeys().getEncryptionKey(),
+              newKeys.getClientKeys().getInitializationVector(),
+              newKeys.getServerKeys().getEncryptionKey(),
+              newKeys.getServerKeys().getInitializationVector(),
+              secureChannel.getSymmetricSignatureSize());
+      listener.onSecurityKeysCreated(keyset);
+    }
 
     /*
      * Cancel the previous timeout, if it exists, and start a new one.


### PR DESCRIPTION
## Summary

Add a callback-based key export mechanism that captures the symmetric keys derived during OpenSecureChannel handshakes and writes them in the Wireshark OPC UA key log format for offline traffic decryption.

Closes #1719.

- Added `SecurityKeysListener` callback interface, `SecurityKeyset` immutable value object, and `WiresharkKeyLogWriter` file-based implementation in `stack-core` — the three core types that enable key export.
- Wired the listener through the SDK config builders (`OpcUaClientConfig`, `OpcUaServerConfig`) and `ApplicationContext` bridge interfaces to the two transport-layer key derivation sites.
- Added `configureClient()` / `configureServer()` hooks to `ClientExample` / `ExampleServer` so examples can customize both configs without reimplementing the runner.
- Added `KeyLogExample` demonstrating end-to-end key logging with an encrypted client/server connection.
- Feature reference: [`docs/features/wireshark-key-log.md`](https://github.com/eclipse-milo/milo/blob/feature/wireshark-keylog/docs/features/wireshark-key-log.md)

## Key Changes

- **Core types (`stack-core`):** `SecurityKeyset` is a Java record with defensive-copy on both construction and accessor return. `WiresharkKeyLogWriter` synchronizes on the callback and flushes per entry; I/O errors are logged rather than thrown so a write failure doesn't interrupt the Netty event loop.

- **Transport integration:** The listener is invoked immediately after `setChannelSecurity()` in both `UascClientMessageHandler.installSecurityToken()` and `UascServerAsymmetricHandler.openSecureChannel()`, guarded by `newKeys != null` (null when security policy is `None`). The `ApplicationContext` interfaces gain a `default` method returning `null` for backward compatibility.

- **SDK configuration path:** Follows the existing config-builder → `ApplicationContext` → transport-handler pattern used by `getKeyPair()`, `getCertificateManager()`, etc. Config interfaces expose `Optional<SecurityKeysListener>`; the `ApplicationContext` overrides bridge via `.orElse(null)`.

- **Example infrastructure:** `configureClient()` / `configureServer()` on `ClientExample` and new `ExampleServer` constructors are general-purpose hooks, not key-log-specific.

## Testing

- `SecurityKeysetTest` — defensive copy on construction, accessor return cloning, component round-trip.
- `WiresharkKeyLogWriterTest` — single entry format validation, append mode (two entries → 12 lines), concurrent writes from 20 threads with interleaving check.
- Verification: `mvn -q clean verify`

## References

- [Wireshark MR: opcua: add decryption support](https://gitlab.com/wireshark/wireshark/-/merge_requests/12586)
- [OPC UA Part 6, Section 6.7.5: Deriving Keys](https://reference.opcfoundation.org/Core/Part6/v105/docs/6.7.5)
- [Unified Automation C++ SDK: Wireshark encrypted analysis](https://documentation.unified-automation.com/uasdkcpp/2.0.0/html/wireshark_encrypted.html)