### PR TITLE
Expose ActivateSession service result on UaSession

### DIFF
--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/session/ActivateSessionServiceResultOverrideTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/session/ActivateSessionServiceResultOverrideTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.client.session;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.concurrent.TimeUnit;
+import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
+import org.eclipse.milo.opcua.sdk.server.EndpointConfig;
+import org.eclipse.milo.opcua.sdk.server.OpcUaServer;
+import org.eclipse.milo.opcua.sdk.test.DelegatingSessionServiceSet;
+import org.eclipse.milo.opcua.sdk.test.TestClient;
+import org.eclipse.milo.opcua.sdk.test.TestServer;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
+import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
+import org.eclipse.milo.opcua.stack.core.types.structured.ActivateSessionRequest;
+import org.eclipse.milo.opcua.stack.core.types.structured.ActivateSessionResponse;
+import org.eclipse.milo.opcua.stack.core.types.structured.ResponseHeader;
+import org.eclipse.milo.opcua.stack.transport.server.ServiceRequestContext;
+import org.junit.jupiter.api.Test;
+
+public class ActivateSessionServiceResultOverrideTest {
+
+  @Test
+  void initialActivationCapturesAdvisoryCode() throws Exception {
+    OpcUaServer server = TestServer.create().getServer();
+
+    var sessionServiceSet =
+        new DelegatingSessionServiceSet(server) {
+          @Override
+          public ActivateSessionResponse onActivateSession(
+              ServiceRequestContext context, ActivateSessionRequest request) throws UaException {
+            ActivateSessionResponse response = super.onActivateSession(context, request);
+
+            return withServiceResult(
+                response, new StatusCode(StatusCodes.Good_PasswordChangeRequired));
+          }
+        };
+
+    for (EndpointConfig endpoint : server.getConfig().getEndpoints()) {
+      server.addServiceSet(endpoint.getPath(), sessionServiceSet);
+    }
+
+    server.startup().get();
+
+    OpcUaClient client = TestClient.create(server, cfg -> {});
+    try {
+      client.connect();
+
+      StatusCode result = client.getSession().getLastActivateSessionServiceResult().orElseThrow();
+
+      assertEquals(StatusCodes.Good_PasswordChangeRequired, result.getValue());
+    } finally {
+      try {
+        client.disconnectAsync().get(2, TimeUnit.SECONDS);
+      } finally {
+        server.shutdown().get(2, TimeUnit.SECONDS);
+      }
+    }
+  }
+
+  private static ActivateSessionResponse withServiceResult(
+      ActivateSessionResponse response, StatusCode serviceResult) {
+
+    var header = response.getResponseHeader();
+
+    return new ActivateSessionResponse(
+        new ResponseHeader(
+            header.getTimestamp(),
+            header.getRequestHandle(),
+            serviceResult,
+            header.getServiceDiagnostics(),
+            header.getStringTable(),
+            header.getAdditionalHeader()),
+        response.getServerNonce(),
+        response.getResults(),
+        response.getDiagnosticInfos());
+  }
+}

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/session/ActivateSessionServiceResultTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/session/ActivateSessionServiceResultTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.client.session;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Optional;
+import org.eclipse.milo.opcua.sdk.test.AbstractClientServerTest;
+import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
+import org.junit.jupiter.api.Test;
+
+public class ActivateSessionServiceResultTest extends AbstractClientServerTest {
+
+  @Test
+  void resultPresentAfterConnect() throws UaException {
+    Optional<StatusCode> result = client.getSession().getLastActivateSessionServiceResult();
+
+    assertTrue(result.isPresent());
+    assertTrue(result.get().isGood());
+  }
+}

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/test/DelegatingSessionServiceSet.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/test/DelegatingSessionServiceSet.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.test;
+
+import java.util.Objects;
+import org.eclipse.milo.opcua.sdk.server.OpcUaServer;
+import org.eclipse.milo.opcua.sdk.server.servicesets.SessionServiceSet;
+import org.eclipse.milo.opcua.sdk.server.servicesets.impl.DefaultSessionServiceSet;
+import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.types.structured.ActivateSessionRequest;
+import org.eclipse.milo.opcua.stack.core.types.structured.ActivateSessionResponse;
+import org.eclipse.milo.opcua.stack.core.types.structured.CancelRequest;
+import org.eclipse.milo.opcua.stack.core.types.structured.CancelResponse;
+import org.eclipse.milo.opcua.stack.core.types.structured.CloseSessionRequest;
+import org.eclipse.milo.opcua.stack.core.types.structured.CloseSessionResponse;
+import org.eclipse.milo.opcua.stack.core.types.structured.CreateSessionRequest;
+import org.eclipse.milo.opcua.stack.core.types.structured.CreateSessionResponse;
+import org.eclipse.milo.opcua.stack.transport.server.ServiceRequestContext;
+
+public class DelegatingSessionServiceSet implements SessionServiceSet {
+
+  private final SessionServiceSet delegate;
+
+  public DelegatingSessionServiceSet(OpcUaServer server) {
+    this(new DefaultSessionServiceSet(server));
+  }
+
+  public DelegatingSessionServiceSet(SessionServiceSet delegate) {
+    this.delegate = Objects.requireNonNull(delegate, "delegate");
+  }
+
+  @Override
+  public CreateSessionResponse onCreateSession(
+      ServiceRequestContext context, CreateSessionRequest request) throws UaException {
+    return delegate.onCreateSession(context, request);
+  }
+
+  @Override
+  public ActivateSessionResponse onActivateSession(
+      ServiceRequestContext context, ActivateSessionRequest request) throws UaException {
+    return delegate.onActivateSession(context, request);
+  }
+
+  @Override
+  public CloseSessionResponse onCloseSession(
+      ServiceRequestContext context, CloseSessionRequest request) throws UaException {
+    return delegate.onCloseSession(context, request);
+  }
+
+  @Override
+  public CancelResponse onCancel(ServiceRequestContext context, CancelRequest request)
+      throws UaException {
+    return delegate.onCancel(context, request);
+  }
+}

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/OpcUaSession.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/OpcUaSession.java
@@ -11,9 +11,11 @@
 package org.eclipse.milo.opcua.sdk.client;
 
 import com.google.common.base.MoreObjects;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.structured.SignedSoftwareCertificate;
 import org.jspecify.annotations.NonNull;
@@ -22,6 +24,7 @@ import org.jspecify.annotations.Nullable;
 public class OpcUaSession extends ConcurrentHashMap<String, Object> implements UaSession {
 
   private volatile ByteString serverNonce = ByteString.NULL_VALUE;
+  private volatile @Nullable StatusCode lastActivateSessionServiceResult;
 
   private final NodeId authToken;
   private final NodeId sessionId;
@@ -89,8 +92,18 @@ public class OpcUaSession extends ConcurrentHashMap<String, Object> implements U
     return serverNonce;
   }
 
+  @Override
+  public Optional<StatusCode> getLastActivateSessionServiceResult() {
+    return Optional.ofNullable(lastActivateSessionServiceResult);
+  }
+
   public void setServerNonce(ByteString serverNonce) {
     this.serverNonce = serverNonce;
+  }
+
+  public void setLastActivateSessionServiceResult(
+      @Nullable StatusCode lastActivateSessionServiceResult) {
+    this.lastActivateSessionServiceResult = lastActivateSessionServiceResult;
   }
 
   @Nullable

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/UaSession.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/UaSession.java
@@ -10,8 +10,10 @@
 
 package org.eclipse.milo.opcua.sdk.client;
 
+import java.util.Optional;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.structured.SignedSoftwareCertificate;
 import org.jspecify.annotations.NonNull;
@@ -69,6 +71,16 @@ public interface UaSession {
    * @return the server {@link SignedSoftwareCertificate}s.
    */
   SignedSoftwareCertificate[] getServerSoftwareCertificates();
+
+  /**
+   * Get the service result from the most recent successful ActivateSession response, including
+   * reactivation.
+   *
+   * @return the most recent successful ActivateSession service result, if available.
+   */
+  default Optional<StatusCode> getLastActivateSessionServiceResult() {
+    return Optional.empty();
+  }
 
   /**
    * Returns the attribute bound to {@code name} in this session, or <code>null</code> if no

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/session/SessionFsmFactory.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/session/SessionFsmFactory.java
@@ -1362,6 +1362,8 @@ public class SessionFsmFactory {
                         csr.getServerCertificate(),
                         csr.getServerSoftwareCertificates());
 
+                session.setLastActivateSessionServiceResult(
+                    asr.getResponseHeader().getServiceResult());
                 session.setServerNonce(asrNonce);
 
                 return completedFuture(session);
@@ -1409,6 +1411,8 @@ public class SessionFsmFactory {
           .thenApply(ActivateSessionResponse.class::cast)
           .thenCompose(
               asr -> {
+                session.setLastActivateSessionServiceResult(
+                    asr.getResponseHeader().getServiceResult());
                 session.setServerNonce(asr.getServerNonce());
 
                 return completedFuture(session);


### PR DESCRIPTION
## Summary

Expose the most recent successful `ActivateSession` service result through `UaSession` so client code can observe advisory `Good_*` outcomes such as `Good_PasswordChangeRequired` after a session is established or reactivated.

- Add `UaSession.getLastActivateSessionServiceResult()` and back it with `OpcUaSession` so callers can inspect the latest successful `ActivateSession` status without reaching into lower-level protocol objects.
- Update the session FSM to record the `ActivateSessionResponse` service result on both initial activation and reactivation so the session reflects the server's latest accepted response.
- Add integration coverage for the default success case and for advisory-good responses such as `Good_PasswordChangeRequired`, using a delegating test service set to customize `ActivateSession` responses.

## Key Changes

- **Session API surface:** `UaSession` now exposes an optional last `ActivateSession` service result, which keeps the API backward compatible for session implementations that do not populate it.
- **Session lifecycle tracking:** `SessionFsmFactory` stores the service result after both initial activation and reactivation so the session reflects the latest successful server response.
- **Integration test harness:** Add a delegating session service set for tests so `ActivateSession` responses can be overridden without replacing the default session service implementation.

## Testing

- `ActivateSessionServiceResultTest` verifies that a connected client session exposes a present, good `ActivateSession` service result after connect.
- `ActivateSessionServiceResultOverrideTest` verifies that advisory good codes returned by `ActivateSession`, including `Good_PasswordChangeRequired`, are preserved on the client session.
- Verification command: `mvn -q clean verify`

## References

- [Discussion #1729: Expose ActivateSession service result (Good_PasswordChangeRequired) to client code](https://github.com/eclipse-milo/milo/discussions/1729)
