### PR TITLE
Decouple OpcUaSubscription.SyncState from MonitoredItem operations

### DIFF
--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/subscriptions/OpcUaSubscriptionTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/subscriptions/OpcUaSubscriptionTest.java
@@ -423,6 +423,110 @@ public class OpcUaSubscriptionTest extends AbstractClientServerTest {
   }
 
   @Test
+  void syncStateNotAffectedByMonitoredItems() throws UaException {
+    var subscription = new OpcUaSubscription(client);
+
+    try {
+      // Add item before create — syncState stays INITIAL
+      var item = OpcUaMonitoredItem.newDataItem(NodeIds.Server_ServerStatus_CurrentTime);
+      subscription.addMonitoredItem(item);
+      assertEquals(SyncState.INITIAL, subscription.getSyncState());
+
+      subscription.create();
+      assertEquals(SyncState.SYNCHRONIZED, subscription.getSyncState());
+
+      // Add another item — syncState stays SYNCHRONIZED
+      var item2 = OpcUaMonitoredItem.newDataItem(NodeIds.Server_ServerStatus_State);
+      subscription.addMonitoredItem(item2);
+      assertEquals(SyncState.SYNCHRONIZED, subscription.getSyncState());
+
+      // Remove an item — syncState stays SYNCHRONIZED
+      subscription.removeMonitoredItem(item2);
+      assertEquals(SyncState.SYNCHRONIZED, subscription.getSyncState());
+    } finally {
+      subscription.delete();
+    }
+  }
+
+  @Test
+  void createWithItemsSetsSynchronized() throws UaException {
+    var subscription = new OpcUaSubscription(client);
+
+    try {
+      subscription.addMonitoredItem(
+          OpcUaMonitoredItem.newDataItem(NodeIds.Server_ServerStatus_CurrentTime));
+      subscription.create();
+      assertEquals(SyncState.SYNCHRONIZED, subscription.getSyncState());
+    } finally {
+      subscription.delete();
+    }
+  }
+
+  @Test
+  void isMonitoredItemsSynchronized() throws UaException {
+    var subscription = new OpcUaSubscription(client);
+
+    try {
+      // Empty subscription — vacuously true
+      subscription.create();
+      assertTrue(subscription.isMonitoredItemsSynchronized());
+
+      // Add an item — item is INITIAL, not yet synced
+      var item = OpcUaMonitoredItem.newDataItem(NodeIds.Server_ServerStatus_CurrentTime);
+      subscription.addMonitoredItem(item);
+      assertFalse(subscription.isMonitoredItemsSynchronized());
+
+      // Synchronize — item becomes SYNCHRONIZED
+      subscription.synchronizeMonitoredItems();
+      assertTrue(subscription.isMonitoredItemsSynchronized());
+
+      // Remove the item — pending deletion, not synced
+      subscription.removeMonitoredItem(item);
+      assertFalse(subscription.isMonitoredItemsSynchronized());
+
+      // Synchronize deletion
+      subscription.synchronizeMonitoredItems();
+      assertTrue(subscription.isMonitoredItemsSynchronized());
+    } finally {
+      subscription.delete();
+    }
+  }
+
+  @Test
+  void isFullySynchronized() throws UaException {
+    var subscription = new OpcUaSubscription(client);
+
+    try {
+      // INITIAL — not fully synchronized
+      assertFalse(subscription.isFullySynchronized());
+
+      subscription.create();
+
+      // SYNCHRONIZED, no items — fully synchronized
+      assertTrue(subscription.isFullySynchronized());
+
+      // Add item — subscription SYNCHRONIZED but item INITIAL
+      var item = OpcUaMonitoredItem.newDataItem(NodeIds.Server_ServerStatus_CurrentTime);
+      subscription.addMonitoredItem(item);
+      assertFalse(subscription.isFullySynchronized());
+
+      // Synchronize items — now fully synchronized
+      subscription.synchronizeMonitoredItems();
+      assertTrue(subscription.isFullySynchronized());
+
+      // Change a subscription parameter — subscription UNSYNCHRONIZED
+      subscription.setPublishingInterval(5000.0);
+      assertFalse(subscription.isFullySynchronized());
+
+      // Modify subscription — back to fully synchronized
+      subscription.modify();
+      assertTrue(subscription.isFullySynchronized());
+    } finally {
+      subscription.delete();
+    }
+  }
+
+  @Test
   void createSubscriptionAgainAfterDeleting() throws Exception {
     var subscription = new OpcUaSubscription(client);
     subscription.create();

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/subscriptions/OpcUaSubscription.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/subscriptions/OpcUaSubscription.java
@@ -855,13 +855,17 @@ public class OpcUaSubscription {
    * Check if all {@link OpcUaMonitoredItem}s belonging to this subscription are synchronized with
    * the server.
    *
-   * <p>Returns {@code true} when no MonitoredItems are pending deletion and every item in the
-   * subscription has {@link OpcUaMonitoredItem.SyncState#SYNCHRONIZED}.
+   * <p>Returns {@code true} when no MonitoredItems that require server-side deletion are pending
+   * deletion and every item in the subscription has
+   * {@link OpcUaMonitoredItem.SyncState#SYNCHRONIZED}. Items pending deletion while still in
+   * {@link OpcUaMonitoredItem.SyncState#INITIAL} are ignored because they were never created on
+   * the server.
    *
    * @return {@code true} if all MonitoredItems are synchronized.
    */
   public boolean isMonitoredItemsSynchronized() {
-    return itemsToDelete.isEmpty()
+    return itemsToDelete.stream()
+            .noneMatch(item -> item.getSyncState() != OpcUaMonitoredItem.SyncState.INITIAL)
         && monitoredItems.values().stream()
             .allMatch(item -> item.getSyncState() == OpcUaMonitoredItem.SyncState.SYNCHRONIZED);
   }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/subscriptions/OpcUaSubscription.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/subscriptions/OpcUaSubscription.java
@@ -856,10 +856,10 @@ public class OpcUaSubscription {
    * the server.
    *
    * <p>Returns {@code true} when no MonitoredItems that require server-side deletion are pending
-   * deletion and every item in the subscription has
-   * {@link OpcUaMonitoredItem.SyncState#SYNCHRONIZED}. Items pending deletion while still in
-   * {@link OpcUaMonitoredItem.SyncState#INITIAL} are ignored because they were never created on
-   * the server.
+   * deletion and every item in the subscription has {@link
+   * OpcUaMonitoredItem.SyncState#SYNCHRONIZED}. Items pending deletion while still in {@link
+   * OpcUaMonitoredItem.SyncState#INITIAL} are ignored because they were never created on the
+   * server.
    *
    * @return {@code true} if all MonitoredItems are synchronized.
    */

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/subscriptions/OpcUaSubscription.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/subscriptions/OpcUaSubscription.java
@@ -143,11 +143,7 @@ public class OpcUaSubscription {
               true,
               priority);
 
-      if (monitoredItems.isEmpty()) {
-        syncState = SyncState.SYNCHRONIZED;
-      } else {
-        syncState = SyncState.UNSYNCHRONIZED;
-      }
+      syncState = SyncState.SYNCHRONIZED;
 
       serverState =
           new ServerState(
@@ -335,10 +331,6 @@ public class OpcUaSubscription {
       item.setClientHandle(clientHandle);
 
       monitoredItems.put(clientHandle, item);
-
-      if (syncState != SyncState.INITIAL) {
-        syncState = SyncState.UNSYNCHRONIZED;
-      }
     }
   }
 
@@ -369,10 +361,6 @@ public class OpcUaSubscription {
 
     if (removedItem != null) {
       itemsToDelete.add(removedItem);
-
-      if (syncState != SyncState.INITIAL) {
-        syncState = SyncState.UNSYNCHRONIZED;
-      }
     }
   }
 
@@ -861,6 +849,34 @@ public class OpcUaSubscription {
    */
   public SyncState getSyncState() {
     return syncState;
+  }
+
+  /**
+   * Check if all {@link OpcUaMonitoredItem}s belonging to this subscription are synchronized with
+   * the server.
+   *
+   * <p>Returns {@code true} when no MonitoredItems are pending deletion and every item in the
+   * subscription has {@link OpcUaMonitoredItem.SyncState#SYNCHRONIZED}.
+   *
+   * @return {@code true} if all MonitoredItems are synchronized.
+   */
+  public boolean isMonitoredItemsSynchronized() {
+    return itemsToDelete.isEmpty()
+        && monitoredItems.values().stream()
+            .allMatch(item -> item.getSyncState() == OpcUaMonitoredItem.SyncState.SYNCHRONIZED);
+  }
+
+  /**
+   * Check if this subscription and all its {@link OpcUaMonitoredItem}s are synchronized with the
+   * server.
+   *
+   * <p>Equivalent to checking that {@link #getSyncState()} is {@link SyncState#SYNCHRONIZED} and
+   * {@link #isMonitoredItemsSynchronized()} is {@code true}.
+   *
+   * @return {@code true} if the subscription settings and all MonitoredItems are synchronized.
+   */
+  public boolean isFullySynchronized() {
+    return syncState == SyncState.SYNCHRONIZED && isMonitoredItemsSynchronized();
   }
 
   /**


### PR DESCRIPTION
SyncState now tracks only subscription settings synchronization. MonitoredItem add/remove no longer sets UNSYNCHRONIZED, and create() always sets SYNCHRONIZED. New isMonitoredItemsSynchronized() and isFullySynchronized() methods provide item-level and aggregate sync checks.